### PR TITLE
Make import styles in init consistent.

### DIFF
--- a/pymbar/__init__.py
+++ b/pymbar/__init__.py
@@ -31,15 +31,11 @@ __license__ = "LGPL"
 __maintainer__ = "Michael R. Shirts and John D. Chodera"
 __email__ = "michael.shirts@virginia.edu,choderaj@mskcc.org"
 
-import pymbar
+from pymbar import timeseries, testsystems, confidenceintervals, version
 from pymbar.mbar import MBAR
 from pymbar.bar import BAR, BARzero
 from pymbar.exp import EXP, EXPGauss
 
-import pymbar.timeseries
-import pymbar.testsystems as testsystems
-import pymbar.confidenceintervals
-from pymbar import version
 
 __all__ = ['EXP', 'EXPGauss', 'BAR', 'BARzero', 'MBAR', 'timeseries', 'testsystems', 'confidenceintervals', 'utils']
 


### PR DESCRIPTION
 re #49 

My point here is to avoid encouraging users to do `import pymbar;pymbar.pymbar.something`.  The new namespace looks like this:

```
In [1]: import pymbar

In [2]: pymbar.
pymbar.bar                  pymbar.BARzero              pymbar.exp                  pymbar.EXPGauss             pymbar.MBAR                 pymbar.timeseries           pymbar.version
pymbar.BAR                  pymbar.confidenceintervals  pymbar.EXP                  pymbar.mbar                 pymbar.testsystems          pymbar.utils                

```
