### PR TITLE
Added backwards-compatibility computeEXP() and friends

### DIFF
--- a/pymbar/bar.py
+++ b/pymbar/bar.py
@@ -335,3 +335,33 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, maximum_iterations=500, 
         if verbose:
             print "DeltaF = %8.3f" % (DeltaF)
         return DeltaF
+
+#=============================================================================================
+# For compatibility with 2.0.1-beta
+#=============================================================================================
+
+deprecation_warning = """
+Warning
+-------
+This method name is deprecated, and provided for backward-compatibility only.
+It may be removed in future versions.
+"""
+
+def computeBARzero(*args, **kwargs):
+    return BARzero(*args, **kwargs)
+computeBARzero.__doc__ = BARzero.__doc__ + deprecation_warning
+
+def computeBAR(*args, **kwargs):
+    return BAR(*args, **kwargs)
+computeBAR.__doc__ = BAR.__doc__ + deprecation_warning
+
+def _compatibilityDoctests():
+    """
+    Backwards-compatibility doctests.
+
+    >>> from pymbar import testsystems
+    >>> [w_F, w_R] = testsystems.gaussian_work_example(mu_F=None, DeltaF=1.0, seed=0)
+    >>> DeltaF = BARzero(w_F, w_R, 0.0)
+    >>> [DeltaF, dDeltaF] = computeBAR(w_F, w_R)
+    """
+    pass

--- a/pymbar/exp.py
+++ b/pymbar/exp.py
@@ -54,7 +54,6 @@ from pymbar.utils import _logsum
 # One-sided exponential averaging (EXP).
 #=============================================================================================
 
-
 def EXP(w_F, compute_uncertainty=True, is_timeseries=False):
     """
     Estimate free energy difference using one-sided (unidirectional) exponential averaging (EXP).
@@ -122,7 +121,6 @@ def EXP(w_F, compute_uncertainty=True, is_timeseries=False):
     else:
         return DeltaF
 
-
 #=============================================================================================
 # Gaussian approximation to exponential averaging (Gauss).
 #=============================================================================================
@@ -187,3 +185,34 @@ def EXPGauss(w_F, compute_uncertainty=True, is_timeseries=False):
         return (DeltaF, dDeltaF)
     else:
         return DeltaF
+
+
+#=============================================================================================
+# For compatibility with 2.0.1-beta
+#=============================================================================================
+
+deprecation_warning = """
+Warning
+-------
+This method name is deprecated, and provided for backward-compatibility only.
+It may be removed in future versions.
+"""
+
+def computeEXP(*args, **kwargs):
+    return EXP(*args, **kwargs)
+computeEXP.__doc__ = EXP.__doc__ + deprecation_warning
+
+def computeEXPGauss(*args, **kwargs):
+    return EXPGauss(*args, **kwargs)
+computeEXPGauss.__doc__ = EXPGauss.__doc__ + deprecation_warning
+
+def _compatibilityDoctests():
+    """
+    Backwards-compatibility doctests.
+
+    >>> from pymbar import testsystems
+    >>> [w_F, w_R] = testsystems.gaussian_work_example(mu_F=None, DeltaF=1.0, seed=0)
+    >>> [DeltaF, dDeltaF] = computeEXP(w_F)
+    >>> [DeltaF, dDeltaF] = computeEXPGauss(w_F)
+    """
+    pass


### PR DESCRIPTION
This addresses the issue of backwards-compatible names for exp.py and bar.py.

https://github.com/choderalab/pymbar/issues/44
