### PR TITLE
Accidentally sets the wrong uncertainties to zero

### DIFF
--- a/pymbar/mbar.py
+++ b/pymbar/mbar.py
@@ -425,7 +425,7 @@ class MBAR:
                     # Hmm.  Will this print correctly?
                     print "A squared uncertainty is negative.  d2DeltaF = %e" % d2DeltaF[(numpy.any(d2DeltaF) < warning_cutoff)]
                 else:
-                    d2DeltaF[d2DeltaF < warning_cutoff)] = 0.0
+                    d2DeltaF[d2DeltaF < warning_cutoff] = 0.0
 
             # take the square root of the matrix
             dDeltaf_ij = numpy.sqrt(d2DeltaF)


### PR DESCRIPTION
When numbers are negative, but only up to numerical precision, we automatically set them to zero.  But this reset used incorrect arrays. This commit should fix the problem.
