### PR TITLE
Switched to int64, moved logsumexp to utils.

### DIFF
--- a/pymbar/bar.py
+++ b/pymbar/bar.py
@@ -49,8 +49,7 @@ __license__ = "LGPL 2.1"
 #=============================================================================================
 import numpy as np
 import numpy.linalg
-from pymbar.utils import ParameterError, ConvergenceError, BoundsError
-from pymbar.mbar_solvers import logsumexp
+from pymbar.utils import ParameterError, ConvergenceError, BoundsError, logsumexp
 from pymbar.exp import EXP
 
 

--- a/pymbar/bar.py
+++ b/pymbar/bar.py
@@ -49,7 +49,8 @@ __license__ = "LGPL 2.1"
 #=============================================================================================
 import numpy as np
 import numpy.linalg
-from pymbar.utils import _logsum, ParameterError, ConvergenceError, BoundsError
+from pymbar.utils import ParameterError, ConvergenceError, BoundsError
+from pymbar.mbar_solvers import logsumexp
 from pymbar.exp import EXP
 
 
@@ -111,7 +112,7 @@ def BARzero(w_F, w_R, DeltaF):
         # give up; if there's overflow, return zero
         print("The input data results in overflow in BAR")
         return np.nan
-    log_numer = _logsum(log_f_F) - np.log(T_F)
+    log_numer = logsumexp(log_f_F) - np.log(T_F)
 
     # Compute log_denominator.
     # log_denom = log < f(-W) exp[-W] >_R
@@ -123,7 +124,7 @@ def BARzero(w_F, w_R, DeltaF):
     except:
         print("The input data results in overflow in BAR")
         return np.nan
-    log_denom = _logsum(log_f_R) - np.log(T_R)
+    log_denom = logsumexp(log_f_R) - np.log(T_R)
 
     # This function must be zeroed to find a root
     fzero = DeltaF - (log_denom - log_numer)

--- a/pymbar/exp.py
+++ b/pymbar/exp.py
@@ -46,7 +46,7 @@ __license__ = "LGPL 2.1"
 # IMPORTS
 #=============================================================================================
 import numpy as np
-from pymbar.utils import _logsum
+from pymbar.mbar_solvers import logsumexp
 
 #=============================================================================================
 # One-sided exponential averaging (EXP).
@@ -96,7 +96,7 @@ def EXP(w_F, compute_uncertainty=True, is_timeseries=False):
     T = float(np.size(w_F))  # number of work measurements
 
     # Estimate free energy difference by exponential averaging using DeltaF = - log < exp(-w_F) >
-    DeltaF = - (_logsum(- w_F) - np.log(T))
+    DeltaF = - (logsumexp(- w_F) - np.log(T))
 
     if compute_uncertainty:
         # Compute x_i = np.exp(-w_F_i - max_arg)

--- a/pymbar/exp.py
+++ b/pymbar/exp.py
@@ -46,7 +46,7 @@ __license__ = "LGPL 2.1"
 # IMPORTS
 #=============================================================================================
 import numpy as np
-from pymbar.mbar_solvers import logsumexp
+from pymbar.utils import logsumexp
 
 #=============================================================================================
 # One-sided exponential averaging (EXP).

--- a/pymbar/mbar.py
+++ b/pymbar/mbar.py
@@ -42,8 +42,7 @@ import math
 import numpy as np
 import numpy.linalg as linalg
 from pymbar import mbar_solvers
-from pymbar.utils import kln_to_kn, kn_to_n, ParameterError
-logsumexp = mbar_solvers.logsumexp
+from pymbar.utils import kln_to_kn, kn_to_n, ParameterError, logsumexp
 
 DEFAULT_SOLVER_PROTOCOL = mbar_solvers.DEFAULT_SOLVER_PROTOCOL
 DEFAULT_SUBSAMPLING_PROTOCOL = mbar_solvers.DEFAULT_SUBSAMPLING_PROTOCOL

--- a/pymbar/tests/test_mbar_solvers.py
+++ b/pymbar/tests/test_mbar_solvers.py
@@ -4,27 +4,6 @@ from pymbar.utils_for_testing import eq
 import scipy.misc
 from nose import SkipTest
 
-def test_logsumexp():
-    a = np.random.normal(size=(200, 500, 5))
-
-    for axis in range(a.ndim):
-        ans_ne = pymbar.mbar_solvers.logsumexp(a, axis=axis)
-        ans_no_ne = pymbar.mbar_solvers.logsumexp(a, axis=axis, use_numexpr=False)
-        ans_scipy = scipy.misc.logsumexp(a, axis=axis)
-        eq(ans_ne, ans_no_ne)
-        eq(ans_ne, ans_scipy)
-
-def test_logsumexp_b():
-    a = np.random.normal(size=(200, 500, 5))
-    b = np.random.normal(size=(200, 500, 5)) ** 2.
-
-    for axis in range(a.ndim):
-        ans_ne = pymbar.mbar_solvers.logsumexp(a, b=b, axis=axis)
-        ans_no_ne = pymbar.mbar_solvers.logsumexp(a, b=b, axis=axis, use_numexpr=False)
-        ans_scipy = scipy.misc.logsumexp(a, b=b, axis=axis)
-        eq(ans_ne, ans_no_ne)
-        eq(ans_ne, ans_scipy)
-
 
 def load_oscillators(n_states, n_samples):
     name = "%dx%d oscillators" % (n_states, n_samples)

--- a/pymbar/tests/test_utils.py
+++ b/pymbar/tests/test_utils.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pymbar
+from pymbar.utils_for_testing import eq
+import scipy.misc
+from nose import SkipTest
+
+def test_logsumexp():
+    a = np.random.normal(size=(200, 500, 5))
+
+    for axis in range(a.ndim):
+        ans_ne = pymbar.utils.logsumexp(a, axis=axis)
+        ans_no_ne = pymbar.utils.logsumexp(a, axis=axis, use_numexpr=False)
+        ans_scipy = scipy.misc.logsumexp(a, axis=axis)
+        eq(ans_ne, ans_no_ne)
+        eq(ans_ne, ans_scipy)
+
+def test_logsumexp_b():
+    a = np.random.normal(size=(200, 500, 5))
+    b = np.random.normal(size=(200, 500, 5)) ** 2.
+
+    for axis in range(a.ndim):
+        ans_ne = pymbar.utils.logsumexp(a, b=b, axis=axis)
+        ans_no_ne = pymbar.utils.logsumexp(a, b=b, axis=axis, use_numexpr=False)
+        ans_scipy = scipy.misc.logsumexp(a, b=b, axis=axis)
+        eq(ans_ne, ans_no_ne)
+        eq(ans_ne, ans_scipy)
+
+def test_logsum():
+    u = np.random.normal(size=(200))
+    y1 = pymbar.utils.logsumexp(u)
+    y2 = pymbar.utils._logsum(u)
+    eq(y1, y2, decimal=12)

--- a/pymbar/utils.py
+++ b/pymbar/utils.py
@@ -26,8 +26,14 @@
 
 from six.moves import zip_longest
 import warnings
-
 import numpy as np
+
+try:  # numexpr used in logsumexp when available.
+    import numexpr
+    HAVE_NUMEXPR = True
+except ImportError:
+    HAVE_NUMEXPR = False
+
 
 ##############################################################################
 # functions / classes
@@ -220,6 +226,7 @@ def ensure_type(val, dtype, ndim, name, length=None, can_be_none=False, shape=No
 
 def _logsum(a_n):
     """Compute the log of a sum of exponentiated terms exp(a_n) in a numerically-stable manner.
+    NOTE: this function has been deprecated in favor of logsumexp.
 
     Parameters
     ----------
@@ -241,7 +248,6 @@ def _logsum(a_n):
     _logsum a_n = \log \sum_{n=1}^N \exp[a_n]
 
 
-
     Example
     -------
     >>> a_n = np.array([0.0, 1.0, 1.2], np.float64)
@@ -259,6 +265,66 @@ def _logsum(a_n):
     log_sum = np.log(np.sum(terms)) + max_log_term
 
     return log_sum
+
+def logsumexp(a, axis=None, b=None, use_numexpr=True):
+    """Compute the log of the sum of exponentials of input elements.
+
+    Parameters
+    ----------
+    a : array_like
+        Input array.
+    axis : None or int, optional, default=None
+        Axis or axes over which the sum is taken. By default `axis` is None,
+        and all elements are summed.
+    b : array-like, optional
+        Scaling factor for exp(`a`) must be of the same shape as `a` or
+        broadcastable to `a`.
+    use_numexpr : bool, optional, default=True
+        If True, use the numexpr library to speed up the calculation, which
+        can give a 2-4X speedup when working with large arrays.
+
+    Returns
+    -------
+    res : ndarray
+        The result, ``log(sum(exp(a)))`` calculated in a numerically
+        more stable way. If `b` is given then ``log(sum(b*exp(a)))``
+        is returned.
+
+    See Also
+    --------
+    numpy.logaddexp, numpy.logaddexp2, scipy.misc.logsumexp
+
+    Notes
+    -----
+    This is based on scipy.misc.logsumexp but with optional numexpr
+    support for improved performance.
+    """
+
+    a = np.asarray(a)
+
+    a_max = np.amax(a, axis=axis, keepdims=True)
+
+    if a_max.ndim > 0:
+        a_max[~np.isfinite(a_max)] = 0
+    elif not np.isfinite(a_max):
+        a_max = 0
+
+    if b is not None:
+        b = np.asarray(b)
+        if use_numexpr and HAVE_NUMEXPR:
+            out = np.log(numexpr.evaluate("b * exp(a - a_max)").sum(axis))
+        else:
+            out = np.log(np.sum(b * np.exp(a - a_max), axis=axis))
+    else:
+        if use_numexpr and HAVE_NUMEXPR:
+            out = np.log(numexpr.evaluate("exp(a - a_max)").sum(axis))
+        else:
+            out = np.log(np.sum(np.exp(a - a_max), axis=axis))
+
+    a_max = np.squeeze(a_max, axis=axis)
+    out += a_max
+
+    return out
 
 #=============================================================================================
 # Exception classes

--- a/pymbar/utils.py
+++ b/pymbar/utils.py
@@ -70,7 +70,7 @@ def kln_to_kn(kln, N_k = None, cleanup = False):
     if N_k == None:
         # We assume that all N_k are N_max.
         # Not really an easier way to do this without being given the answer.
-        N_k = N_max * np.ones([L], dtype=np.int32)
+        N_k = N_max * np.ones([L], dtype=np.int64)
     N = np.sum(N_k)
 
     kn = np.zeros([L, N], dtype=np.float64)
@@ -110,7 +110,7 @@ def kn_to_n(kn, N_k = None, cleanup = False):
     if N_k == None:
         # We assume that all N_k are N_max.
         # Not really an easier way to do this without being given the answer.
-        N_k = N_max*np.ones([K], dtype=np.int32)
+        N_k = N_max*np.ones([K], dtype=np.int64)
     N = np.sum(N_k)
 
     n = np.zeros([N], dtype=np.float64)


### PR DESCRIPTION
1.  Switched int32 to int64.  I'm worried about someone sending a billion samples into mbar, which is bound to happen at some point.  
2.  For consistency with the old code, I moved `logsumexp()` from `mbar_solvers.py` to `utils.py`.  
3.  I've switched calls to the old `_logsum()` to use `logsumexp()`
4.  For now, I've left `_logsum()` where it is and use it as a reference in our unit tests comparing to `logsumexp()`