### PR TITLE
Improved harmonic_oscillators.py example

### DIFF
--- a/examples/harmonic-oscillators.py
+++ b/examples/harmonic-oscillators.py
@@ -618,7 +618,6 @@ def generate_pmf_data(ndim=1, nbinsperdim=15, nsamples = 1000, K0=20.0, Ku = 100
       val = gridscale*((i/dp[d]) % nperdim[d] + xrange[d][0])
       center.append(val)
     center = numpy.array(center)
-    print i, center
     xu_i[i,:] = center
     mu2 = numpy.dot(center,center)
     f_k_analytical[i] = numpy.log((ndim*numpy.pi/ksum)**(3/2) *numpy.exp(-kprod*mu2/(2*ksum)))


### PR DESCRIPTION
Runs both 1d and 2d PMF calculations, using reusable code.  For some other PMF tools, it's useful to have a 1D example in the example set.