### PR TITLE
Stefano/time series fix

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -10,7 +10,7 @@ requirements:
     - scipy
     - setuptools
     - numexpr   
-    - six 
+    - six
   run:
     - python
     - numpy
@@ -21,7 +21,8 @@ requirements:
 test:
   requires:
     - nose
-    - setuptools    
+    - setuptools
+    - statsmodels    
   imports:
     - pymbar
   commands:

--- a/pymbar/timeseries.py
+++ b/pymbar/timeseries.py
@@ -873,14 +873,14 @@ def detectEquilibration_binary_search(A_t, bs_nodes=10):
     n_grid = min(bs_nodes, T)
     
     while True:
-        time_grid = np.unique((10 ** np.linspace(np.log10(start), np.log10(end), n_grid)).round().astype('int'))
-        
+        time_grid = np.unique((10 ** np.linspace(np.log10(start), np.log10(end), n_grid)).round().astype('int')) 
         g_t = np.ones(time_grid.size)
         Neff_t = np.ones(time_grid.size)
         
-        for k, t in enumerate(time_grid[:-1]):
-            g_t[k] = statisticalInefficiency_fft(A_t[t:])
-            Neff_t[k] = (T - t + 1) / g_t[k]
+        for k, t in enumerate(time_grid):
+            if t < T-1:
+                g_t[k] = statisticalInefficiency_fft(A_t[t:])
+                Neff_t[k] = (T - t + 1) / g_t[k]
 
         Neff_max = Neff_t.max()
         k = Neff_t.argmax()

--- a/pymbar/timeseries.py
+++ b/pymbar/timeseries.py
@@ -874,7 +874,6 @@ def detectEquilibration_binary_search(A_t, bs_nodes=10):
     
     while True:
         time_grid = np.unique((10 ** np.linspace(np.log10(start), np.log10(end), n_grid)).round().astype('int'))
-        n_grid = min(bs_nodes, time_grid.size)
         
         g_t = np.ones(time_grid.size)
         Neff_t = np.ones(time_grid.size)


### PR DESCRIPTION
removed bug in loop of detectEquilibration_binary_search, added kwarg "bs_nodes" to vary number of initial nodes, now the function adapts the number of nodes to refine result until this is less than minimum stable number of nodes, which is 4 (this way the final error will be smaller even if a large number of nodes are used at the start, calculation stops when )