### PR TITLE
Changed MBAR.computeOverlap to return only O, not the entire tuple. Addi...

### DIFF
--- a/examples/alchemical-free-energy/alchemical_analysis.py
+++ b/examples/alchemical-free-energy/alchemical_analysis.py
@@ -242,7 +242,7 @@ def estimatewithMBAR(u_kln, N_k, reltol, regular_estimate=False):
    if regular_estimate:
       if P.overlap: 
          print "The overlap matrix is..."
-         O = MBAR.computeOverlap('matrix')
+         O = MBAR.computeOverlap()[2]
          for k in range(K):
             line = ''
             for l in range(K):


### PR DESCRIPTION
...tionally

removed argument which was causing the following error:

File "/opt/alchemical-free-energy/alchemical_analysis.py", line 245, in
estimatewithMBAR
    O = MBAR.computeOverlap('matrix')
TypeError: computeOverlap() takes exactly 1 argument (2 given)