### PR TITLE
Make a copy of u_kn instead of just a pointer for A_in in computeEntropyandEnthalpy

### DIFF
--- a/pymbar/mbar.py
+++ b/pymbar/mbar.py
@@ -1141,7 +1141,7 @@ class MBAR:
 
         # Retrieve N and K for convenience.
         [K,N] = np.shape(u_kn)
-        A_in = u_kn
+        A_in = u_kn.copy()
         state_map = np.zeros([2,K],int)
         for k in range(K):    
             state_map[0,k] = k


### PR DESCRIPTION
`computeEntropyandEnthalpy` function was setting `A_in = u_kn` instead of a copy of u_kn, so when A_in was manipulated in the `computeExpectationsInner`, it was also manipulating u_kn. The free energy from `computeEntropyandEnthalpy` was then not the same as `computePerturbedFreeEnergies.` This pull request fixes this issue.