### PR TITLE
Future-proof NumPy ndarray == None and ndarray != None comparisons

### DIFF
--- a/pymbar/mbar.py
+++ b/pymbar/mbar.py
@@ -869,7 +869,7 @@ class MBAR:
                     elif len(np.shape(u_kn)) == 2:
                         u_kn = kn_to_n(u_kn, N_k=self.N_k)
 
-        if u_kn == None:
+        if u_kn is None:
             u_kn = self.u_kn
 
         # Retrieve N and K for convenience.
@@ -1136,7 +1136,7 @@ class MBAR:
         if dims==3:
             u_kn = kln_to_kn(u_kn, N_k=self.N_k)
 
-        if u_kn == None:
+        if u_kn is None:
             u_kn = self.u_kn
 
         # Retrieve N and K for convenience.

--- a/pymbar/mbar.py
+++ b/pymbar/mbar.py
@@ -237,7 +237,7 @@ class MBAR:
 
         # If an initial guess of the relative dimensionless free energies is
         # specified, start with that.
-        if initial_f_k != None:
+        if initial_f_k is not None:
             if self.verbose:
                 print("Initializing f_k with provided initial guess.")
             # Cast to np array.
@@ -855,7 +855,7 @@ class MBAR:
         if not state_dependent:
             if dims==2:
                 A_n = kn_to_n(A_n, N_k=self.N_k)
-                if u_kn != None:
+                if u_kn is not None:
                     if len(np.shape(u_kn)) == 3:
                         u_kn = kln_to_kn(u_kn, N_k=self.N_k)
                     elif len(np.shape(u_kn)) == 2:
@@ -863,7 +863,7 @@ class MBAR:
         else:
             if dims==3:
                 A_n = kln_to_kn(A_n, N_k=self.N_k)
-                if u_kn != None:
+                if u_kn is not None:
                     if len(np.shape(u_kn)) == 3:
                         u_kn = kln_to_kn(u_kn, N_k=self.N_k)
                     elif len(np.shape(u_kn)) == 2:

--- a/pymbar/utils.py
+++ b/pymbar/utils.py
@@ -67,7 +67,7 @@ def kln_to_kn(kln, N_k = None, cleanup = False):
     # rewrite into kn shape
     [K, L, N_max] = np.shape(kln)
 
-    if N_k == None:
+    if N_k is None:
         # We assume that all N_k are N_max.
         # Not really an easier way to do this without being given the answer.
         N_k = N_max * np.ones([L], dtype=np.int64)
@@ -107,7 +107,7 @@ def kn_to_n(kn, N_k = None, cleanup = False):
     # rewrite into kn shape
     [K, N_max] = np.shape(kn)
 
-    if N_k == None:
+    if N_k is None:
         # We assume that all N_k are N_max.
         # Not really an easier way to do this without being given the answer.
         N_k = N_max*np.ones([K], dtype=np.int64)


### PR DESCRIPTION
This PR resolves issues #199 to prevent NumPy throwing a future warning about comparisons to `None` becoming element wise in future versions.

The PR makes the following replacements to preserve the logic statements functionality in the future: 
`ndarray == None` to `ndarray is None` 
`ndarray != None` to `ndarray is not None`
