### PR TITLE
Stop mocking out numpy and scipy in sphinx conf.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,12 +15,14 @@
 import sys
 import os
 
+# KAB: As of July 22, 2015 it seems that it might be preferable to no longer mock out numpy and scipy.
+
 # Use mock to make our code think that numpy and scipy are available, even though they might not be available on readthedocs
-import mock
- 
-MOCK_MODULES = ['numpy', 'scipy', "numpy.linalg", "scipy.special", "scipy.stats"]
-for mod_name in MOCK_MODULES:
-    sys.modules[mod_name] = mock.Mock()
+#import mock
+
+#MOCK_MODULES = ['numpy', 'scipy', "numpy.linalg", "scipy.special", "scipy.stats"]
+#for mod_name in MOCK_MODULES:
+#    sys.modules[mod_name] = mock.Mock()
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the


### PR DESCRIPTION
On my machine, this clears up the sphinx build errors and builds useful API docs again.  Haven't tested on readthedocs, so I suppose the best way to do that is to just merge.