### PR TITLE
Correlation

### DIFF
--- a/pymbar/tests/test_timeseries.py
+++ b/pymbar/tests/test_timeseries.py
@@ -140,3 +140,18 @@ def test_detectEquil_constant_trailing():
     ~50 if we try to include part of the equilibration samples, or it can be Neff=1 if we find that the
     whole first half is discarded. 
     """
+
+def test_correlationFunctionMultiple():
+    """
+    tests the truncate and norm feature
+    """
+    A_t = [testsystems.correlated_timeseries_example(N=10000, tau=10.0) for i in range(10)]
+    corr_norm = timeseries.normalizedFluctuationCorrelationFunctionMultiple(A_kn=A_t)
+    corr = timeseries.normalizedFluctuationCorrelationFunctionMultiple(A_kn=A_t, norm=False)
+    corr_norm_trun = timeseries.normalizedFluctuationCorrelationFunctionMultiple(A_kn=A_t, truncate=True)
+    corr_trun = timeseries.normalizedFluctuationCorrelationFunctionMultiple(A_kn=A_t, norm=False, truncate=True)
+    assert (corr_norm_trun[-1] >= 0)
+    assert (corr_trun[-1] >= 0)
+    assert (corr_norm[0] == 1.)
+    assert (corr_norm_trun[0] == 1.)
+    assert (len(corr_trun) == len(corr_norm_trun))

--- a/pymbar/timeseries.py
+++ b/pymbar/timeseries.py
@@ -373,7 +373,7 @@ def integratedAutocorrelationTimeMultiple(A_kn, fast=False):
 #=============================================================================================
 
 
-def normalizedFluctuationCorrelationFunction(A_n, B_n=None, N_max=None):
+def normalizedFluctuationCorrelationFunction(A_n, B_n=None, N_max=None, norm=True):
     """Compute the normalized fluctuation (cross) correlation function of (two) stationary timeseries.
 
     C(t) = (<A(t) B(t)> - <A><B>) / (<AB> - <A><B>)
@@ -388,7 +388,8 @@ def normalizedFluctuationCorrelationFunction(A_n, B_n=None, N_max=None):
         B_n[n] is nth value of timeseries B.  Length is deduced from vector.
     N_max : int, default=None
         if specified, will only compute correlation function out to time lag of N_max
-
+    norm: bool, optional, default=True
+        if False will retrun the unnormalized correlation function D(t) = <A(t) B(t)>
     Returns
     -------
     C_n : np.ndarray
@@ -452,21 +453,24 @@ def normalizedFluctuationCorrelationFunction(A_n, B_n=None, N_max=None):
     if(sigma2_AB == 0):
         raise ParameterError('Sample covariance sigma_AB^2 = 0 -- cannot compute statistical inefficiency')
 
-    # allocate storage for normalized fluctuation correlation function
+    # allocate storage for normalized and fluctuation correlation function
     C_n = np.zeros([N_max + 1], np.float64)
 
-    # Compute normalized correlation funtion.
+    # Compute normalized correlation function.
     t = 0
     for t in range(0, N_max + 1):
         # compute normalized fluctuation correlation function at time t
         C_n[t] = np.sum(dA_n[0:(N - t)] * dB_n[t:N] + dB_n[0:(N - t)] * dA_n[t:N]) / (2.0 * float(N - t) * sigma2_AB)
 
     # Return the computed correlation function
-    return C_n
+    if norm:
+        return C_n
+    else:
+        return C_n*sigma2_AB + mu_A*mu_B
 #=============================================================================================
 
 
-def normalizedFluctuationCorrelationFunctionMultiple(A_kn, B_kn=None, N_max=None):
+def normalizedFluctuationCorrelationFunctionMultiple(A_kn, B_kn=None, N_max=None, norm=True):
     """Compute the normalized fluctuation (cross) correlation function of (two) timeseries from multiple timeseries samples.
 
     C(t) = (<A(t) B(t)> - <A><B>) / (<AB> - <A><B>)
@@ -480,7 +484,8 @@ def normalizedFluctuationCorrelationFunctionMultiple(A_kn, B_kn=None, N_max=None
         B_kn[k] is the kth timeseries, and B_kn[k][n] is nth value of timeseries k.  B_kn[k] must have same length as A_kn[k]
     N_max : int, optional, default=None
         if specified, will only compute correlation function out to time lag of N_max
-
+    norm: bool, optional, default=True
+        if False, will return unnormalized D(t) = <A(t) B(t)>
     Returns
     -------
     C_n[n] : np.ndarray
@@ -570,7 +575,7 @@ def normalizedFluctuationCorrelationFunctionMultiple(A_kn, B_kn=None, N_max=None
         sigma2_AB += np.sum(dA_kn[k] * dB_kn[k])
     sigma2_AB /= float(N)
 
-    # allocate storage for normalized fluctuation correlation function
+    # allocate storage for normalized and fluctuation correlation function
     C_n = np.zeros([N_max + 1], np.float64)
 
     # Accumulate the integrated correlation time by computing the normalized correlation time at
@@ -596,7 +601,10 @@ def normalizedFluctuationCorrelationFunctionMultiple(A_kn, B_kn=None, N_max=None
         C_n[t] = C
 
     # Return the computed fluctuation correlation function.
-    return C_n
+    if norm:
+        return C_n
+    else:
+        return C_n*sigma2_AB + mu_A*mu_B
 #=============================================================================================
 
 

--- a/pymbar/timeseries.py
+++ b/pymbar/timeseries.py
@@ -453,7 +453,7 @@ def normalizedFluctuationCorrelationFunction(A_n, B_n=None, N_max=None, norm=Tru
     if(sigma2_AB == 0):
         raise ParameterError('Sample covariance sigma_AB^2 = 0 -- cannot compute statistical inefficiency')
 
-    # allocate storage for normalized and fluctuation correlation function
+    # allocate storage for normalized fluctuation correlation function
     C_n = np.zeros([N_max + 1], np.float64)
 
     # Compute normalized correlation function.
@@ -577,7 +577,7 @@ def normalizedFluctuationCorrelationFunctionMultiple(A_kn, B_kn=None, N_max=None
         sigma2_AB += np.sum(dA_kn[k] * dB_kn[k])
     sigma2_AB /= float(N)
 
-    # allocate storage for normalized and fluctuation correlation function
+    # allocate storage for normalized fluctuation correlation function
     C_n = np.zeros([N_max + 1], np.float64)
 
     # Accumulate the integrated correlation time by computing the normalized correlation time at

--- a/pymbar/timeseries.py
+++ b/pymbar/timeseries.py
@@ -588,8 +588,6 @@ def normalizedFluctuationCorrelationFunctionMultiple(A_kn, B_kn=None, N_max=None
     negative = False
     for t in range(0, N_max + 1):
         # compute unnormalized correlation function
-        if negative:
-            break
         numerator = 0.0
         denominator = 0.0
         for k in range(K):
@@ -606,6 +604,9 @@ def normalizedFluctuationCorrelationFunctionMultiple(A_kn, B_kn=None, N_max=None
 
         # Store correlation function.
         C_n[t] = C
+
+        if negative:
+            break
 
     # Return the computed fluctuation correlation function.
     if norm:


### PR DESCRIPTION
This PR adds the following options to `normalizedFluctuationCorrelationFunctionMultiple`:

1) return D(t) - the unnormalized correlation function `<A(t) B(t)>`
2) Ability to stop accumulating the correlation function once it goes negative. 