### PR TITLE
Fixed error message on importing statsmodels

### DIFF
--- a/pymbar/timeseries.py
+++ b/pymbar/timeseries.py
@@ -831,7 +831,7 @@ def statisticalInefficiency_fft(A_n, mintime=3, memsafe=True):
     try:
         import statsmodels.api as sm
     except ImportError as err:
-        err.message += "\n You need to install statsmodels to use the FFT based correlation function."
+        err.args = (err.args[0] + "\n You need to install statsmodels to use the FFT based correlation function.",)
         raise
 
     # Create np copies of input arguments.


### PR DESCRIPTION
I found a customised error message that wasn't working (you try and add something to the end, but it doesn't actually get output, see below).  Also `err.message` is deprecated and isn't in py3, so this might fix a headache in the future.

Before:
```python
    830     """
    831     try:
--> 832         import statsmodels.api as sm
    833     except ImportError as err:
    834         err.message += "\n You need to install statsmodels to use the FFT based correlation function."

ImportError: No module named statsmodels.api
```

After:
```python
    830     """
    831     try:
--> 832         import statsmodels.api as sm
    833     except ImportError as err:
    834         err.args = (err.args[0] + "\n You need to install statsmodels to use the FFT based correlation function.",)

ImportError: No module named statsmodels.api
 You need to install statsmodels to use the FFT based correlation function.
```
