### PR TITLE
pymbar 3.0.0 release; clean up README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,14 @@ References
 
   Chodera JD, Swope WC, Pitera JW, Seok C, and Dill KA. Use of the weighted histogram analysis method for the analysis of simulated and parallel tempering simulations. J. Chem. Theor. Comput. 3(1):26-41 (2007).  [DOI](http://dx.doi.org/10.1021/ct0502864)
 
+* The automatic equilibration detection method provided in `pymbar.timeseries.detectEquilibration()` is described here:
+
+  Chodera JD. A simple method for automated equilibration detection in molecular simulations. J. Chem. Theor. Comput. 12:1799, 2016.  [DOI](http://dx.doi.org/10.1021/acs.jctc.5b00784)
+
 License
 -------
 
-`pymbar`` is free software and is licensed under the LGPLv2 license.
+`pymbar` is free software and is licensed under the LGPLv2 license.
 
 
 Thanks

--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ To analyze this data, we first initialize the `MBAR` object:
 ```
 Estimating dimensionless free energy differences between the sampled thermodynamic states and their associated uncertainties (standard errors) simply requires a call to `getFreeEnergyDifferences()`:
 ```python
->>> (Deltaf_ij_estimated, dDeltaf_ij_estimated, Theta_ij) = mbar.getFreeEnergyDifferences()
+>>> (Deltaf_ij, dDeltaf_ij, Theta_ij) = mbar.getFreeEnergyDifferences()
 ```
+Here, `Deltaf_ij[i,j]` is the dimensionless free energy difference `f_j - f_i`, `dDeltaf_ij[i,j]` is the standard error in this estimate, and `Theta_ij` a covariance matrix that can be used to propagate error into quantities derived from the free energies.
+
 Expectations and associated uncertainties can easily be estimated for observables `A(x)` for all states:
 ```python
 >>> A_kn = x_kn # use position of harmonic oscillator as observable
@@ -54,7 +56,6 @@ Expectations and associated uncertainties can easily be estimated for observable
 where `EA_k[k]` is the estimated expectation of the mean oscillator position in thermodynamic state `k`.
 
 See the docstring help for these individual methods for more information on exact usage; in Python or IPython, you can view the docstrings with `help()`.  
-Additional examples can be found in [pymbar-examples](http://github.com/choderalab/pymbar-examples/).  
 
 Authors
 -------

--- a/README.md
+++ b/README.md
@@ -63,20 +63,6 @@ Authors
 * Levi N. Naden <levi.naden@choderalab.org>
 * Michael R. Shirts <michael.shirts@virginia.edu>
 
-Manifest
---------
-
-This archive contains the following files:
-
-* `README.md` - this file
-* `LICENSE` - a copy of the GNU General Public License version 2 covering this code
-* `pymbar/` - Python MBAR package
-* `examples/` - examples of applications of MBAR to various types of calculations
-  See the README.md in that folder for more information
-* `docs/` - sphinx documetation
-* `devtools/` - travis CI and conda configuration files
-
-
 References
 ----------
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 pymbar
 ======
 
-Python implementation of the multistate Bennett acceptance ratio (MBAR) method for estimating expectations and free energy differences.  See our [Docs](http://pymbar.readthedocs.org/en/latest/).
+Python implementation of the multistate Bennett acceptance ratio (MBAR) method for estimating expectations and free energy differences.
+See our [docs](http://pymbar.readthedocs.org/en/latest/).
 
 
 Installation
@@ -14,10 +15,10 @@ Installation
 
 The easiest way to install `pymbar` is via [conda](http://conda.pydata.org), a binary package installer that comes with the [Anaconda Scientific Python distribution](https://store.continuum.io/cshop/anaconda/):
 ```tcsh
-conda install -c https://conda.binstar.org/omnia pymbar
+conda install -c omnia pymbar
 ```
 
-Besides conda, you can also install `pymbar` using `pip` (`pip install pymbar`) or directly from the source directory (`python setup.py install`).
+Besides conda, you can also install `pymbar` from the [Python package index](https://pypi.python.org/pypi/pymbar) using `pip` (`pip install pymbar`) or directly from the source directory (`python setup.py install`).
 
 
 Usage

--- a/README.md
+++ b/README.md
@@ -6,67 +6,62 @@
 pymbar
 ======
 
-Python implementation of the multistate Bennett acceptance ratio (MBAR) method for estimating expectations and free energy differences.
+Python implementation of the [multistate Bennett acceptance ratio (MBAR)](http://www.alchemistry.org/wiki/Multistate_Bennett_Acceptance_Ratio) method for estimating expectations and free energy differences from equilibrium samples from multiple probability densities.
 See our [docs](http://pymbar.readthedocs.org/en/latest/).
 
 
 Installation
 ------------
 
-The easiest way to install `pymbar` is via [conda](http://conda.pydata.org), a binary package installer that comes with the [Anaconda Scientific Python distribution](https://store.continuum.io/cshop/anaconda/):
-```tcsh
+The easiest way to install the `pymbar` release is via [conda](http://conda.pydata.org):
+```bash
 conda install -c omnia pymbar
 ```
-
-Besides conda, you can also install `pymbar` from the [Python package index](https://pypi.python.org/pypi/pymbar) using `pip` (`pip install pymbar`) or directly from the source directory (`python setup.py install`).
-
+You can also install `pymbar` from the [Python package index](https://pypi.python.org/pypi/pymbar) using `pip`:
+```bash
+pip install pymbar
+```
+The development version can be installed directly from github via `pip`:
+```bash
+pip install git+https://github.com/choderalab/pymbar.git
+```
 
 Usage
 -----
 
-Basic usage involves importing pymbar, loading data, and constructing an MBAR object from the reduced potential of simulation or experimental data:
+Basic usage involves importing `pymbar` and constructing an `MBAR` object from the [reduced potential](http://www.alchemistry.org/wiki/Multistate_Bennett_Acceptance_Ratio#Reduced_potential) of simulation or experimental data.
 
+Suppose we sample a 1D harmonic oscillator from a few thermodynamic states:
 ```python
->>> from pymbar import MBAR, testsystems
->>> x_k, u_kn, N_k, s_n = testsystems.HarmonicOscillatorsTestCase().sample()
+>>> from pymbar import testsystems
+>>> [x_n, u_kn, N_k, s_n] = testsystems.HarmonicOscillatorsTestCase().sample()
+```
+We have the `nsamples` sampled oscillator positions `x_n` (with samples from all states concatenated), [reduced potentials](http://www.alchemistry.org/wiki/Multistate_Bennett_Acceptance_Ratio#Reduced_potential) in the `(nstates,nsamples)` matrix `u_kn`, number of samples per state in the `nsamples` array `N_k`, and indices `s_n` denoting which thermodynamic state each sample was drawn from.
+
+To analyze this data, we first initialize the `MBAR` object:
+```python
 >>> mbar = MBAR(u_kn, N_k)
 ```
-
-Next, we extract the dimensionless free energy differences and uncertainties:
-
+Estimating dimensionless free energy differences between the sampled thermodynamic states and their associated uncertainties (standard errors) simply requires a call to `getFreeEnergyDifferences()`:
 ```python
 >>> (Deltaf_ij_estimated, dDeltaf_ij_estimated, Theta_ij) = mbar.getFreeEnergyDifferences()
 ```
-
-or compute expectations of given observables A(x) for all states:
-
+Expectations and associated uncertainties can easily be estimated for observables `A(x)` for all states:
 ```python
->>> (A_k_estimated, dA_k_estimated) = mbar.computeExpectations(x_k)
+>>> A_kn = x_kn # use position of harmonic oscillator as observable
+>>> (EA_k, dEA_k) = mbar.computeExpectations(A_kn)
 ```
-See the help for these individual methods for more information on exact usage; in Python or IPython, you can view the docstrings with `help()`.  
-Additional examples can be found in [pymbar-examples](http://github.com/choderalab/pymbar-examples/).  Note that the example for free energy calculations found in pymbar-examples/alchemical-free-energy has moved to https://github.com/MobleyLab/alchemical-analysis
+where `EA_k[k]` is the estimated expectation of the mean oscillator position in thermodynamic state `k`.
 
-
-Prerequisites
--------------
-
-To install and run pymbar requires the following:
-
-* Python 2.7 or later: http://www.python.org/
-* NumPy: http://numpy.scipy.org/
-* SciPy: http://www.scipy.org/
-* NumExpr: https://github.com/pydata/numexpr
-* six
-* nose
-* Some optional graphing functionality in the tests requires the matplotlib library: http://matplotlib.sourceforge.net/
-
+See the docstring help for these individual methods for more information on exact usage; in Python or IPython, you can view the docstrings with `help()`.  
+Additional examples can be found in [pymbar-examples](http://github.com/choderalab/pymbar-examples/).  
 
 Authors
 -------
-* John D. Chodera <choderaj@mskcc.org>
+* Kyle A. Beauchamp <kyle.beauchamp@choderalab.org>
+* John D. Chodera <john.chodera@choderalab.org>
+* Levi N. Naden <levi.naden@choderalab.org>
 * Michael R. Shirts <michael.shirts@virginia.edu>
-* Kyle A. Beauchamp <beauchak@mskcc.org>
-
 
 Manifest
 --------
@@ -82,7 +77,6 @@ This archive contains the following files:
 * `devtools/` - travis CI and conda configuration files
 
 
-
 References
 ----------
 
@@ -94,16 +88,14 @@ References
 
   Chodera JD, Swope WC, Pitera JW, Seok C, and Dill KA. Use of the weighted histogram analysis method for the analysis of simulated and parallel tempering simulations. J. Chem. Theor. Comput. 3(1):26-41 (2007).  [DOI](http://dx.doi.org/10.1021/ct0502864)
 
-
 License
 -------
 
-Pymbar is free software and is licensed under the GPLv2 license.
+`pymbar`` is free software and is licensed under the LGPLv2 license.
 
 
 Thanks
 ------
-
 We would especially like to thank a large number of people for helping us identify issues
 and ways to improve `pymbar`, including Tommy Knotts, David Mobley, Himanshu Paliwal,
 Zhiqiang Tan, Patrick Varilly, Todd Gingrich, Aaron Keys, Anna Schneider, Adrian Roitberg,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,8 @@ import os
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.intersphinx',
               'sphinx.ext.todo', 'sphinx.ext.pngmath', 'sphinx.ext.ifconfig',
               'numpydoc', 'sphinx.ext.inheritance_diagram',
-              'sphinx.ext.autosummary', 'sphinx.ext.extlinks', ]
+              'sphinx.ext.autosummary', 'sphinx.ext.extlinks',
+              'sphinxcontrib.bibtex']
 
 autosummary_generate = True
 autodoc_default_flags = ['members', 'inherited-members']
@@ -312,4 +313,3 @@ texinfo_documents = [
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
-

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -3,101 +3,42 @@
 Getting started
 ###############
 
-Dependencies
-============
-
-``pymbar`` requires ``numpy`` and ``scipy``. You'll also need a working C
-compiler and build environment, to compile various C-level extensions.
-
-Easy Way (Recommended)
-----------------------
-
-The easiest way to get all of the dependencies is to install one of the 
-pre-packaged scientific python distributes like `Enthought's Canopy 
-<https://www.enthought.com/products/canopy/>`_ or `Continuum's Anaconda 
-<https://store.continuum.io/>`_. These distributions already contain all of 
-the dependences, and are distributed via 1-click installers.
-
-Medium Way
-----------
-
-Linux
-++++++
-If you're on ubuntu and have root, you can install everything through your package manager. ::
-
-  $ sudo apt-get install python-dev python-numpy python-nose python-setuptools python-scipy
-
-Mac
-+++
-If you're on mac and want a package manager, you should be using `homebrew <http://mxcl.github.io/homebrew/>`_ and ``brews``'s python (see `this page <https://github.com/mxcl/homebrew/wiki/Homebrew-and-Python>`_ for details). The best way to install numpy and scipy with ``brew`` is to use
-samueljohn's tap. ::
-
-  $ brew tap samueljohn/python
-  $ brew install python
-  $ brew install numpy
-  $ brew install scipy
-
-Harder Way : Compiling from source (no root needed)
----------------------------------------------------
-
-If you don't already have a python installation you want to use, you can compile a new one. ::
-
-  $ wget http://www.python.org/ftp/python/2.7.5/Python-2.7.5.tgz
-  $ tar -xzvf Python-2.7.5.tgz
-  $ cd Python-2.7.5
-  $ ./configure --prefix=$HOME/local/python
-  $ make
-  $ make install
-
-  $ export PATH=$HOME/local/python/bin:$PATH
-
-If you don't have ``easy_install`` or ``pip`` yet, you can get them with ::
-
-  $ wget http://pypi.python.org/packages/source/s/setuptools/setuptools-0.6c11.tar.gz
-  $ tar -xzvf setuptools-0.6c11.tar.gz
-  $ cd setuptools-0.6c11.tar.gz
-  $ python setup.py install
-  $ easy_install pip
-
-Now you're home free ::
-
-  $ pip install numpy
-  $ pip install scipy
-
 Installing ``pymbar``
 =====================
 
-``pymbar`` currently runs best on Python 2.7.x; earlier versions of Python are not
-supported.  ``pymbar`` is developed and
-tested on mac and linux platforms. 
+conda (recommended)
+-------------------
 
-Easy Way (Recommended)
-----------------------
+The easiest way to install the ``pymbar`` release is via `conda <http://conda.pydata.org>`_:
 
-Just run ::
+  $ conda install -c omnia pymbar
+
+pip
+---
+
+You can also install ``pymbar`` from the `Python package index <https://pypi.python.org/pypi/pymbar>`_ using ``pip``:
 
   $ pip install pymbar
 
-Medium Way (Advanced Users Only)
-------------------------------------
-To get the latest unstable version, clone the source code repository from github::
+Development version
+-------------------
 
-  $ git clone git://github.com/choderalab/pymbar.git
+The development version can be installed directly from github via ``pip``:
 
-Then, in the directory containing the source code, you can install it with. ::
-
-  $ python setup.py install
-
+  $ pip install git+https://github.com/choderalab/pymbar.git
 
 Running the tests
 =================
 Running the tests is a great way to verify that everything is working. The test
 suite uses `nose <https://nose.readthedocs.org/en/latest/>`_, which you can pick
-up via ``pip`` if you don't already have it. ::
+up via ``conda`` or ``pip`` if you don't already have it. ::
+
+  $ conda install --yes nose
+
+or
 
   $ pip install nose
-  
-Then enter the ``pymbar`` the source directory and run ::
 
-  $ nosetests
+You can then run the tests with:
 
+  $ nosetests -vv pymbar

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,6 @@ pymbar
 
 Python implementation of the `multistate Bennett acceptance ratio (MBAR) <http://www.alchemistry.org/wiki/Multistate_Bennett_Acceptance_Ratio>`_ method for estimating expectations and free energy differences
 
-
 Documentation
 -------------
 
@@ -20,8 +19,7 @@ Documentation
    mbar
    timeseries
    testsystems
-
-
+   references
 
 Indices and tables
 ==================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@
 pymbar
 ======
 
-Python implementation of the multistate Bennett acceptance ratio (MBAR) method for estimating expectations and free energy differences
+Python implementation of the `multistate Bennett acceptance ratio (MBAR) <http://www.alchemistry.org/wiki/Multistate_Bennett_Acceptance_Ratio>`_ method for estimating expectations and free energy differences
 
 
 Documentation
@@ -29,4 +29,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-

--- a/docs/mbar.rst
+++ b/docs/mbar.rst
@@ -1,8 +1,8 @@
 .. currentmodule:: pymbar.mbar
 
-The mbar module : :class:`pymbar.mbar`
+The :module:`mbar` module : :class:`MBAR`
 ======================================
 
-The mbar module contains the MBAR class, the key object in pymbar.
+The :module:`mbar` module contains the :class:`MBAR` class, which implements the `multistate Bennett acceptance ratio (MBAR) <http://www.alchemistry.org/wiki/Multistate_Bennett_Acceptance_Ratio>`_ method :cite:`shirts-chodera:jcp:2008:mbar`.
 
 .. automodule:: pymbar.mbar

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1,0 +1,19 @@
+@article{shirts-chodera:jcp:2008:mbar,
+   author = {Michael R. Shirts and John D. Chodera},
+   title = {Statistically optimal analysis of samples from multiple equilibrium states},
+   journal = {Journal of Chemical Physics},
+   volume = {129},
+   pages = {124105},
+   year = {2008},
+   type = {Journal Article}
+}
+
+@article{chodera:jctc:2016:automatic-equilibration-detection,
+   author = {John D. Chodera},
+   title = {A simple method for automated equilibration detection in molecular simulations},
+   journal = {Journal of Chemical Theory and Computation},
+   volume = {12},
+   pages = {1799},
+   year = {2016},
+   type = {Journal Article}
+}

--- a/docs/rtd_requirements.txt
+++ b/docs/rtd_requirements.txt
@@ -2,3 +2,4 @@ numpy
 nose
 numpydoc
 scipy
+sphinxcontrib-bibtex

--- a/docs/testsystems.rst
+++ b/docs/testsystems.rst
@@ -7,3 +7,9 @@ The ``pymbar.testsystems`` module contains a number of test systems with analyti
 These test systems are also convenient to use if you want to easily generate synthetic data to experiment with the capabilities of ``pymbar``.
 
 .. automodule:: pymbar.testsystems
+
+.. automodule:: pymbar.testsystems.harmonic_oscillators
+.. automodule:: pymbar.testsystems.timeseries
+.. automodule:: pymbar.testsystems.exponential_distributions
+.. automodule:: pymbar.testsystems.gaussian_work
+.. automodule:: pymbar.testsystems.pymbar_datasets

--- a/docs/testsystems.rst
+++ b/docs/testsystems.rst
@@ -3,6 +3,7 @@
 The testsystems Module : :class:`pymbar.testsystems`
 ====================================================
 
-testsystems contains a number of test systems that you can use with pymbar.
+The ``pymbar.testsystems`` module contains a number of test systems with analytically or numerically computable expectations or free energies we use to validate its implementation.
+These test systems are also convenient to use if you want to easily generate synthetic data to experiment with the capabilities of ``pymbar``.
 
 .. automodule:: pymbar.testsystems

--- a/docs/timeseries.rst
+++ b/docs/timeseries.rst
@@ -1,8 +1,56 @@
 .. currentmodule:: pymbar.timeseries
 
-The timeseries module : :class:`pymbar.timeseries`
+The timeseries module : :module:`pymbar.timeseries`
 ==================================================
 
-The timeseries module contains tools for dealing with timeseries data.
+The ``pymbar.timeseries`` module contains tools for dealing with timeseries data.
+The `MBAR <http://www.alchemistry.org/wiki/Multistate_Bennett_Acceptance_Ratio>`_ method is only applicable to uncorrelated samples from probability distributions, so we provide a number of tools that can be used to decorrelate simulation data.
+
+Automatically identifying the equilibrated production region
+------------------------------------------------------------
+
+Most simulations start from initial conditions that are highly unrepresentative of equilibrated samples that occur late in the simulation.
+We can improve our estimates by discarding these initial regions to "equilibration" (also known as "burn-in").
+We recommend a simple scheme described in Ref. :cite:`chodera:jctc:2016:automatic-equilibration-detection`, which identifies the production region as the final contiguous region containing the *largest number of uncorrelated samples.
+This scheme is implemented in the :function:`detectEquilibration` method:
+
+.. python
+
+   from pymbar import timeseries
+   [t0, g, Neff_max] = timeseries.detectEquilibration(A_t) # compute indices of uncorrelated timeseries
+   A_t_equil = A_t[t0:]
+   indices = timeseries.subsampleCorrelatedData(A_t_equil, g=g)
+   A_n = A_t_equil[indices]
+
+In this example, the :function:`detectEquilibration` method is used on the correlated timeseries ``A_t`` to identify the sample index corresponding to the beginning of the production region, ``t_0``, the statistical inefficiency of the production region ``[t0:]``, ``g``, and the effective number of uncorrelated samples in the production region, ``Neff_max``.
+The production (equilibrated) region of the timeseries is extracted as ``A_t_equil`` and then subsampled using the :function:`subsampleCorrelatedData` method with the provided statistical inefficiency ``g``.
+Finally, the decorrelated samples are stored in ``A_n``.
+
+Note that, by default, the statistical inefficiency is computed for every time origin in a call to :function:`detectEquilibration`, which can be slow.
+If your dataset is more than a few hundred samples, you may want to evaluate only every ``nskip`` samples as potential time origins.
+This may result in discarding slightly more data than strictly necessary, but may not have a significant impact if the timeseries is long.
+
+.. python
+
+   nskip = 10 # only try every 10 samples for time origins
+   [t0, g, Neff_max] = timeseries.detectEquilibration(A_t, nskip=nskip)
+
+Subsampling timeseries data
+---------------------------
+
+If there is no need to discard the initial transient to equilibration, the :function:`subsampleCorrelatedData` method can be used directly to identify an effectively uncorrelated subset of data.
+
+.. python
+
+   from pymbar import timeseries
+   indices = timeseries.subsampleCorrelatedData(A_t_equil)
+   A_n = A_t_equil[indices]
+
+Here, the statistical inefficiency ``g`` is computed automatically.
+
+Other utility timeseries functions
+----------------------------------
+
+A number of other useful functions for computing autocorrelation functions from one or more timeseries sampled from the same process are also provided.
 
 .. automodule:: pymbar.timeseries

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -1,8 +1,8 @@
 .. currentmodule:: pymbar.utils
 
-Utilities : :class:`pymbar.utils`
+Utilities : :module:`pymbar.utils`
 =================================
 
-These functions are some miscellaneous functions used by other parts of the pymbar library.
+These functions are some miscellaneous functions used by other parts of the ``pymbar`` library.
 
 .. automodule:: pymbar.utils

--- a/docs/zbibliography.rst
+++ b/docs/zbibliography.rst
@@ -1,0 +1,7 @@
+.. only:: html
+
+   Bibliography
+   ############
+
+.. bibliography:: references.bib
+   :style: unsrt

--- a/pymbar/mbar.py
+++ b/pymbar/mbar.py
@@ -57,9 +57,9 @@ class MBAR:
     """Multistate Bennett acceptance ratio method (MBAR) for the analysis of multiple equilibrium samples.
 
     Notes
-    -----    
+    -----
     Note that this method assumes the data are uncorrelated.
-    Correlated data must be subsampled to extract uncorrelated (effectively independent) samples (see example below).
+    Correlated data must be subsampled to extract uncorrelated (effectively independent) samples.
 
     References
     ----------
@@ -75,32 +75,32 @@ class MBAR:
 
         Upon initialization, the dimensionless free energies for all states are computed.
         This may take anywhere from seconds to minutes, depending upon the quantity of data.
-        After initialization, the computed free energies may be obtained by a call to 'getFreeEnergies()', or
-        free energies or expectation at any state of interest can be computed by calls to 'computeFreeEnergy()' or
-        'computeExpectations()'.
+        After initialization, the computed free energies may be obtained by a call to :function:`getFreeEnergies`, or
+        free energies or expectation at any state of interest can be computed by calls to :function:`computeFreeEnergy` or
+        :function:`computeExpectations`.
 
         ----------
         u_kn : np.ndarray, float, shape=(K, N_max)
-            u_kn[k,n] is the reduced potential energy of uncorrelated
+            ``u_kn[k,n]`` is the reduced potential energy of uncorrelated
             configuration n evaluated at state k.
-            u_kln: np.ndarray, float, shape (K, L, N_max)
-               if the simulation is in form u_kln[k,l,n] it is converted to u_kn format
+        u_kln : np.ndarray, float, shape (K, L, N_max)
+            if the simulation is in form ``u_kln[k,l,n]`` it is converted to ``u_kn`` format
 
-        u_kn = [ u_1(x_1) u_1(x_2) u_1(x_3) . . . u_1(x_n)
-                 u_2(x_1) u_2(x_2) u_2(x_3) . . . u_2(x_n)
-                                .  .  .
-                 u_k(x_1) u_k(x_2) u_k(x_3) . . . u_k(x_n)]
+            u_kn = [ u_1(x_1) u_1(x_2) u_1(x_3) . . . u_1(x_n)
+                     u_2(x_1) u_2(x_2) u_2(x_3) . . . u_2(x_n)
+                                                . . .
+                     u_k(x_1) u_k(x_2) u_k(x_3) . . . u_k(x_n)]
 
         N_k :  np.ndarray, int, shape=(K)
-            N_k[k] is the number of uncorrelated snapshots sampled from state k.
+            ``N_k[k]`` is the number of uncorrelated snapshots sampled from state ``k``.
             Some may be zero, indicating that there are no samples from that state.
 
-        We assume that the states are ordered such that the first N_k
-        are from the first state, the 2nd N_k the second state, and so
-        forth. This only becomes important for BAR -- MBAR does not
-        care which samples are from which state.  We should eventually
-        allow this assumption to be overwritten by parameters passed
-        from above, once u_kln is phased out.
+            We assume that the states are ordered such that the first ``N_k``
+            are from the first state, the 2nd ``N_k`` the second state, and so
+            forth. This only becomes important for BAR -- MBAR does not
+            care which samples are from which state.  We should eventually
+            allow this assumption to be overwritten by parameters passed
+            from above, once ``u_kln`` is phased out.
 
         maximum_iterations : int, optional
             Set to limit the maximum number of iterations performed (default 1000)
@@ -109,7 +109,7 @@ class MBAR:
         verbosity : bool, optional
             Set to True if verbose debug output is desired (default False)
         initial_f_k : np.ndarray, float, shape=(K), optional
-            Set to the initial dimensionless free energies to use as a 
+            Set to the initial dimensionless free energies to use as a
             guess (default None, which sets all f_k = 0)
         method : list(dict), optional, default=None
             List of dictionaries to define a sequence of solver algorithms
@@ -123,7 +123,7 @@ class MBAR:
             (default: 'zeros', unless specific values are passed in.)
         x_kindices
             Which state is each x from?  Usually doesn't matter, but does for BAR. We assume the samples
-            are in K order (the first N_k[0] samples are from the 0th state, the next N_k[1] samples from 
+            are in K order (the first N_k[0] samples are from the 0th state, the next N_k[1] samples from
             the 1st state, and so forth.
 
         Notes
@@ -189,7 +189,7 @@ class MBAR:
             for k in range(K):
                 self.x_kindices[Nsum:Nsum+N_k[k]] = k
                 Nsum += N_k[k]
-            
+
         # verbosity level -- if True, will print extra debug information
         self.verbose = verbose
 
@@ -260,10 +260,10 @@ class MBAR:
                 print("Initial dimensionless free energies with method %s" % (initialize))
                 print("f_k = ")
                 print(self.f_k)
-        
+
         self.f_k = mbar_solvers.solve_mbar_with_subsampling(self.u_kn, self.N_k, self.f_k, solver_protocol, subsampling_protocol, subsampling, x_kindices=self.x_kindices)
         self.Log_W_nk = mbar_solvers.mbar_log_W_nk(self.u_kn, self.N_k, self.f_k)
-        
+
         # Print final dimensionless free energies.
         if self.verbose:
             print("Final dimensionless free energies")
@@ -285,7 +285,7 @@ class MBAR:
         weights : np.ndarray, float, shape=(N, K)
             NxK matrix of weights in the MBAR covariance and averaging formulas
 
-        """        
+        """
         return np.exp(self.Log_W_nk)
 
 
@@ -313,16 +313,16 @@ class MBAR:
 
         It also counts the efficiency of the sampling, which is simply the ratio
         of the effective number of samples at a given state to the total number
-        of samples collected.  This is printed in verbose output, but is not 
+        of samples collected.  This is printed in verbose output, but is not
         returned for now.
-        
+
         Returns
         -------
         N_eff : np.ndarray, float, shape=(K)
-                estimated number of samples contributing to estimates at each 
-                state i. An estimate to how many samples collected just at state 
-                i would result in similar statistical efficiency as the MBAR 
-                simulation. Valid for both sampled states (in which the weight 
+                estimated number of samples contributing to estimates at each
+                state i. An estimate to how many samples collected just at state
+                i would result in similar statistical efficiency as the MBAR
+                simulation. Valid for both sampled states (in which the weight
                 will be greater than N_k[i], and unsampled states.
 
         Parameters
@@ -335,7 +335,7 @@ class MBAR:
         # using Kish (1965) formula (Kish, Leslie (1965). Survey Sampling. New York: Wiley)
         # As the weights become more concentrated in fewer observations, the effective sample size shrinks.
         # from http://healthcare-economist.com/2013/08/22/effective-sample-size/
-        # effective # of samples contributing to averages carried out at state i 
+        # effective # of samples contributing to averages carried out at state i
         #                        =  (\sum_{n=1}^N w_in)^2 / \sum_{n=1}^N w_in^2
         #                        =  (\sum_{n=1}^N w_in^2)^-1
         #
@@ -344,7 +344,7 @@ class MBAR:
 
         Examples
         --------
-        
+
         >>> from pymbar import testsystems
         >>> [x_kn, u_kln, N_k, s_n] = testsystems.HarmonicOscillatorsTestCase().sample()
         >>> mbar = MBAR(u_kln, N_k)
@@ -426,12 +426,12 @@ class MBAR:
         Deltaf_ij : np.ndarray, float, shape=(K, K)
             Deltaf_ij[i,j] is the estimated free energy difference
         dDeltaf_ij : np.ndarray, float, shape=(K, K)
-            If compute_uncertainty==True, 
-            dDeltaf_ij[i,j] is the estimated statistical uncertainty 
+            If compute_uncertainty==True,
+            dDeltaf_ij[i,j] is the estimated statistical uncertainty
             (one standard deviation) in Deltaf_ij[i,j].  Otherwise None.
         (optional) Theta_ij : np.ndarray, float, shape=(K, K)
             The theta_matrix if return_theta==True, otherwise None.
-            
+
 
         Notes
         -----
@@ -454,14 +454,14 @@ class MBAR:
 
         """
         Deltaf_ij, dDeltaf_ij, Theta_ij = None, None, None  # By default, returns None for dDelta and Theta
-        
+
         # Compute free energy differences.
         f_i = np.matrix(self.f_k)
         Deltaf_ij = f_i - f_i.transpose()
 
         # zero out numerical error for thermodynamically identical states
         self._zerosamestates(Deltaf_ij)
-        
+
         Deltaf_ij = np.array(Deltaf_ij)  # Convert from np.matrix to np.array
 
         if compute_uncertainty or return_theta:
@@ -493,7 +493,7 @@ class MBAR:
         Compute the expectations of multiple observables of phase
         space functions [A_0(x),A_1(x),...,A_i(x)] along with the
         covariances of their estimates at multiple states.
-        
+
         intended as an internal function to keep all the optimized and
         robust expectation code in one place, but will leave it
         open to allow for later modifications
@@ -540,11 +540,11 @@ class MBAR:
              Ca_ij[i,j] is the COVARIANCE in the estimates of observables A_i and A_j (as determined by the state list)
             (* not the square root of anything, the full covariance matrix *)
 
-        Situations this will be used for : 
-            * multiple observables, single state (called though computeMultipleExpectations) 
-            * single observable, multiple states (called through computeExpectations) 
-            This has two cases: observables that don't change with state, and observables that 
-            do change with state.  
+        Situations this will be used for :
+            * multiple observables, single state (called though computeMultipleExpectations)
+            * single observable, multiple states (called through computeExpectations)
+            This has two cases: observables that don't change with state, and observables that
+            do change with state.
             For example, the set of energies at state k consist in energy function of state
             1 evaluated at state 1, energies of state 2 evaluated at
             state 2, and so forth.
@@ -555,7 +555,6 @@ class MBAR:
         Examples
         --------
 
-        update this example to be more general
         >>> from pymbar import testsystems
         >>> (x_n, u_kn, N_k, s_n) = testsystems.HarmonicOscillatorsTestCase().sample(mode='u_kn')
         >>> mbar = MBAR(u_kn, N_k)
@@ -579,11 +578,11 @@ class MBAR:
             S = mapshape[1]
 
         # reshape arrays explicitly into 2d (even if only one state) to make it easy to manipulate
-        shapeu = np.shape(u_ln)    
+        shapeu = np.shape(u_ln)
         if len(shapeu) == 1:
             u_ln = np.reshape(u_ln,[1,shapeu[0]])
 
-        shapeA = np.shape(A_n)    
+        shapeA = np.shape(A_n)
         if len(shapeA) == 1:
             A_n = np.reshape(A_n,[1,shapeA[0]])
 
@@ -591,10 +590,10 @@ class MBAR:
         N = self.N  # N is total number of samples
         returns = {}  # dictionary we will store uncertainties in
 
-        # make observables all positive, allowing us to take the logarithm, which is 
+        # make observables all positive, allowing us to take the logarithm, which is
         # required to prevent overflow in some examples.
-        # WARNING: one issue to watch for is if one of the energies is extremely 
-        # low (-10^10 or lower), but most of the energies of interest are much higher.  
+        # WARNING: one issue to watch for is if one of the energies is extremely
+        # low (-10^10 or lower), but most of the energies of interest are much higher.
         # This could lead to roundoff problems (check with Levi N.)
 
         L_list = np.unique(state_list)
@@ -628,7 +627,7 @@ class MBAR:
         # Pre-calculate the log denominator: Eqns 13, 14 in MBAR paper
         states_with_samples = (self.N_k > 0)
         log_denominator_n = logsumexp(self.f_k[states_with_samples] - self.u_kn[states_with_samples].T, b=self.N_k[states_with_samples], axis=1)
-        # Compute row of W_nk matrix for the extra states corresponding to u_ln 
+        # Compute row of W_nk matrix for the extra states corresponding to u_ln
         # that the state list specifies
         for l in L_list:
             la = K+l  #l, augmented
@@ -669,7 +668,7 @@ class MBAR:
             Theta_ij = self._computeAsymptoticCovarianceMatrix(
                 np.exp(Log_W_nk), N_k, method=uncertainty_method)
 
-            # Note: these variances will be the same whether or not we 
+            # Note: these variances will be the same whether or not we
             # subtract a different constant from each A_i
             # for efficency, output theta in block form
             #          K*K   K*S  K*NL
@@ -731,18 +730,18 @@ class MBAR:
         Inputs: d_ij: a matrix of standard deviations of the quantities f_i - f_j
 
         K: The number of states in each 'chunk', has to be constant
-        
+
         outputs: KxK variance matrix for the sums or differences \sum a_i df_i
-        
+
         We wish to calculate the variance of a weighted sum of free energy differences.
-        for example var(\sum a_i df_i). 
-        
-        We explicitly lay out the calculations for four variables (where each variable 
+        for example var(\sum a_i df_i).
+
+        We explicitly lay out the calculations for four variables (where each variable
         is a logarithm of a partion function), then generalize.
-        
+
         The uncertainty in the sum of two weighted differences is var(a1(f_i1 - f_j1) + a2(f_i2 - f_j2)) =
         a1^2 var(f_i1 - f_j1) + a2^2 var(f_i2 - f_j2) + 2 a1 a2 cov(f_i1 - f_j1, f_i2 - f_j2)
-        
+
         cov(f_i1 - f_j1, f_i2 - f_j2) = cov(f_i1,f_i2) - cov(f_i1,f_j2) - cov(f_j1,f_i2) + cov(f_j1,f_j2)
 
         call:
@@ -751,7 +750,7 @@ class MBAR:
         f_j1 = b
         f_i2 = c
         f_j2 = d
-        
+
         a1^2 var(a-b) + a2^2 var(c-d) + 2a1a2 cov(a-b,c-d)
         we want 2cov(a-b,c-d) = 2cov(a,c)-2cov(a,d)-2cov(b,c)+2cov(b,d)
         since  var(x-y) = var(x) + var(y) - 2cov(x,y)
@@ -764,12 +763,12 @@ class MBAR:
             2cov(b,d) = -var(b-d) + var(b) + var(d)
         adding up, we get:
             2cov(a-b,c-d) = 2cov(a,c)-2cov(a,d)-2cov(b,c)+2cov(b,d) =  - var(a-c) + var(a-d) + var(b-c) - var(b-d)
-  
+
             a1^2 var(a-b)+a2^2 var(c-d)+2a1a2cov(a-b,c-d) = a1^2 var(a-b)+a2^2 var(c-d)+a1a2 [-var(a-c)+var(a-d)+var(b-c)-var(b-d)]
             var(a1(f_i1 - f_j1) + a2(f_i2 - f_j2)) =
             = a1^2 var(f_i1 - f_j1) + a2^2 var(f_i2 - f_j2) + 2a1 a2 cov(f_i1 - f_j1, f_i2 - f_j2)
             = a1^2 var(f_i1 - f_j1) + a2^2 var(f_i2 - f_j2) + a1 a2 [-var(f_i1 - f_i2) + var(f_i1 - f_j2) + var(f_j1-f_i2) - var(f_j1 - f_j2)]
-            
+
         assume two arrays of free energy differences, and and array of constant vectors a.
         we want the variance var(\sum_k a_k (f_i,k - f_j,k)) Each set is separated from the other by an offset K
         same process applies with the sum, with the single var tems and the pair terms
@@ -807,7 +806,7 @@ class MBAR:
             default is self.u_kn
 
         output : string, optional
-            'averages' outputs expectations of observables and 'differences' outputs 
+            'averages' outputs expectations of observables and 'differences' outputs
             a matrix of differences in the observables.
 
         compute_uncertainty : bool, optional
@@ -919,7 +918,7 @@ class MBAR:
             mu = inner_results['observables']
             if compute_uncertainty:
                 sigma = np.sqrt(covA_ij[0:K,0:K].diagonal())
-                               
+
         if output == 'differences':
             A_im = np.matrix(inner_results['observables'])
             A_ij = A_im - A_im.transpose()
@@ -964,7 +963,7 @@ class MBAR:
         A_i : np.ndarray, float, shape=(I)
             A_i[i] is the estimate for the expectation of A_i(x) at the state specified by u_kn
         dA_i : np.ndarray, float, shape = (I)
-            dA_i[i] is the uncertainty in the expectation of A_state_map[i](x) at the state specified by u_n[state_map[i],:] 
+            dA_i[i] is the uncertainty in the expectation of A_state_map[i](x) at the state specified by u_n[state_map[i],:]
             or None if compute_uncertainty is False
         d2A_ij : np.ndarray, float, shape=(I, I)
             d2A_ij[i,j] is the COVARIANCE in the estimates of A_i[i] and A_i[j]: we can't actually take a square root
@@ -987,7 +986,7 @@ class MBAR:
         K = self.K
         N = self.N  # N is total number of samples
 
-        if len(np.shape(A_in)) == 3:  
+        if len(np.shape(A_in)) == 3:
             A_in_old = A_in.copy()  # convert to k by n format
             A_in = np.zeros([I, N], np.float64)
             for i in range(I):
@@ -1003,7 +1002,7 @@ class MBAR:
                                                       return_theta=(compute_uncertainty or compute_covariance),
                                                       uncertainty_method=uncertainty_method,
                                                       warning_cutoff=warning_cutoff)
-        
+
         expectations, uncertainties, covariances = None, None, None
         expectations = inner_results['observables']
 
@@ -1021,14 +1020,14 @@ class MBAR:
         if compute_covariance:
             # compute estimate of statistical covariance of the observables
             covariances = inner_results['Theta'][0:I,0:I]
-            
+
         return expectations, uncertainties, covariances
 
 
     #=========================================================================
     def computePerturbedFreeEnergies(self, u_ln, compute_uncertainty=True, uncertainty_method=None, warning_cutoff=1.0e-10):
         """Compute the free energies for a new set of states.
-        
+
         Here, we desire the free energy differences among a set of new states, as well as the uncertainty estimates in these differences.
 
         Parameters
@@ -1081,7 +1080,7 @@ class MBAR:
                                                       warning_cutoff=warning_cutoff)
 
         Deltaf_ij, dDeltaf_ij = None, None
-        
+
         f_k = np.matrix(inner_results['free energies'])
         Deltaf_ij = np.array(f_k - f_k.transpose())
 
@@ -1148,10 +1147,10 @@ class MBAR:
         [K,N] = np.shape(u_kn)
         A_in = u_kn.copy()
         state_map = np.zeros([2,K],int)
-        for k in range(K):    
+        for k in range(K):
             state_map[0,k] = k
             state_map[1,k] = k
-    
+
         inner_results = self.computeExpectationsInner(A_in, u_kn, state_map,
                                                       return_theta=True,
                                                       uncertainty_method=uncertainty_method,
@@ -1387,7 +1386,7 @@ class MBAR:
     #=========================================================================
     # PRIVATE METHODS - INTERFACES ARE NOT EXPORTED
     #=========================================================================
-                           
+
     def _ErrorOfDifferences(self,cov,warning_cutoff=1.0e-10):
         """
         inputs:
@@ -1398,7 +1397,7 @@ class MBAR:
 
         diag = np.matrix(cov.diagonal())
         d2 = diag + diag.transpose() - 2 * cov
-        
+
         # check for any numbers below zero.
         if (np.any(d2 < 0.0)):
             if (np.any(d2) < warning_cutoff):
@@ -1470,10 +1469,10 @@ class MBAR:
           'svd' computes the generalized inverse using the singular value decomposition -- this should be efficient yet accurate (faster)
           'svd-ew' is the same as 'svd', but uses the eigenvalue decomposition of W'W to bypass the need to perform an SVD (fastest)
           'approximate' only requires multiplication of KxN and NxK matrices, but is an approximate underestimate of the uncertainty.
-        
-        svd and svd-ew are described in appendix D of Shirts, 2007 JCP, while 
+
+        svd and svd-ew are described in appendix D of Shirts, 2007 JCP, while
         "approximate" in Section 4 of Kong, 2003. J. R. Statist. Soc. B.
-        
+
         We currently recommend 'svd-ew'.
         """
 
@@ -1514,7 +1513,7 @@ class MBAR:
             I = np.identity(K, dtype=np.float64)
 
             # Compute SVD of W
-            [U, S, Vt] = linalg.svd(W, full_matrices=False)  # False Avoids O(N^2) memory allocation by only calculting the active subspace of U.            
+            [U, S, Vt] = linalg.svd(W, full_matrices=False)  # False Avoids O(N^2) memory allocation by only calculting the active subspace of U.
             Sigma = np.matrix(np.diag(S))
             V = np.matrix(Vt).T
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ import six
 
 ##########################
 VERSION = "3.0.0"
-ISRELEASED = True
+ISRELEASED = False
 __version__ = VERSION
 ##########################
 

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@ import subprocess
 import six
 
 ##########################
-VERSION = "3.0.0.dev0"
-ISRELEASED = False
+VERSION = "3.0.0"
+ISRELEASED = True
 __version__ = VERSION
 ##########################
 
@@ -98,9 +98,9 @@ def buildKeywordDictionary():
     setupKeywords = {}
     setupKeywords["name"]              = "pymbar"
     setupKeywords["version"]           = VERSION
-    setupKeywords["author"]            = "Michael R. Shirts and John D. Chodera"
-    setupKeywords["author_email"]      = "michael.shirts@virginia.edu, choderaj@mskcc.org"
-    setupKeywords["license"]           = "GPL 2.0"
+    setupKeywords["author"]            = "Levi N. Naden and Michael R. Shirts and John D. Chodera"
+    setupKeywords["author_email"]      = "levi.naden@choderalab.org, michael.shirts@virginia.edu, john.chodera@choderalab.org"
+    setupKeywords["license"]           = "LGPL 2.1"
     setupKeywords["url"]               = "http://github.com/choderalab/pymbar"
     setupKeywords["download_url"]      = "http://github.com/choderalab/pymbar"
     setupKeywords["packages"]          = ['pymbar', 'pymbar.testsystems', 'pymbar.tests']
@@ -115,9 +115,9 @@ def buildKeywordDictionary():
     setupKeywords["requires"]          = ["numpy", "scipy", "nose", "numexpr"]
     setupKeywords["long_description"]  = """
     Pymbar (https://simtk.org/home/pymbar) is a library
-    that provides tools for optimally combining simulations 
-    from multiple thermodynamic states using maximum likelihood 
-    methods to compute free energies (normalization constants) 
+    that provides tools for optimally combining simulations
+    from multiple thermodynamic states using maximum likelihood
+    methods to compute free energies (normalization constants)
     and expectation values from all of the samples simultaneously.
     """
     outputString=""
@@ -126,12 +126,12 @@ def buildKeywordDictionary():
     for key in sorted(setupKeywords.keys()):
          value         = setupKeywords[key]
          outputString += key.rjust(firstTab) + str( value ).rjust(secondTab) + "\n"
-    
+
     print("%s" % outputString)
 
     #get_config_var(None)  # this line is necessary to fix the imports Mac OS X
     return setupKeywords
-    
+
 
 def main():
     setupKeywords = buildKeywordDictionary()
@@ -139,7 +139,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-
-
-
-


### PR DESCRIPTION
`pymbar 3.0.0dev2` has been out for ages, so it's time to release it.

I'm also taking a stab at cleaning up the `README.md` and docs.