### PR TITLE
Enable py 3.6 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ env:
     - python=2.7  CONDA_PY=27
     - python=3.4  CONDA_PY=34
     - python=3.5  CONDA_PY=35
+    - python=3.6  CONDA_PY=36
 
   global:
     - ORGNAME="omnia"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ environment:
       PYTHON_VERSION: "3.4"
       PYTHON_ARCH: "64"
       CONDA_PY: "34"
-      CONDA_NPY: "112"
+      CONDA_NPY: "111"
 
     - PYTHON: "C:\\Python36_64"
       PYTHON_VERSION: "3.6"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,13 +10,19 @@ environment:
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "64"
       CONDA_PY: "27"
-      CONDA_NPY: "19"
+      CONDA_NPY: "112"
 
     - PYTHON: "C:\\Python34_64"
       PYTHON_VERSION: "3.4"
       PYTHON_ARCH: "64"
       CONDA_PY: "34"
-      CONDA_NPY: "19"
+      CONDA_NPY: "112"
+
+    - PYTHON: "C:\\Python36_64"
+      PYTHON_VERSION: "3.6"
+      PYTHON_ARCH: "64"
+      CONDA_PY: "36"
+      CONDA_NPY: "112"
 
 install:
   # this installs the appropriate Miniconda (Py2/Py3, 32/64 bit),

--- a/devtools/appveyor/install.ps1
+++ b/devtools/appveyor/install.ps1
@@ -7,10 +7,10 @@ $MINICONDA_URL = "http://repo.continuum.io/miniconda/"
 
 function DownloadMiniconda ($python_version, $platform_suffix) {
     $webclient = New-Object System.Net.WebClient
-    if ($python_version -match "3.4") {
-        $filename = "Miniconda3-3.7.3-Windows-" + $platform_suffix + ".exe"
-    } else {
+    if ($python_version -match "2.7") {
         $filename = "Miniconda-3.7.3-Windows-" + $platform_suffix + ".exe"
+    } else {
+        $filename = "Miniconda3-3.7.3-Windows-" + $platform_suffix + ".exe"
     }
     $url = $MINICONDA_URL + $filename
 


### PR DESCRIPTION
This PR will be for testing and enabling Python 3.6. 

As dependencies for `pymbar` are released for Python 3.6, we can restart the CI builds as needed.

Required for #260 