### PR TITLE
modified _pymbar extension to allow compilation across python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ def buildKeywordDictionary():
     setupKeywords["zip_safe"]          = False
     #setupKeywords["py_modules"]        = ["pymbar", "timeseries", "testsystems", "confidenceintervals"]
     setupKeywords["data_files"]        = [('pymbar', ["pymbar/_pymbar.c"])]  # Ensures the _pymbar.c files are shipped regardless of Py Version
-    setupKeywords["ext_modules"]       = [CMBAR] if six.PY2 else []
+    setupKeywords["ext_modules"]       = [CMBAR]
     # setupKeywords["test_suite"]        = "tests" # requires we migrate to setuptools
     setupKeywords["platforms"]         = ["Linux", "Mac OS X", "Windows"]
     setupKeywords["description"]       = "Python implementation of the multistate Bennett acceptance ratio (MBAR) method."


### PR DESCRIPTION
Minor issue: `_pymbar` extension isn't compiled under python3.x. The extension is probably dispensable as it is used only in `old_mbar` and the program doesn't crash if the module it isn't available. Nevertheless, probably a good idea to maintain cross-platform compatibility. This PR should fix  #253.