### PR TITLE
Add DOI Badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Anaconda Cloud Downloads Badge](https://anaconda.org/omnia/pymbar/badges/downloads.svg)](https://anaconda.org/omnia/pymbar)
 [![Anaconda Cloud Badge](https://anaconda.org/omnia/pymbar/badges/installer/conda.svg)](https://anaconda.org/omnia/pymbar)
 [![PyPI Version](https://badge.fury.io/py/pymbar.png)](https://pypi.python.org/pypi/pymbar)
+[![DOI](https://zenodo.org/badge/9991771.svg)](https://zenodo.org/badge/latestdoi/9991771)
 
 pymbar
 ======


### PR DESCRIPTION
As it says on the tin

The DOI tracking has been enabled for a while, this just adds it to the README/Homepage