### PR TITLE
Python 3.8 Conda-Forge Fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ script:
 env:
   matrix:
     - python=2.7  CONDA_PY=27
-    - python=3.5  CONDA_PY=35
-    - python=3.6  CONDA_PY=36
+    - python=3.7  CONDA_PY=37
+    - python=3.8  CONDA_PY=38
 
   global:
     - ORGNAME="conda-forge"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,8 +29,8 @@ install:
   # as well as pip, conda-build, and the binstar CLI
   - ps: . ".\\devtools\\appveyor\\install.ps1"
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-  - conda update conda-build jinja2
   - conda config --add channels conda-forge
+  - conda install conda-build jinja2
 
 build: false
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ install:
   - ps: . ".\\devtools\\appveyor\\install.ps1"
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - conda config --add channels conda-forge
-  - conda install conda-build jinja2
+  - conda install --yes conda-build jinja2
 
 build: false
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,16 +12,16 @@ environment:
       CONDA_PY: "27"
       CONDA_NPY: "112"
 
-    - PYTHON: "C:\\Python35_64"
-      PYTHON_VERSION: "3.5"
-      PYTHON_ARCH: "64"
-      CONDA_PY: "35"
-      CONDA_NPY: "112"
-
     - PYTHON: "C:\\Python36_64"
       PYTHON_VERSION: "3.6"
       PYTHON_ARCH: "64"
       CONDA_PY: "36"
+      CONDA_NPY: "112"
+
+    - PYTHON: "C:\\Python37_64"
+      PYTHON_VERSION: "3.7"
+      PYTHON_ARCH: "64"
+      CONDA_PY: "37"
       CONDA_NPY: "112"
 
 install:

--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -3,28 +3,22 @@ pushd .
 cd $HOME
 
 # Install Miniconda
-MINICONDA=Miniconda2-latest-Linux-x86_64.sh
+# Sed cuts out everything before the first digit, then traps the first digit and everything after
 MINICONDA_HOME=$HOME/miniconda
 MINICONDA_MD5=$(curl -s https://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
-wget -q http://repo.continuum.io/miniconda/$MINICONDA
-# Parse version out of file as fall back
-# Sed cuts out everything before the first digit, then traps the first digit and everything after
-MINICONDA_DL_VER=$(head $MINICONDA | grep VER | sed -n 's/[^0-9]*\([0-9.]*\)/\1/p')
-MINICONDA_FILE_VER="Miniconda2-$MINICONDA_DL_VER-Linux-x86_64.sh"
-MINICONDA_MD5_VER=$(curl -s https://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA_FILE_VER | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
+wget -q https://repo.continuum.io/miniconda/$MINICONDA
 if [[ $MINICONDA_MD5 != $(md5sum $MINICONDA | cut -d ' ' -f 1) ]]; then
-    if [[ $MINICONDA_MD5_VER != $(md5sum $MINICONDA | cut -d ' ' -f 1) ]]; then
-        echo "Miniconda MD5 mismatch"
-        exit 1
-    fi
+    echo "Miniconda MD5 mismatch"
+    exit 1
 fi
+
 bash $MINICONDA -b -p $MINICONDA_HOME
 
 # Configure miniconda
 export PIP_ARGS="-U"
 export PATH=$MINICONDA_HOME/bin:$PATH
 conda update --yes conda
-conda install --yes conda-build=2.1.17 jinja2 anaconda-client pip
+conda install --yes conda-build jinja2 anaconda-client pip
 
 # Restore original directory
 popd

--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -3,6 +3,7 @@ pushd .
 cd $HOME
 
 # Install Miniconda
+MINICONDA=Miniconda3-latest-Linux-x86_64.sh
 # Sed cuts out everything before the first digit, then traps the first digit and everything after
 MINICONDA_HOME=$HOME/miniconda
 MINICONDA_MD5=$(curl -s https://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')


### PR DESCRIPTION
In order to accomodate conda-forge/pymbar-feedstock#5 this PR fixes the travis-ci tests (in theory) and then we can do a 3.0.4 release which has the fixes in #296 which the C-F build needs