### PR TITLE
Make all outputs default to 3.0.3 behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,15 @@ To analyze this data, we first initialize the `MBAR` object:
 ```
 Estimating dimensionless free energy differences between the sampled thermodynamic states and their associated uncertainties (standard errors) simply requires a call to `getFreeEnergyDifferences()`:
 ```python
->>>  results = mbar.getFreeEnergyDifferences()
+>>>  results = mbar.getFreeEnergyDifferences(return_dict=True)
 ```
 Here `results` is a dictionary with keys `Deltaf_ij`, `dDeltaf`, and `Theta`. `Deltaf_ij[i,j]` is the matrix of dimensionless free energy differences `f_j - f_i`, `dDeltaf_ij[i,j]` is the matrix of standard errors in this matrices estimate, and `Theta` is a covariance matrix that can be used to propagate error into quantities derived from the free energies.
+By default, `return_dict` is `False` and the return will be a tuple.
 
 Expectations and associated uncertainties can easily be estimated for observables `A(x)` for all states:
 ```python
 >>> A_kn = x_kn # use position of harmonic oscillator as observable
->>> results = mbar.computeExpectations(A_kn)
+>>> results = mbar.computeExpectations(A_kn, return_dict=True)
 ```
 where `results` is a dictionary with keys `mu`, `sigma`, and `Theta`, where `mu[i]` is the array of the estimate for the average of the observable for in state i, `sigma[i]` is the estimated standard deviation of the `mu` estimates,  and `Theta[i,j]` is the covarinace matrix of the log weights. 
 

--- a/examples/constant-force-optical-trap/force-bias-optical-trap.py
+++ b/examples/constant-force-optical-trap/force-bias-optical-trap.py
@@ -211,9 +211,6 @@ for k in range(K):
 # Compute PMF in unbiased potential (in units of kT).
 print("Computing PMF...")
 (f_i, df_i) = mbar.computePMF(u_kn, bin_kn, nbins)
-results = mbar.computePMF(u_kn, bin_kn, nbins)
-f_i = results['f_i']
-df_i = results['df_i']
 # compute estimate of PMF including Jacobian term
 pmf_i = f_i + numpy.log(bin_width_i)
 # Write out unbiased estimate of PMF
@@ -237,7 +234,7 @@ print("analysis took %f seconds" % elapsed_time)
 # compute observed and expected histograms at each state
 for l in range(0,K):
     # compute PMF at state l
-    results = mbar.computePMF(u_kln[:,l,:], bin_kn, nbins)
+    results = mbar.computePMF(u_kln[:,l,:], bin_kn, nbins, return_dict=True)
     f_i = results['f_i']
     df_i = results['df_i']
     # compute estimate of PMF including Jacobian term

--- a/examples/harmonic-oscillators/harmonic-oscillators-distributions.py
+++ b/examples/harmonic-oscillators/harmonic-oscillators-distributions.py
@@ -135,7 +135,7 @@ for replicate_index in range(0,nreplicates):
 
   # Initialize the MBAR class, determining the free energies.
   mbar = MBAR(u_kln, N_k, relative_tolerance=1.0e-10,verbose=False) # use fast Newton-Raphson solver
-  results = mbar.getFreeEnergyDifferences()
+  results = mbar.getFreeEnergyDifferences(return_dict=True)
   Deltaf_ij_estimated = results['Delta_f']
   dDeltaf_ij_estimated = results['dDelta_f']
 

--- a/examples/harmonic-oscillators/harmonic-oscillators.py
+++ b/examples/harmonic-oscillators/harmonic-oscillators.py
@@ -25,7 +25,8 @@
 from __future__ import print_function
 import sys
 import numpy
-from pymbar import testsystems, EXP, EXPGauss, BAR, MBAR, utils
+from pymbar import testsystems, EXP, EXPGauss, BAR, MBAR
+from pymbar.utils import ParameterError
 
 #=============================================================================================
 # HELPER FUNCTIONS
@@ -142,7 +143,7 @@ print("=============================================")
 print("      Testing getFreeEnergyDifferences       ")
 print("=============================================")
 
-results = mbar.getFreeEnergyDifferences()
+results = mbar.getFreeEnergyDifferences(return_dict=True)
 Delta_f_ij_estimated = results['Delta_f']
 dDelta_f_ij_estimated = results['dDelta_f']
 
@@ -174,7 +175,7 @@ for i in range(Knon-1):
   k1 = nonzero_indices[i+1]
   w_F = u_kln[k, k1, 0:N_k[k]]   - u_kln[k, k, 0:N_k[k]]       # forward work                                  
   w_R = u_kln[k1, k, 0:N_k[k1]] - u_kln[k1, k1, 0:N_k[k1]]    # reverse work                                  
-  results = BAR(w_F, w_R)
+  results = BAR(w_F, w_R, return_dict=True)
   df_bar = results['Delta_f']
   ddf_bar = results['dDelta_f']
   bar_analytical = (f_k_analytical[k1]-f_k_analytical[k]) 
@@ -190,7 +191,7 @@ print("EXP forward free energy")
 for k in range(K-1):
   if N_k[k] != 0:
     w_F = u_kln[k, k+1, 0:N_k[k]]   - u_kln[k, k, 0:N_k[k]]       # forward work
-    results = EXP(w_F)
+    results = EXP(w_F, return_dict=True)
     df_exp = results['Delta_f']
     ddf_exp = results['dDelta_f']
     exp_analytical = (f_k_analytical[k+1]-f_k_analytical[k]) 
@@ -202,7 +203,7 @@ print("EXP reverse free energy")
 for k in range(1,K):
   if N_k[k] != 0:
     w_R = u_kln[k, k-1, 0:N_k[k]] - u_kln[k, k, 0:N_k[k]]         # reverse work                                  
-    (df_exp,ddf_exp) = EXP(w_R)
+    (df_exp,ddf_exp) = EXP(w_R, return_dict=True)
     df_exp = -results['Delta_f']
     ddf_exp = results['dDelta_f']
     exp_analytical = (f_k_analytical[k]-f_k_analytical[k-1]) 
@@ -218,7 +219,7 @@ print("Gaussian forward estimate")
 for k in range(K-1):
   if N_k[k] != 0:
     w_F = u_kln[k, k+1, 0:N_k[k]]   - u_kln[k, k, 0:N_k[k]]       # forward work                                  
-    results = EXPGauss(w_F)
+    results = EXPGauss(w_F, return_dict=True)
     df_gauss = results['Delta_f']
     ddf_gauss = results['dDelta_f']
     gauss_analytical = (f_k_analytical[k+1]-f_k_analytical[k]) 
@@ -230,7 +231,7 @@ print("Gaussian reverse estimate")
 for k in range(1,K):
   if N_k[k] != 0:
     w_R = u_kln[k, k-1, 0:N_k[k]] - u_kln[k, k, 0:N_k[k]]         # reverse work                                  
-    results = EXPGauss(w_R)
+    results = EXPGauss(w_R, return_dict=True)
     df_gauss = results['Delta_f']
     ddf_gauss = results['dDelta_f']
     gauss_analytical = (f_k_analytical[k]-f_k_analytical[k-1]) 
@@ -286,7 +287,7 @@ for observe in observables:
     for k in range(0,K):
       A_kn[k,0:N_k[k]] = x_kn[k,0:N_k[k]]**2
 
-  results = mbar.computeExpectations(A_kn, state_dependent = state_dependent)
+  results = mbar.computeExpectations(A_kn, state_dependent = state_dependent, return_dict=True)
   A_k_estimated = results['mu']
   dA_k_estimated = results['sigma']
 
@@ -340,7 +341,7 @@ for observe in observables:
   stdevs = numpy.abs(As_k_error[Nk_ne_zero]/dAs_k_estimated[Nk_ne_zero])
   print(stdevs)
 
-  results = mbar.computeExpectations(A_kn, state_dependent = state_dependent, output = 'differences')
+  results = mbar.computeExpectations(A_kn, state_dependent = state_dependent, output = 'differences', return_dict=True)
   A_kl_estimated = results['mu']  
   dA_kl_estimated = results['sigma']
 
@@ -383,7 +384,7 @@ A_ikn = numpy.zeros([len(observables_single), K, N_k.max()], numpy.float64)
 for i,observe in enumerate(observables_single):
   A_ikn[i,:,:] = A_kn_all[observe]
 for i in range(K):
-  results = mbar.computeMultipleExpectations(A_ikn, u_kln[:,i,:], compute_covariance=True)
+  results = mbar.computeMultipleExpectations(A_ikn, u_kln[:,i,:], compute_covariance=True, return_dict=True)
   A_i = results['mu']
   dA_ij = results['sigma']
   Ca_ij = results['covariances']
@@ -398,7 +399,7 @@ print("============================================")
 print("      Testing computeEntropyAndEnthalpy")
 print("============================================")
 
-results = mbar.computeEntropyAndEnthalpy(u_kn = u_kln, verbose = True)
+results = mbar.computeEntropyAndEnthalpy(u_kn = u_kln, verbose = True, return_dict=True)
 Delta_f_ij = results['Delta_f']
 dDelta_f_ij = results['dDelta_f']
 Delta_u_ij = results['Delta_u']
@@ -467,7 +468,7 @@ for k in range(K):
     for l in range(L):
       unew_kln[k,l,0:N_k[k]] = (K_extra[l]/2.0) * (x_kn[k,0:N_k[k]]-O_extra[l])**2
 
-results = mbar.computePerturbedFreeEnergies(unew_kln)
+results = mbar.computePerturbedFreeEnergies(unew_kln, return_dict=True)
 Delta_f_ij_estimated = results['Delta_f']
 dDelta_f_ij_estimated = results['dDelta_f']
 
@@ -519,7 +520,7 @@ for observe in observables:
     A_kn = A_kn_all['position^2']
 
   A_k_estimated, dA_k_estimated 
-  results = mbar.computeExpectations(A_kn,unew_kln[:,[nth],:],state_dependent=state_dependent)
+  results = mbar.computeExpectations(A_kn,unew_kln[:,[nth],:],state_dependent=state_dependent, return_dict=True)
   A_k_estimated = results['mu'] 
   dA_k_estimated = results['sigma']
   # need to additionally transform to get the square root
@@ -543,7 +544,7 @@ print("============================================")
 print("      Testing computeOverlap   ")
 print("============================================")
 
-results = mbar.computeOverlap()
+results = mbar.computeOverlap(return_dict=True)
 O = results['scalar']
 O_i = results['eigenvalues']
 O_ij = results['matrix']
@@ -577,7 +578,7 @@ print("We should have that with MBAR, err_MBAR = sqrt(N_k/N_eff)*err_standard,")
 print("so standard (scaled) results should be very close to MBAR results.")
 print("No standard estimate exists for states that are not sampled.")
 A_kn = x_kn
-results = mbar.computeExpectations(A_kn)
+results = mbar.computeExpectations(A_kn, return_dict=True)
 val_mbar = results['mu']
 err_mbar = results['sigma']
 err_standard = numpy.zeros([K],dtype = numpy.float64)
@@ -744,7 +745,7 @@ for i in range(nbins):
 
 # Compute PMF.
 print("Computing PMF ...")
-results = mbar.computePMF(u_n, bin_n, nbins, uncertainties = 'from-specified', pmf_reference = zeroindex)
+results = mbar.computePMF(u_n, bin_n, nbins, uncertainties = 'from-specified', pmf_reference = zeroindex, return_dict=True)
 f_i = results['f_i']
 df_i = results['df_i']
 
@@ -833,7 +834,7 @@ for i in range(nbins):
 # Compute PMF.          
 print("Computing PMF ...")
 [f_i, df_i] 
-results = mbar.computePMF(u_n, bin_n, nbins, uncertainties = 'from-specified', pmf_reference = zeroindex)
+results = mbar.computePMF(u_n, bin_n, nbins, uncertainties = 'from-specified', pmf_reference = zeroindex, return_dict=True)
 f_i = results['f_i']
 df_i = results['df_i']
 

--- a/examples/heat-capacity/heat-capacity.py
+++ b/examples/heat-capacity/heat-capacity.py
@@ -281,23 +281,23 @@ for n in range(nBoots_work):
     E_kln = u_kln  # not a copy, we are going to write over it, but we don't need it any more.
     for k in range(K):
         E_kln[:,k,:]*=beta_k[k]**(-1)  # get the 'unreduced' potential -- we can't take differences of reduced potentials because the beta is different; math is much more confusing with derivatives of the reduced potentials.
-    results = mbar.computeExpectations(E_kln, state_dependent = True)
+    results = mbar.computeExpectations(E_kln, state_dependent = True, return_dict=True)
     E_expect = results['mu']
     dE_expect = results['sigma']
     allE_expect[:,n] = E_expect[:]
 
     # expectations for the differences, which we need for numerical derivatives
-    results = mbar.computeExpectations(E_kln,output='differences', state_dependent = True)
+    results = mbar.computeExpectations(E_kln,output='differences', state_dependent = True, return_dict=True)
     DeltaE_expect = results['mu']
     dDeltaE_expect = results['sigma']
     print("Computing Expectations for E^2...")
 
-    results = mbar.computeExpectations(E_kln**2, state_dependent = True)
+    results = mbar.computeExpectations(E_kln**2, state_dependent = True, return_dict=True)
     E2_expect = results['mu']
     dE2_expect = results['sigma']
     allE2_expect[:,n] = E2_expect[:]
 
-    results = mbar.getFreeEnergyDifferences()
+    results = mbar.getFreeEnergyDifferences(return_dict=True)
     df_ij = results['Delta_f']
     ddf_ij = results['dDelta_f']
 

--- a/examples/parallel-tempering-2dpmf/parallel-tempering-2dpmf.py
+++ b/examples/parallel-tempering-2dpmf/parallel-tempering-2dpmf.py
@@ -293,7 +293,7 @@ u_kn = target_beta * U_kn
 # f_i[i] is the dimensionless free energy of bin i (in kT) at the temperature of interest
 # df_i[i,j] is an estimate of the covariance in the estimate of (f_i[i] - f_j[j], with reference
 # the lowest free energy state.
-results = mbar.computePMF(u_kn, bin_kn, nbins, uncertainties='from-lowest')
+results = mbar.computePMF(u_kn, bin_kn, nbins, uncertainties='from-lowest', return_dict=True)
 f_i = results['f_i']
 df_i = results['df_i']
 

--- a/examples/umbrella-sampling-pmf/umbrella-sampling.py
+++ b/examples/umbrella-sampling-pmf/umbrella-sampling.py
@@ -147,7 +147,7 @@ print("Running MBAR...")
 mbar = pymbar.MBAR(u_kln, N_k, verbose = True)
 
 # Compute PMF in unbiased potential (in units of kT).
-results = mbar.computePMF(u_kn, bin_kn, nbins)
+results = mbar.computePMF(u_kn, bin_kn, nbins, return_dict=True)
 f_i = results['f_i']
 df_i = results['df_i']
 

--- a/pymbar/exp.py
+++ b/pymbar/exp.py
@@ -51,7 +51,7 @@ from pymbar.utils import logsumexp
 # One-sided exponential averaging (EXP).
 #=============================================================================================
 
-def EXP(w_F, compute_uncertainty=True, is_timeseries=False):
+def EXP(w_F, compute_uncertainty=True, is_timeseries=False, return_dict=False):
     """Estimate free energy difference using one-sided (unidirectional) exponential averaging (EXP).
 
     Parameters
@@ -63,17 +63,17 @@ def EXP(w_F, compute_uncertainty=True, is_timeseries=False):
     is_timeseries : bool, default=False
         if True, correlation in data is corrected for by estimation of statisitcal inefficiency (default: False)
         Use this option if you are providing correlated timeseries data and have not subsampled the data to produce uncorrelated samples.
+    return_dict : bool, default False
+        If true, returns are a dictionary, else they are a tuple
 
     Returns
     -------
-    result_vals : dictionary
-    
-    Possible keys in the result_vals dictionary
-
     'Delta_f' : float
         Free energy difference
+        If return_dict, key is 'Delta_f'
     'dDelta_f': float
         Estimated standard deviation of free energy difference
+        If return_dict, key is 'dDelta_f'
 
     Notes
     -----
@@ -86,16 +86,17 @@ def EXP(w_F, compute_uncertainty=True, is_timeseries=False):
 
     >>> from pymbar import testsystems
     >>> [w_F, w_R] = testsystems.gaussian_work_example(mu_F=None, DeltaF=1.0, seed=0)
-    >>> results = EXP(w_F)
+    >>> results = EXP(w_F, return_dict=True)
     >>> print('Forward free energy difference is %.3f +- %.3f kT' % (results['Delta_f'], results['dDelta_f']))
     Forward free energy difference is 1.088 +- 0.076 kT
-    >>> results = EXP(w_R)
+    >>> results = EXP(w_R, return_dict=True)
     >>> print('Reverse free energy difference is %.3f +- %.3f kT' % (results['Delta_f'], results['dDelta_f']))
     Reverse free energy difference is -1.073 +- 0.082 kT
 
     """
 
     result_vals = dict()
+    result_list = []
 
     # Get number of work measurements.
     T = float(np.size(w_F))  # number of work measurements
@@ -126,16 +127,21 @@ def EXP(w_F, compute_uncertainty=True, is_timeseries=False):
 
         # Return estimate of free energy difference and uncertainty.
         result_vals['Delta_f'] = DeltaF
-        result_vals['dDelta_f'] = dDeltaF 
+        result_vals['dDelta_f'] = dDeltaF
+        result_list.append(DeltaF)
+        result_list.append(dDeltaF)
     else:
         result_vals['Delta_f'] = DeltaF
-    return result_vals
+        result_list.append(DeltaF)
+    if return_dict:
+        return result_vals
+    return tuple(result_list)
 
 #=============================================================================================
 # Gaussian approximation to exponential averaging (Gauss).
 #=============================================================================================
 
-def EXPGauss(w_F, compute_uncertainty=True, is_timeseries=False):
+def EXPGauss(w_F, compute_uncertainty=True, is_timeseries=False, return_dict=False):
     """Estimate free energy difference using gaussian approximation to one-sided (unidirectional) exponential averaging.
 
     Parameters
@@ -147,17 +153,17 @@ def EXPGauss(w_F, compute_uncertainty=True, is_timeseries=False):
     is_timeseries : bool, default=False
         if True, correlation in data is corrected for by estimation of statisitcal inefficiency (default: False)
         Use this option if you are providing correlated timeseries data and have not subsampled the data to produce uncorrelated samples.
+    return_dict : bool, default False
+        If true, returns are a dictionary, else they are a tuple
 
     Returns
     -------
-    result_vals : dictionary
-    
-    Possible keys in the result_vals dictionary
-
     'Delta_f' : float
         Free energy difference between the two states
+        If return_dict, key is 'Delta_f'
     'dDelta_f': float
         Estimated standard deviation of free energy difference between the two states.
+        If return_dict, key is 'dDelta_f'
 
     Notes
     -----
@@ -169,10 +175,10 @@ def EXPGauss(w_F, compute_uncertainty=True, is_timeseries=False):
 
     >>> from pymbar import testsystems
     >>> [w_F, w_R] = testsystems.gaussian_work_example(mu_F=None, DeltaF=1.0, seed=0)
-    >>> results = EXPGauss(w_F)
+    >>> results = EXPGauss(w_F, return_dict=True)
     >>> print('Forward Gaussian approximated free energy difference is %.3f +- %.3f kT' % (results['Delta_f'], results['dDelta_f']))
     Forward Gaussian approximated free energy difference is 1.049 +- 0.089 kT
-    >>> results = EXPGauss(w_R)
+    >>> results = EXPGauss(w_R, return_dict=True)
     >>> print('Reverse Gaussian approximated free energy difference is %.3f +- %.3f kT' % (results['Delta_f'], results['dDelta_f']))
     Reverse Gaussian approximated free energy difference is -1.073 +- 0.080 kT
 
@@ -186,6 +192,7 @@ def EXPGauss(w_F, compute_uncertainty=True, is_timeseries=False):
     DeltaF = np.average(w_F) - 0.5 * var
 
     result_vals = dict()
+    result_list = []
     if compute_uncertainty:
         # Compute effective number of uncorrelated samples.
         g = 1.0  # statistical inefficiency
@@ -202,10 +209,15 @@ def EXPGauss(w_F, compute_uncertainty=True, is_timeseries=False):
 
         # Return estimate of free energy difference and uncertainty.
         result_vals['Delta_f'] = DeltaF
-        result_vals['dDelta_f'] = dDeltaF 
+        result_vals['dDelta_f'] = dDeltaF
+        result_list.append(DeltaF)
+        result_list.append(dDeltaF)
     else:
         result_vals['Delta_f'] = DeltaF
-    return result_vals
+        result_list.append(DeltaF)
+    if return_dict:
+        return result_vals
+    return tuple(result_list)
 
 #=============================================================================================
 # For compatibility with 2.0.1-beta

--- a/pymbar/mbar.py
+++ b/pymbar/mbar.py
@@ -404,23 +404,27 @@ class MBAR:
         return N_eff
 
     # =========================================================================
-    def computeOverlap(self):
+    def computeOverlap(self, return_dict=True):
         """
         Compute estimate of overlap matrix between the states.
 
+        Parameters
+        ----------
+        return_dict : bool, Default False
+            If true, results are a dict, else a tuple
+
         Returns
         -------
-        result_vals : dictonary
-
-        Possible keys in the result_vals dictionary:
-
         'scalar' : np.ndarray, float, shape=(K, K)
             One minus the largest nontrival eigenvalue (largest is 1 or -1)
+            If return_dict, key is 'scalar'
         'eigenvalues' : np.ndarray, float, shape=(K)
             The sorted (descending) eigenvalues of the overlap matrix.
-        'O' : np.ndarray, float, shape=(K, K)
+            If return_dict, key is 'eigenvalues'
+        'matrix' : np.ndarray, float, shape=(K, K)
             Estimated state overlap matrix: O[i,j] is an estimate
             of the probability of observing a sample from state i in state j
+            If return_dict, key is 'matrix'
 
         Notes
         -----
@@ -440,7 +444,7 @@ class MBAR:
         >>> from pymbar import testsystems
         >>> (x_kn, u_kn, N_k, s_n) = testsystems.HarmonicOscillatorsTestCase().sample(mode='u_kn')
         >>> mbar = MBAR(u_kn, N_k)
-        >>> results = mbar.computeOverlap()
+        >>> results = mbar.computeOverlap(return_dict=True)
 
         """
 
@@ -456,10 +460,12 @@ class MBAR:
         results_vals['eigenvalues'] = eigenvals
         results_vals['matrix'] = O
 
-        return results_vals
+        if return_dict:
+            return results_vals
+        return overlap_scalar, eigenvals, O
 
     #=========================================================================
-    def getFreeEnergyDifferences(self, compute_uncertainty=True, uncertainty_method=None, warning_cutoff=1.0e-10, return_theta=False):
+    def getFreeEnergyDifferences(self, compute_uncertainty=True, uncertainty_method=None, warning_cutoff=1.0e-10, return_theta=False, return_dict=False):
         """Get the dimensionless free energy differences and uncertainties among all thermodynamic states.
 
 
@@ -476,21 +482,22 @@ class MBAR:
             than this number (default: 1.0e-10)
         return_theta : bool, optional
             Whether or not to return the theta matrix.  Can be useful for complicated differences.
+        return_dict: bool, default False
+            If true, returns are in a dictionary otherwise a tuple is returned
 
         Returns
         -------
-        result_vals : dictionary
-
-        Possible keys in the result_vals dictionary:
-
         'Delta_f' : np.ndarray, float, shape=(K, K)
             Deltaf_ij[i,j] is the estimated free energy difference
+            If return_dict, key is 'Delta_f'
         'dDelta_f' : np.ndarray, float, shape=(K, K)
             If compute_uncertainty==True,
             dDeltaf_ij[i,j] is the estimated statistical uncertainty
             (one standard deviation) in Deltaf_ij[i,j].  Otherwise not included.
+            If return_dict, key is 'dDelta_f'
         'Theta' : np.ndarray, float, shape=(K, K)
             The theta_matrix if return_theta==True, otherwise not included.
+            If return_dict, key is 'Theta'
 
         Notes
         -----
@@ -509,7 +516,7 @@ class MBAR:
         >>> from pymbar import testsystems
         >>> (x_n, u_kn, N_k, s_n) = testsystems.HarmonicOscillatorsTestCase().sample(mode='u_kn')
         >>> mbar = MBAR(u_kn, N_k)
-        >>> results = mbar.getFreeEnergyDifferences()
+        >>> results = mbar.getFreeEnergyDifferences(return_dict=True)
 
         """
         Deltaf_ij, dDeltaf_ij, Theta_ij = None, None, None  # By default, returns None for dDelta and Theta
@@ -524,8 +531,10 @@ class MBAR:
         Deltaf_ij = np.array(Deltaf_ij)  # Convert from np.matrix to np.array
 
         result_vals = dict()
+        return_list = []
 
         result_vals['Delta_f'] = Deltaf_ij
+        return_list.append(Deltaf_ij)
 
         if compute_uncertainty or return_theta:
             # Compute asymptotic covariance matrix.
@@ -539,11 +548,15 @@ class MBAR:
             # Return matrix of free energy differences and uncertainties.
             dDeltaf_ij = np.array(dDeltaf_ij)
             result_vals['dDelta_f'] = dDeltaf_ij
+            return_list.append(dDeltaf_ij)
 
         if return_theta:
             result_vals['Theta'] = Theta_ij
+            return_list.append(Theta_ij)
 
-        return result_vals
+        if return_dict:
+            return result_vals
+        return tuple(return_list)
 
     # =========================================================================
     def computeExpectationsInner(self, A_n, u_ln, state_map,
@@ -596,7 +609,7 @@ class MBAR:
 
         'Theta' : np.ndarray, float, shape = (K+len(state_list), K+len(state_list)) the covariance matrix of log weights.
 
-        'Amin' : np.ndarray, float, shape = (S), needed for reconstructing the covariance one level up. 
+        'Amin' : np.ndarray, float, shape = (S), needed for reconstructing the covariance one level up.
 
         'f' : np.ndarray, float, shape = (K+len(state_list)), 'free energies' of the new states (i.e. ln (<A>-Amin+1)) as the log form is easier to work with.
 
@@ -875,7 +888,8 @@ class MBAR:
     #=========================================================================
     def computeExpectations(self, A_n, u_kn=None, output='averages', state_dependent=False,
                             compute_uncertainty=True, uncertainty_method=None,
-                            warning_cutoff=1.0e-10, return_theta=False):
+                            warning_cutoff=1.0e-10, return_theta=False,
+                            return_dict=False):
         """Compute the expectation of an observable of a phase space function.
 
         Compute the expectation of an observable of a single phase space
@@ -907,22 +921,24 @@ class MBAR:
 
         state_dependent: bool, whether the expectations are state-dependent.
 
+        return_dict: bool, default False
+            If true, return is a dictionary, else its a tuple
+
         Returns
         -------
-        result_vals : dictionary
-
-        Possible keys in the result_vals dictionary:
-
         'mu' : np.ndarray, float
             if output is 'averages'
             A_i  (K np float64 array) -  A_i[i] is the estimate for the expectation of A(x) for state i.
             if output is 'differences'
+            if return_dict: key is 'mu'
         'sigma' : np.ndarray, float
             dA_i  (K np float64 array) - dA_i[i] is uncertainty estimate (one standard deviation) for A_i[i]
             or
             dA_ij (K np float64 array) - dA_ij[i,j] is uncertainty estimate (one standard deviation) for the difference in A beteen i and j
             or None, if compute_uncertainty is False.
+            if return_dict: key is 'sigma'
         'Theta' ((KxK np float64 array): Covariance matrix of log weights
+            if return_dict, key is 'Theta'
 
         References
         ----------
@@ -936,9 +952,9 @@ class MBAR:
         >>> (x_n, u_kn, N_k, s_n) = testsystems.HarmonicOscillatorsTestCase().sample(mode='u_kn')
         >>> mbar = MBAR(u_kn, N_k)
         >>> A_n = x_n
-        >>> results = mbar.computeExpectations(A_n)
+        >>> results = mbar.computeExpectations(A_n, return_dict=True)
         >>> A_n = u_kn[0,:]
-        >>> results = mbar.computeExpectations(A_n, output='differences')
+        >>> results = mbar.computeExpectations(A_n, output='differences', return_dict=True)
         """
 
         dims = len(np.shape(A_n))
@@ -992,6 +1008,7 @@ class MBAR:
                                                       warning_cutoff=warning_cutoff)
 
         result_vals = dict()
+        result_list = []
         if compute_uncertainty or return_theta:
             # we want the theta matrix for the exponentials of the
             # observables, which means we need to make the
@@ -1005,25 +1022,33 @@ class MBAR:
 
         if output == 'averages':
             result_vals['mu'] = inner_results['observables']
+            result_list.append(result_vals['mu'])
             if compute_uncertainty:
                 result_vals['sigma'] = np.sqrt(covA_ij[0:K,0:K].diagonal())
+                result_list.append(result_vals['sigma'])
 
         if output == 'differences':
             A_im = np.matrix(inner_results['observables'])
             A_ij = A_im - A_im.transpose()
 
             result_vals['mu'] = np.array(A_ij)
+            result_list.append(result_vals['mu'])
             if compute_uncertainty:
                 result_vals['sigma'] = self._ErrorOfDifferences(covA_ij,warning_cutoff=warning_cutoff)
+                result_list.append(result_vals['sigma'])
 
         if return_theta:
             result_vals['Theta'] = Theta
+            result_list.append(Theta)
 
-        return result_vals
+        if return_dict:
+            return result_vals
+        return tuple(result_list)
 
     #=========================================================================
     def computeMultipleExpectations(self, A_in, u_n, compute_uncertainty=True, compute_covariance=False,
-                                    uncertainty_method=None, warning_cutoff=1.0e-10, return_theta=False):
+                                    uncertainty_method=None, warning_cutoff=1.0e-10, return_theta=False,
+                                    return_dict=False):
         """Compute the expectations of multiple observables of phase space functions.
 
         Compute the expectations of multiple observables of phase
@@ -1050,22 +1075,24 @@ class MBAR:
             See help for computeAsymptoticCovarianceMatrix() for more information on various methods. (default: None)
         warning_cutoff : float, optional
             Warn if squared-uncertainty is negative and larger in magnitude than this number (default: 1.0e-10)
+        return_dict: bool, default False
+            If true, return is a dictionary, else its a tuple
 
         Returns
         -------------
-        result_vals : dictionary
-
-        Possible keys in the result_vals dictionary:
-
         'mu' : np.ndarray, float, shape=(I)
             result_vals['mu'] is the estimate for the expectation of A_i(x) at the state specified by u_kn
+            If return_dict, key will be 'mu'
         'sigma' : np.ndarray, float, shape = (I)
             result_vals['sigma'] is the uncertainty in the expectation of A_state_map[i](x) at the state specified by u_n[state_map[i],:]
             or None if compute_uncertainty is False
+            If return_dict, key will be 'sigma'
         'covariances' : np.ndarray, float, shape=(I, I)
             result_vals['covariances'] is the COVARIANCE in the estimates of A_i[i] and A_i[j]: we can't actually take a square root
             or None if compute_covariance is False
+            If return_dict, key will be 'covartiances'
         'Theta': np.ndarray, float, shape=(I, I), covariances of the log weights, useful for some additional calculations.
+            If return_dict, key will be 'Theta'
 
         Examples
         --------
@@ -1075,7 +1102,7 @@ class MBAR:
         >>> mbar = MBAR(u_kn, N_k)
         >>> A_in = np.array([x_n,x_n**2,x_n**3])
         >>> u_n = u_kn[0,:]
-        >>> results = mbar.computeMultipleExpectations(A_in, u_kn)
+        >>> results = mbar.computeMultipleExpectations(A_in, u_kn, return_dict=True)
 
         """
 
@@ -1101,8 +1128,10 @@ class MBAR:
                                                       uncertainty_method=uncertainty_method,
                                                       warning_cutoff=warning_cutoff)
         result_vals = dict()
+        return_list = []
         expectations, uncertainties, covariances = None, None, None
         result_vals['mu'] = inner_results['observables']
+        return_list.append(result_vals['mu'])
 
         if compute_uncertainty or compute_covariance or return_theta:
             Adiag = np.zeros([2*I,2*I],dtype=np.float64)
@@ -1110,22 +1139,28 @@ class MBAR:
             diag[0:I] = diag[I:2*I] = inner_results['observables']-inner_results['Amin']
             np.fill_diagonal(Adiag,diag)
             Theta = Adiag*inner_results['Theta']*Adiag
-            if return_theta:
-                result_vals['Theta'] = Theta
 
             if compute_uncertainty:
                 covA_ij = np.array(Theta[0:I,0:I]+Theta[I:2*I,I:2*I]-Theta[0:I,I:2*I]-Theta[I:2*I,0:I])
                 result_vals['sigma'] = np.sqrt(covA_ij[0:I,0:I].diagonal())
+                return_list.append(result_vals['sigma'])
 
             if compute_covariance:
                 # compute estimate of statistical covariance of the observables
                 result_vals['covariances'] = inner_results['Theta'][0:I,0:I]
+                return_list.append(result_vals['covariances'])
 
-        return result_vals
+            if return_theta:
+                result_vals['Theta'] = Theta
+                return_list.append(result_vals['Theta'])
+
+        if return_dict:
+            return result_vals
+        return tuple(return_list)
 
 
     #=========================================================================
-    def computePerturbedFreeEnergies(self, u_ln, compute_uncertainty=True, uncertainty_method=None, warning_cutoff=1.0e-10):
+    def computePerturbedFreeEnergies(self, u_ln, compute_uncertainty=True, uncertainty_method=None, warning_cutoff=1.0e-10, return_dict=False):
         """Compute the free energies for a new set of states.
 
         Here, we desire the free energy differences among a set of new states, as well as the uncertainty estimates in these differences.
@@ -1142,25 +1177,25 @@ class MBAR:
             See help for computeAsymptoticCovarianceMatrix() for more information on various methods. (default: None)
         warning_cutoff : float, optional
             Warn if squared-uncertainty is negative and larger in magnitude than this number (default: 1.0e-10)
+        return_dict: bool, default False
+            If true, return is a dictionary, else its a tuple
 
         Returns
         -------
-        result_vals : dictionary
-
-        Possible keys in the result_vals dictionary:
-
         'Delta_f' : np.ndarray, float, shape=(L, L)
             result_vals['Delta_f'] = f_j - f_i, the dimensionless free energy difference between new states i and j
+            If return_dict, ket is 'Delta_f'
         'dDelta_f' : np.ndarray, float, shape=(L, L)
             result_vals['dDelta_f'] is the estimated statistical uncertainty in result_vals['Delta_f']
             or not included if `compute_uncertainty` is False
+            If return_dict, ket is 'dDelta_f'
 
         Examples
         --------
         >>> from pymbar import testsystems
         >>> (x_n, u_kn, N_k, s_n) = testsystems.HarmonicOscillatorsTestCase().sample(mode='u_kn')
         >>> mbar = MBAR(u_kn, N_k)
-        >>> results = mbar.computePerturbedFreeEnergies(u_kn)
+        >>> results = mbar.computePerturbedFreeEnergies(u_kn, return_dict=True)
         """
 
         # Convert to np matrix.
@@ -1188,17 +1223,22 @@ class MBAR:
         f_k = np.matrix(inner_results['f'])
 
         result_vals = dict()
+        results_list = []
         result_vals['Delta_f'] = np.array(f_k - f_k.transpose())
+        results_list.append(result_vals['Delta_f'])
 
         if (compute_uncertainty):
             result_vals['dDelta_f'] = self._ErrorOfDifferences(inner_results['Theta'],warning_cutoff=warning_cutoff)
+            results_list.append(result_vals['dDelta_f'])
 
         # Return matrix of free energy differences and uncertainties.
-        return result_vals
+        if return_dict:
+            return result_vals
+        return tuple(results_list)
 
     #=====================================================================
 
-    def computeEntropyAndEnthalpy(self, u_kn=None, uncertainty_method=None, verbose=False, warning_cutoff=1.0e-10):
+    def computeEntropyAndEnthalpy(self, u_kn=None, uncertainty_method=None, verbose=False, warning_cutoff=1.0e-10, return_dict=False):
         """Decompose free energy differences into enthalpy and entropy differences.
 
         Compute the decomposition of the free energy difference between
@@ -1214,25 +1254,29 @@ class MBAR:
             See help for computeAsymptoticCovarianceMatrix() for more information on various methods. (default: None)
         warning_cutoff : float, optional
             Warn if squared-uncertainty is negative and larger in magnitude than this number (default: 1.0e-10)
+        return_dict: bool, default False
+            If true, return is a dictionary, else its a tuple
 
         Returns
         -------
-        result_vals : dictionary
-
-        Keys in the result_vals dictionary:
-
         'Delta_f' : np.ndarray, float, shape=(K, K)
             results['Delta_f'] is the dimensionless free energy difference f_j - f_i
+            If return_dict, key is 'Delta_f'
         'dDelta_f' : np.ndarray, float, shape=(K, K)
             uncertainty in results['Delta_f']
+            If return_dict, key is 'dDelta_f'
         'Delta_u' : np.ndarray, float, shape=(K, K)
             results['Delta_u'] is the reduced potential energy difference u_j - u_i
+            If return_dict, key is 'Delta_u'
         'dDelta_u' : np.ndarray, float, shape=(K, K)
             uncertainty in results['Delta_u']
+            If return_dict, key is 'dDelta_u'
         'Delta_s' : np.ndarray, float, shape=(K, K)
             results['Delta_s'] is the reduced entropy difference S/k between states i and j (s_j - s_i)
+            If return_dict, key is 'Delta_s'
         'dDelta_s' : np.ndarray, float, shape=(K, K)
             uncertainty in results['Delta_s']
+            If return_dict, key is 'dDelta_s'
 
         Examples
         --------
@@ -1240,7 +1284,7 @@ class MBAR:
         >>> from pymbar import testsystems
         >>> (x_n, u_kn, N_k, s_n) = testsystems.HarmonicOscillatorsTestCase().sample(mode='u_kn')
         >>> mbar = MBAR(u_kn, N_k)
-        >>> results = mbar.computeEntropyAndEnthalpy()
+        >>> results = mbar.computeEntropyAndEnthalpy(return_dict=True)
 
         """
         if verbose:
@@ -1312,18 +1356,27 @@ class MBAR:
         dDelta_s_ij = self._ErrorOfDifferences(covs,warning_cutoff=warning_cutoff)
 
         result_vals = dict()
+        results_list = []
         result_vals['Delta_f'] = Delta_f_ij
         result_vals['dDelta_f'] = dDelta_f_ij
         result_vals['Delta_u'] = Delta_u_ij
         result_vals['dDelta_u'] = dDelta_u_ij
         result_vals['Delta_s'] = Delta_s_ij
         result_vals['dDelta_s'] = dDelta_s_ij
+        results_list.append(Delta_f_ij)
+        results_list.append(dDelta_f_ij)
+        results_list.append(Delta_u_ij)
+        results_list.append(dDelta_u_ij)
+        results_list.append(Delta_s_ij)
+        results_list.append(dDelta_s_ij)
 
-        return result_vals
+        if return_dict:
+            return result_vals
+        return tuple(results_list)
 
     #=====================================================================
 
-    def computePMF(self, u_n, bin_n, nbins, uncertainties='from-lowest', pmf_reference=None):
+    def computePMF(self, u_n, bin_n, nbins, uncertainties='from-lowest', pmf_reference=None, return_dict=False):
         """
         Compute the free energy of occupying a number of bins.
 
@@ -1348,16 +1401,18 @@ class MBAR:
         pmf_reference : int, optional
             the reference state that is zeroed when uncertainty = 'from-specified'
 
+        return_dict : bool, default False
+            Changes the return from a Tuple to a Dict
+
         Returns
         -------
-        result_vals : dictionary
-
-        Possible keys in the result_vals dictionary:
-
         'f_i' : np.ndarray, float, shape=(K)
-            result_vals['f_i'][i] is the dimensionless free energy of state i, relative to the state of lowest free energy
+            f_i[i] is the dimensionless free energy of state i, relative to the state of lowest free energy
+            If `return_dict`: result_vals['f_i']
         'df_i' : np.ndarray, float, shape=(K)
-            result_vals['df_i'][i] is the uncertainty in the difference of f_i with respect to the state of lowest free energy
+            df_i[i] is the uncertainty in the difference of f_i with respect to the state of lowest free energy
+            Note: if `all-differences` is set for uncertainty method, then the return is 'df_ij'
+            If `return_dict`: result_vals['df_i']
 
         Notes
         -----
@@ -1386,7 +1441,7 @@ class MBAR:
         >>> bin_n = np.zeros(x_n.shape, np.int64)
         >>> bin_n = np.digitize(x_n, bins) - 1
         >>> # Compute PMF for these unequally-sized bins.
-        >>> results = mbar.computePMF(u_n, bin_n, nbins)
+        >>> results = mbar.computePMF(u_n, bin_n, nbins, return_dict=True)
         >>> # If we want to correct for unequally-spaced bins to get a PMF on uniform measure
         >>> f_i_corrected = results['f_i'] - np.log(bin_widths)
 
@@ -1464,12 +1519,6 @@ class MBAR:
             # Shift free energies so that state j has zero free energy.
             f_i -= f_i[j]
 
-            # Return dimensionless free energy and uncertainty.
-            result_vals['f_i'] = f_i
-            result_vals['df_i'] = df_i
-
-            return result_vals
-
         elif (uncertainties == 'all-differences'):
             # Report uncertainties in all free energy differences.
 
@@ -1479,12 +1528,6 @@ class MBAR:
 
             # unsquare uncertainties
             df_ij = np.sqrt(d2f_ij)
-
-            # Return dimensionless free energy and uncertainty.
-            result_vals['f_i'] = f_i
-            result_vals['df_ij'] = df_ij
-
-            return result_vals
 
         elif (uncertainties == 'from-normalization'):
             # Determine uncertainties from normalization that \sum_i p_i = 1.
@@ -1507,13 +1550,19 @@ class MBAR:
             d2f_i = d2p_i / p_i ** 2
             df_i = np.sqrt(d2f_i)
 
-            # return free energy and uncertainty
-            # Return dimensionless free energy and uncertainty.
-            result_vals['f_i'] = f_i
-            result_vals['df_i'] = df_i
-
         else:
             raise ParameterError("Uncertainty method '%s' not recognized." % uncertainties)
+
+        # return free energy and uncertainty
+        # Return dimensionless free energy and uncertainty.
+        if return_dict:
+            result_vals['f_i'] = f_i
+            if uncertainties == 'all-differences':
+                result_vals['df_ij'] = df_ij
+            else:
+                result_vals['df_i'] = df_i
+            return result_vals
+        return f_i, df_i
 
 
     #=========================================================================

--- a/pymbar/tests/test_covariance.py
+++ b/pymbar/tests/test_covariance.py
@@ -25,12 +25,17 @@ def _test(data_generator):
     name, U, N_k, s_n = data_generator()
     print(name)
     mbar = pymbar.MBAR(U, N_k)
-    results1 = mbar.getFreeEnergyDifferences(uncertainty_method="svd")
-    results2 = mbar.getFreeEnergyDifferences(uncertainty_method="svd-ew")
+    results1 = mbar.getFreeEnergyDifferences(uncertainty_method="svd", return_dict=True)
+    fij1_t, dfij1_t = mbar.getFreeEnergyDifferences(uncertainty_method="svd", return_dict=False)
+    results2 = mbar.getFreeEnergyDifferences(uncertainty_method="svd-ew", return_dict=True)
     fij1 = results1['Delta_f']
     dfij1 = results1['dDelta_f']
     fij2 = results2['Delta_f']
     dfij2 = results2['dDelta_f']
+
+    # Check to make sure the returns from with and w/o dict are the same
+    eq(fij1, fij1_t)
+    eq(dfij1, dfij1_t)
 
     eq(pymbar.mbar_solvers.mbar_gradient(U, N_k, mbar.f_k), np.zeros(N_k.shape), decimal=8)
     eq(np.exp(mbar.Log_W_nk).sum(0), np.ones(len(N_k)), decimal=10)

--- a/pymbar/tests/test_mbar.py
+++ b/pymbar/tests/test_mbar.py
@@ -71,9 +71,14 @@ def test_mbar_free_energies():
         eq(N_k, N_k_output)
         mbar = MBAR(u_kn, N_k)
 
-        results = mbar.getFreeEnergyDifferences()
+        results = mbar.getFreeEnergyDifferences(return_dict=True)
+        fe_t, dfe_t = mbar.getFreeEnergyDifferences(return_dict=False)
         fe = results['Delta_f']
         fe_sigma = results['dDelta_f']
+
+        eq(fe, fe_t)
+        eq(fe_sigma, dfe_t)
+
         fe, fe_sigma = fe[0,1:], fe_sigma[0,1:]
 
         fe0 = test.analytical_free_energies()
@@ -91,9 +96,13 @@ def test_mbar_computeExpectations_position_averages():
         x_n, u_kn, N_k_output, s_n = test.sample(N_k, mode='u_kn')
         eq(N_k, N_k_output)
         mbar = MBAR(u_kn, N_k)
-        results = mbar.computeExpectations(x_n)
+        results = mbar.computeExpectations(x_n, return_dict=True)
+        mu_t, sigma_t = mbar.computeExpectations(x_n, return_dict=False)
         mu = results['mu']
         sigma = results['sigma' ]
+
+        eq(mu, mu_t)
+        eq(sigma, sigma_t)
 
         mu0 = test.analytical_observable(observable = 'position')
 
@@ -109,7 +118,7 @@ def test_mbar_computeExpectations_position_differences():
         x_n, u_kn, N_k_output, s_n = test.sample(N_k, mode='u_kn')
         eq(N_k, N_k_output)
         mbar = MBAR(u_kn, N_k)
-        results = mbar.computeExpectations(x_n, output = 'differences')
+        results = mbar.computeExpectations(x_n, output = 'differences', return_dict=True)
         mu_ij = results['mu'] 
         sigma_ij = results['sigma'] 
 
@@ -126,7 +135,7 @@ def test_mbar_computeExpectations_position2():
         x_n, u_kn, N_k_output, s_n = test.sample(N_k, mode='u_kn')
         eq(N_k, N_k_output)
         mbar = MBAR(u_kn, N_k)
-        results = mbar.computeExpectations(x_n ** 2)
+        results = mbar.computeExpectations(x_n ** 2, return_dict=True)
         mu = results['mu']
         sigma = results['sigma'] 
         mu0 = test.analytical_observable(observable = 'position^2')
@@ -143,7 +152,7 @@ def test_mbar_computeExpectations_potential():
         x_n, u_kn, N_k_output, s_n = test.sample(N_k, mode='u_kn')
         eq(N_k, N_k_output)
         mbar = MBAR(u_kn, N_k)
-        results = mbar.computeExpectations(u_kn, state_dependent = True)
+        results = mbar.computeExpectations(u_kn, state_dependent = True, return_dict=True)
         mu = results['mu']
         sigma = results['sigma'] 
         mu0 = test.analytical_observable(observable = 'potential energy')
@@ -165,9 +174,12 @@ def test_mbar_computeMultipleExpectations():
         A[0,:] = x_n
         A[1,:] = x_n**2
         state = 1
-        results = mbar.computeMultipleExpectations(A,u_kn[state,:])
+        results = mbar.computeMultipleExpectations(A,u_kn[state,:], return_dict=True)
+        mu_t, sigma_t = mbar.computeMultipleExpectations(A,u_kn[state,:], return_dict=False)
         mu = results['mu']
         sigma = results['sigma']
+        eq(mu, mu_t)
+        eq(sigma, sigma_t)
         mu0 = test.analytical_observable(observable = 'position')[state]
         mu1 = test.analytical_observable(observable = 'position^2')[state]
         z = (mu0 - mu[0]) / sigma[0]
@@ -184,13 +196,21 @@ def test_mbar_computeEntropyAndEnthalpy():
         x_n, u_kn, N_k_output, s_n = test.sample(N_k, mode='u_kn')
         eq(N_k, N_k_output)
         mbar = MBAR(u_kn, N_k)
-        results =  mbar.computeEntropyAndEnthalpy(u_kn)
+        results =  mbar.computeEntropyAndEnthalpy(u_kn, return_dict=True)
+        f_t, df_t, u_t, du_t, s_t, ds_t = mbar.computeEntropyAndEnthalpy(u_kn, return_dict=False)
         f_ij = results['Delta_f'] 
         df_ij = results['dDelta_f'] 
         u_ij = results['Delta_u'] 
         du_ij = results['dDelta_u']  
         s_ij = results['Delta_s'] 
-        ds_ij = results['dDelta_s'] 
+        ds_ij = results['dDelta_s']
+
+        eq(f_ij, f_t)
+        eq(df_ij, df_t)
+        eq(u_ij, u_t)
+        eq(du_ij, du_t)
+        eq(s_ij, s_t)
+        eq(ds_ij, ds_t)
 
         fa = test.analytical_free_energies()
         ua = test.analytical_observable('potential energy')
@@ -234,10 +254,15 @@ def test_mbar_computeOverlap():
     x_n, u_kn, N_k_output, s_n = test.sample(even_N_k, mode='u_kn')
     mbar = MBAR(u_kn, even_N_k)
 
-    results = mbar.computeOverlap()
+    results = mbar.computeOverlap(return_dict=True)
+    os_t, eig_t, O_t = mbar.computeOverlap(return_dict=False)
     overlap_scalar = results['scalar']
     eigenval = results['eigenvalues']
     O = results['matrix']
+
+    eq(overlap_scalar, os_t)
+    eq(eigenval, eig_t)
+    eq(O, O_t)
 
     reference_matrix = np.matrix((1.0/d)*np.ones([d,d]))
     reference_eigenvalues = np.zeros(d)
@@ -285,9 +310,14 @@ def test_mbar_computePerturbedFreeEnergeies():
         x_n, u_kn, N_k_output, s_n = test.sample(N_k, mode='u_kn')
         numN = np.sum(N_k[:2])
         mbar = MBAR(u_kn[:2,:numN], N_k[:2])  # only do MBAR with the first and last set
-        results = mbar.computePerturbedFreeEnergies(u_kn[2:,:numN])
+        results = mbar.computePerturbedFreeEnergies(u_kn[2:,:numN], return_dict=True)
+        f_t, df_t = mbar.computePerturbedFreeEnergies(u_kn[2:, :numN], return_dict=False)
         fe = results['Delta_f']
         fe_sigma = results['dDelta_f']
+
+        eq(fe, f_t)
+        eq(fe_sigma, df_t)
+
         fe, fe_sigma = fe[0,1:], fe_sigma[0,1:]
 
         print(fe, fe_sigma)
@@ -315,9 +345,14 @@ def test_mbar_computePMF():
     bin_n[within_bounds] = 1 + np.floor((x_n[within_bounds]-xmin)/dx)
     # 0 is reserved for samples outside the domain.  We will ignore this state
     range = np.max(bin_n)+1
-    results = mbar.computePMF(u_kn[refstate,:], bin_n, range, uncertainties = 'from-specified', pmf_reference = 1)
+    results = mbar.computePMF(u_kn[refstate,:], bin_n, range, uncertainties = 'from-specified', pmf_reference = 1, return_dict=True)
+    f_t, df_t = mbar.computePMF(u_kn[refstate,:], bin_n, range, uncertainties = 'from-specified', pmf_reference = 1, return_dict=False)
     f_i = results['f_i']
     df_i = results['df_i']
+
+    eq(f_i, f_t)
+    eq(df_i, df_t)
+
     f0_i = 0.5*test.K_k[refstate]*(bin_centers-test.O_k[refstate])**2
     f_i, df_i = f_i[2:], df_i[2:] # first state is ignored, second is zero, with zero uncertainty
     normf0_i = f0_i[1:] - f0_i[0] # normalize to first state
@@ -336,4 +371,4 @@ def test_mbar_computeExpectationsInner():
         A_in = np.array([x_n, x_n ** 2, x_n ** 3])
         u_n = u_kn[:2,:]
         state_map = np.array([[0,0],[1,0],[2,0],[2,1]],int)
-        results = mbar.computeExpectationsInner(A_in, u_n, state_map)
+        _ = mbar.computeExpectationsInner(A_in, u_n, state_map)

--- a/pymbar/tests/test_mbar_solvers.py
+++ b/pymbar/tests/test_mbar_solvers.py
@@ -83,7 +83,7 @@ def test_protocols():
             mbar = pymbar.MBAR(u_kn, N_k, solver_protocol=({'method': solver_protocol},))
             # Solve MBAR with the correct f_k used for the inital weights
             mbar = pymbar.MBAR(u_kn, N_k, initial_f_k=mbar.f_k, solver_protocol=({'method': solver_protocol},))
-            results = mbar.getFreeEnergyDifferences()
+            results = mbar.getFreeEnergyDifferences(return_dict=True)
             fe = results['Delta_f'][0,1:]
             fe_sigma = results['dDelta_f'][0,1:]
             z = (fe - fa) / fe_sigma

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ import subprocess
 import six
 
 ##########################
-VERSION = "3.0.4"
+VERSION = "3.0.5"
 ISRELEASED = False
 __version__ = VERSION
 ##########################


### PR DESCRIPTION
Still allows dictionary output via kwarg and tests have been added to
ensure the two outputs are the same. This should be considered a
candidate for 3.0.5 release.

Fixes #318
Fixes #316

cc: https://github.com/choderalab/openmmtools/issues/452#issuecomment-560135185
cc: @jaimergp @Lnaden @mrshirts @andrrizzi