### PR TITLE
Fixes sanity check for empty bins in computePMF

### DIFF
--- a/pymbar/mbar.py
+++ b/pymbar/mbar.py
@@ -1473,7 +1473,7 @@ class MBAR:
             indices = np.where(bin_n == i)
 
             # Sanity check.
-            if (len(indices) == 0):
+            if (len(indices[0]) == 0):
                 raise DataError("WARNING: bin %d has no samples -- all bins must have at least one sample." % i)
 
             # Compute dimensionless free energy of occupying state i.


### PR DESCRIPTION
Previous commit uses "if (len(indices) == 0)" to check that the bin is not empty; however, "indices" is a one-length tuple of which the first (and only) element is the list of indices in that bin, causing this check to always pass even for empty bins (the length of indices can only ever be one). Adding "[0]" causes the test to behave as intended.