### PR TITLE
Fixed return type of multiple values to dict-like object

### DIFF
--- a/examples/constant-force-optical-trap/force-bias-optical-trap.py
+++ b/examples/constant-force-optical-trap/force-bias-optical-trap.py
@@ -234,7 +234,7 @@ print("analysis took %f seconds" % elapsed_time)
 # compute observed and expected histograms at each state
 for l in range(0,K):
     # compute PMF at state l
-    results = mbar.computePMF(u_kln[:,l,:], bin_kn, nbins, return_dict=True)
+    results = mbar.computePMF(u_kln[:,l,:], bin_kn, nbins)
     f_i = results['f_i']
     df_i = results['df_i']
     # compute estimate of PMF including Jacobian term

--- a/examples/harmonic-oscillators/harmonic-oscillators-distributions.py
+++ b/examples/harmonic-oscillators/harmonic-oscillators-distributions.py
@@ -135,7 +135,7 @@ for replicate_index in range(0,nreplicates):
 
   # Initialize the MBAR class, determining the free energies.
   mbar = MBAR(u_kln, N_k, relative_tolerance=1.0e-10,verbose=False) # use fast Newton-Raphson solver
-  results = mbar.getFreeEnergyDifferences(return_dict=True)
+  results = mbar.getFreeEnergyDifferences()
   Deltaf_ij_estimated = results['Delta_f']
   dDeltaf_ij_estimated = results['dDelta_f']
 

--- a/examples/harmonic-oscillators/harmonic-oscillators.py
+++ b/examples/harmonic-oscillators/harmonic-oscillators.py
@@ -143,7 +143,7 @@ print("=============================================")
 print("      Testing getFreeEnergyDifferences       ")
 print("=============================================")
 
-results = mbar.getFreeEnergyDifferences(return_dict=True)
+results = mbar.getFreeEnergyDifferences()
 Delta_f_ij_estimated = results['Delta_f']
 dDelta_f_ij_estimated = results['dDelta_f']
 
@@ -175,7 +175,7 @@ for i in range(Knon-1):
   k1 = nonzero_indices[i+1]
   w_F = u_kln[k, k1, 0:N_k[k]]   - u_kln[k, k, 0:N_k[k]]       # forward work                                  
   w_R = u_kln[k1, k, 0:N_k[k1]] - u_kln[k1, k1, 0:N_k[k1]]    # reverse work                                  
-  results = BAR(w_F, w_R, return_dict=True)
+  results = BAR(w_F, w_R)
   df_bar = results['Delta_f']
   ddf_bar = results['dDelta_f']
   bar_analytical = (f_k_analytical[k1]-f_k_analytical[k]) 
@@ -191,7 +191,7 @@ print("EXP forward free energy")
 for k in range(K-1):
   if N_k[k] != 0:
     w_F = u_kln[k, k+1, 0:N_k[k]]   - u_kln[k, k, 0:N_k[k]]       # forward work
-    results = EXP(w_F, return_dict=True)
+    results = EXP(w_F)
     df_exp = results['Delta_f']
     ddf_exp = results['dDelta_f']
     exp_analytical = (f_k_analytical[k+1]-f_k_analytical[k]) 
@@ -203,7 +203,7 @@ print("EXP reverse free energy")
 for k in range(1,K):
   if N_k[k] != 0:
     w_R = u_kln[k, k-1, 0:N_k[k]] - u_kln[k, k, 0:N_k[k]]         # reverse work                                  
-    (df_exp,ddf_exp) = EXP(w_R, return_dict=True)
+    (df_exp,ddf_exp) = EXP(w_R)
     df_exp = -results['Delta_f']
     ddf_exp = results['dDelta_f']
     exp_analytical = (f_k_analytical[k]-f_k_analytical[k-1]) 
@@ -219,7 +219,7 @@ print("Gaussian forward estimate")
 for k in range(K-1):
   if N_k[k] != 0:
     w_F = u_kln[k, k+1, 0:N_k[k]]   - u_kln[k, k, 0:N_k[k]]       # forward work                                  
-    results = EXPGauss(w_F, return_dict=True)
+    results = EXPGauss(w_F)
     df_gauss = results['Delta_f']
     ddf_gauss = results['dDelta_f']
     gauss_analytical = (f_k_analytical[k+1]-f_k_analytical[k]) 
@@ -231,7 +231,7 @@ print("Gaussian reverse estimate")
 for k in range(1,K):
   if N_k[k] != 0:
     w_R = u_kln[k, k-1, 0:N_k[k]] - u_kln[k, k, 0:N_k[k]]         # reverse work                                  
-    results = EXPGauss(w_R, return_dict=True)
+    results = EXPGauss(w_R)
     df_gauss = results['Delta_f']
     ddf_gauss = results['dDelta_f']
     gauss_analytical = (f_k_analytical[k]-f_k_analytical[k-1]) 
@@ -287,7 +287,7 @@ for observe in observables:
     for k in range(0,K):
       A_kn[k,0:N_k[k]] = x_kn[k,0:N_k[k]]**2
 
-  results = mbar.computeExpectations(A_kn, state_dependent = state_dependent, return_dict=True)
+  results = mbar.computeExpectations(A_kn, state_dependent = state_dependent)
   A_k_estimated = results['mu']
   dA_k_estimated = results['sigma']
 
@@ -341,7 +341,7 @@ for observe in observables:
   stdevs = numpy.abs(As_k_error[Nk_ne_zero]/dAs_k_estimated[Nk_ne_zero])
   print(stdevs)
 
-  results = mbar.computeExpectations(A_kn, state_dependent = state_dependent, output = 'differences', return_dict=True)
+  results = mbar.computeExpectations(A_kn, state_dependent = state_dependent, output = 'differences')
   A_kl_estimated = results['mu']  
   dA_kl_estimated = results['sigma']
 
@@ -384,7 +384,7 @@ A_ikn = numpy.zeros([len(observables_single), K, N_k.max()], numpy.float64)
 for i,observe in enumerate(observables_single):
   A_ikn[i,:,:] = A_kn_all[observe]
 for i in range(K):
-  results = mbar.computeMultipleExpectations(A_ikn, u_kln[:,i,:], compute_covariance=True, return_dict=True)
+  results = mbar.computeMultipleExpectations(A_ikn, u_kln[:,i,:], compute_covariance=True)
   A_i = results['mu']
   dA_ij = results['sigma']
   Ca_ij = results['covariances']
@@ -399,7 +399,7 @@ print("============================================")
 print("      Testing computeEntropyAndEnthalpy")
 print("============================================")
 
-results = mbar.computeEntropyAndEnthalpy(u_kn = u_kln, verbose = True, return_dict=True)
+results = mbar.computeEntropyAndEnthalpy(u_kn = u_kln, verbose = True)
 Delta_f_ij = results['Delta_f']
 dDelta_f_ij = results['dDelta_f']
 Delta_u_ij = results['Delta_u']
@@ -468,7 +468,7 @@ for k in range(K):
     for l in range(L):
       unew_kln[k,l,0:N_k[k]] = (K_extra[l]/2.0) * (x_kn[k,0:N_k[k]]-O_extra[l])**2
 
-results = mbar.computePerturbedFreeEnergies(unew_kln, return_dict=True)
+results = mbar.computePerturbedFreeEnergies(unew_kln)
 Delta_f_ij_estimated = results['Delta_f']
 dDelta_f_ij_estimated = results['dDelta_f']
 
@@ -520,7 +520,7 @@ for observe in observables:
     A_kn = A_kn_all['position^2']
 
   A_k_estimated, dA_k_estimated 
-  results = mbar.computeExpectations(A_kn,unew_kln[:,[nth],:],state_dependent=state_dependent, return_dict=True)
+  results = mbar.computeExpectations(A_kn,unew_kln[:,[nth],:],state_dependent=state_dependent)
   A_k_estimated = results['mu'] 
   dA_k_estimated = results['sigma']
   # need to additionally transform to get the square root
@@ -544,7 +544,7 @@ print("============================================")
 print("      Testing computeOverlap   ")
 print("============================================")
 
-results = mbar.computeOverlap(return_dict=True)
+results = mbar.computeOverlap()
 O = results['scalar']
 O_i = results['eigenvalues']
 O_ij = results['matrix']
@@ -578,7 +578,7 @@ print("We should have that with MBAR, err_MBAR = sqrt(N_k/N_eff)*err_standard,")
 print("so standard (scaled) results should be very close to MBAR results.")
 print("No standard estimate exists for states that are not sampled.")
 A_kn = x_kn
-results = mbar.computeExpectations(A_kn, return_dict=True)
+results = mbar.computeExpectations(A_kn)
 val_mbar = results['mu']
 err_mbar = results['sigma']
 err_standard = numpy.zeros([K],dtype = numpy.float64)
@@ -745,7 +745,7 @@ for i in range(nbins):
 
 # Compute PMF.
 print("Computing PMF ...")
-results = mbar.computePMF(u_n, bin_n, nbins, uncertainties = 'from-specified', pmf_reference = zeroindex, return_dict=True)
+results = mbar.computePMF(u_n, bin_n, nbins, uncertainties = 'from-specified', pmf_reference = zeroindex)
 f_i = results['f_i']
 df_i = results['df_i']
 
@@ -834,7 +834,7 @@ for i in range(nbins):
 # Compute PMF.          
 print("Computing PMF ...")
 [f_i, df_i] 
-results = mbar.computePMF(u_n, bin_n, nbins, uncertainties = 'from-specified', pmf_reference = zeroindex, return_dict=True)
+results = mbar.computePMF(u_n, bin_n, nbins, uncertainties = 'from-specified', pmf_reference = zeroindex)
 f_i = results['f_i']
 df_i = results['df_i']
 

--- a/examples/heat-capacity/heat-capacity.py
+++ b/examples/heat-capacity/heat-capacity.py
@@ -281,23 +281,23 @@ for n in range(nBoots_work):
     E_kln = u_kln  # not a copy, we are going to write over it, but we don't need it any more.
     for k in range(K):
         E_kln[:,k,:]*=beta_k[k]**(-1)  # get the 'unreduced' potential -- we can't take differences of reduced potentials because the beta is different; math is much more confusing with derivatives of the reduced potentials.
-    results = mbar.computeExpectations(E_kln, state_dependent = True, return_dict=True)
+    results = mbar.computeExpectations(E_kln, state_dependent = True)
     E_expect = results['mu']
     dE_expect = results['sigma']
     allE_expect[:,n] = E_expect[:]
 
     # expectations for the differences, which we need for numerical derivatives
-    results = mbar.computeExpectations(E_kln,output='differences', state_dependent = True, return_dict=True)
+    results = mbar.computeExpectations(E_kln,output='differences', state_dependent = True)
     DeltaE_expect = results['mu']
     dDeltaE_expect = results['sigma']
     print("Computing Expectations for E^2...")
 
-    results = mbar.computeExpectations(E_kln**2, state_dependent = True, return_dict=True)
+    results = mbar.computeExpectations(E_kln**2, state_dependent = True)
     E2_expect = results['mu']
     dE2_expect = results['sigma']
     allE2_expect[:,n] = E2_expect[:]
 
-    results = mbar.getFreeEnergyDifferences(return_dict=True)
+    results = mbar.getFreeEnergyDifferences()
     df_ij = results['Delta_f']
     ddf_ij = results['dDelta_f']
 

--- a/examples/parallel-tempering-2dpmf/parallel-tempering-2dpmf.py
+++ b/examples/parallel-tempering-2dpmf/parallel-tempering-2dpmf.py
@@ -293,7 +293,7 @@ u_kn = target_beta * U_kn
 # f_i[i] is the dimensionless free energy of bin i (in kT) at the temperature of interest
 # df_i[i,j] is an estimate of the covariance in the estimate of (f_i[i] - f_j[j], with reference
 # the lowest free energy state.
-results = mbar.computePMF(u_kn, bin_kn, nbins, uncertainties='from-lowest', return_dict=True)
+results = mbar.computePMF(u_kn, bin_kn, nbins, uncertainties='from-lowest')
 f_i = results['f_i']
 df_i = results['df_i']
 

--- a/examples/umbrella-sampling-pmf/umbrella-sampling.py
+++ b/examples/umbrella-sampling-pmf/umbrella-sampling.py
@@ -147,7 +147,7 @@ print("Running MBAR...")
 mbar = pymbar.MBAR(u_kln, N_k, verbose = True)
 
 # Compute PMF in unbiased potential (in units of kT).
-results = mbar.computePMF(u_kn, bin_kn, nbins, return_dict=True)
+results = mbar.computePMF(u_kn, bin_kn, nbins)
 f_i = results['f_i']
 df_i = results['df_i']
 

--- a/pymbar/bar.py
+++ b/pymbar/bar.py
@@ -147,7 +147,7 @@ def BARzero(w_F, w_R, DeltaF):
     return fzero
 
 
-def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR',maximum_iterations=500, relative_tolerance=1.0e-12, verbose=False, method='false-position', iterated_solution=True, return_dict=True):
+def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR',maximum_iterations=500, relative_tolerance=1.0e-12, verbose=False, method='false-position', iterated_solution=True):
     """Compute free energy difference using the Bennett acceptance ratio (BAR) method.
 
     Parameters
@@ -176,17 +176,15 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
     iterated_solution : bool, optional, default=True
         whether to fully solve the optimized BAR equation to consistency, or to stop after one step, to be 
         equivalent to transition matrix sampling.
-    return_dict : bool, default True
-        If true, returns are a dict, else they are a tuple
 
     Returns
     -------
+    Results dictionary with the following keys:
+
     'Delta_f' : float
         Free energy difference
-        If return_dict, key is 'Delta_f'
     'dDelta_f': float
         Estimated standard deviation of free energy difference
-        If return_dict, key is 'dDelta_f'
 
 
     References
@@ -244,21 +242,11 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
             if compute_uncertainty:
                 result_vals['Delta_f'] = 0.0 
                 result_vals['dDelta_f'] = 0.0
-                if return_dict:
-                    return result_vals
-                else:
-                    warnings.warn("Returning values as a tuple is deprecated, and will be removed in a future version.",
-                                  UserWarning)
-                    return 0.0, 0.0
+                return result_vals
 
             else:
                 result_vals['Delta_f'] = 0.0
-                if return_dict:
-                    return result_vals
-                else:
-                    warnings.warn("Returning values as a tuple is deprecated, and will be removed in a future version.",
-                                  UserWarning)
-                    return 0.0
+                return result_vals
             
         while FUpperB * FLowerB > 0:
             # if they have the same sign, they do not bracket.  Widen the bracket until they have opposite signs.
@@ -502,22 +490,13 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
             print("DeltaF = {:8.3f} +- {:8.3f}".format(DeltaF, dDeltaF))
         result_vals['Delta_f'] = DeltaF
         result_vals['dDelta_f'] = dDeltaF
-        if return_dict:
-            return result_vals
-        else:
-            warnings.warn("Returning values as a tuple is deprecated, and will be removed in a future version.",
-                          UserWarning)
-            return DeltaF, dDeltaF
+        return result_vals
+
     else:
         if verbose:
             print("DeltaF = {:8.3f}".format(DeltaF))
         result_vals['Delta_f'] = DeltaF
-        if return_dict:
-            return result_vals
-        else:
-            warnings.warn("Returning values as a tuple is deprecated, and will be removed in a future version.",
-                          UserWarning)
-            return DeltaF
+        return result_vals
 
 #=============================================================================================
 # For compatibility with 2.0.1-beta

--- a/pymbar/bar.py
+++ b/pymbar/bar.py
@@ -147,7 +147,7 @@ def BARzero(w_F, w_R, DeltaF):
     return fzero
 
 
-def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR',maximum_iterations=500, relative_tolerance=1.0e-12, verbose=False, method='false-position', iterated_solution=True, return_dict=False):
+def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR',maximum_iterations=500, relative_tolerance=1.0e-12, verbose=False, method='false-position', iterated_solution=True, return_dict=True):
     """Compute free energy difference using the Bennett acceptance ratio (BAR) method.
 
     Parameters
@@ -176,7 +176,7 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
     iterated_solution : bool, optional, default=True
         whether to fully solve the optimized BAR equation to consistency, or to stop after one step, to be 
         equivalent to transition matrix sampling.
-    return_dict : bool, default False
+    return_dict : bool, default True
         If true, returns are a dict, else they are a tuple
 
     Returns
@@ -205,15 +205,15 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
 
     >>> from pymbar import testsystems
     >>> [w_F, w_R] = testsystems.gaussian_work_example(mu_F=None, DeltaF=1.0, seed=0)
-    >>> results = BAR(w_F, w_R, return_dict=True)
+    >>> results = BAR(w_F, w_R)
     >>> print('Free energy difference is {:.3f} +- {:.3f} kT'.format(results['Delta_f'], results['dDelta_f']))
     Free energy difference is 1.088 +- 0.050 kT
 
     Test completion of various other schemes.
 
-    >>> results = BAR(w_F, w_R, method='self-consistent-iteration', return_dict=True)
-    >>> results = BAR(w_F, w_R, method='false-position', return_dict=True)
-    >>> results = BAR(w_F, w_R, method='bisection', return_dict=True)
+    >>> results = BAR(w_F, w_R, method='self-consistent-iteration')
+    >>> results = BAR(w_F, w_R, method='false-position')
+    >>> results = BAR(w_F, w_R, method='bisection')
 
     """
 
@@ -230,8 +230,8 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
         nfunc = 0
 
     if method == 'bisection' or method == 'false-position':
-        UpperB = EXP(w_F, return_dict=True)['Delta_f']
-        LowerB = -EXP(w_R, return_dict=True)['Delta_f']
+        UpperB = EXP(w_F)['Delta_f']
+        LowerB = -EXP(w_R)['Delta_f']
 
         FUpperB = BARzero(w_F, w_R, UpperB)
         FLowerB = BARzero(w_F, w_R, LowerB)
@@ -246,13 +246,20 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
                 result_vals['dDelta_f'] = 0.0
                 if return_dict:
                     return result_vals
-                return 0.0, 0.0
+                else:
+                    warnings.warn("Returning values as a tuple is deprecated, and will be removed in a future version.",
+                                  UserWarning)
+                    return 0.0, 0.0
+
             else:
                 result_vals['Delta_f'] = 0.0
                 if return_dict:
                     return result_vals
-                return 0.0
-
+                else:
+                    warnings.warn("Returning values as a tuple is deprecated, and will be removed in a future version.",
+                                  UserWarning)
+                    return 0.0
+            
         while FUpperB * FLowerB > 0:
             # if they have the same sign, they do not bracket.  Widen the bracket until they have opposite signs.
             # There may be a better way to do this, and the above bracket should rarely fail.
@@ -347,7 +354,9 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
 
         Compute asymptotic variance estimate using Eq. 10a of Bennett,
         1976 (except with n_1<f>_1^2 in the second denominator, it is
-        an error in the original NOTE: The 'BAR' and 'MBAR' estimators
+        an error in the original.
+
+        NOTE: The 'BAR' and 'MBAR' estimators
         do not agree for poor overlap. This is not because of
         numerical precision, but because they are fundamentally
         different estimators. For poor overlap, 'MBAR' diverges high,
@@ -495,14 +504,20 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
         result_vals['dDelta_f'] = dDeltaF
         if return_dict:
             return result_vals
-        return DeltaF, dDeltaF
+        else:
+            warnings.warn("Returning values as a tuple is deprecated, and will be removed in a future version.",
+                          UserWarning)
+            return DeltaF, dDeltaF
     else:
         if verbose:
             print("DeltaF = {:8.3f}".format(DeltaF))
         result_vals['Delta_f'] = DeltaF
         if return_dict:
             return result_vals
-        return DeltaF
+        else:
+            warnings.warn("Returning values as a tuple is deprecated, and will be removed in a future version.",
+                          UserWarning)
+            return DeltaF
 
 #=============================================================================================
 # For compatibility with 2.0.1-beta

--- a/pymbar/exp.py
+++ b/pymbar/exp.py
@@ -51,8 +51,8 @@ from pymbar.utils import logsumexp
 # One-sided exponential averaging (EXP).
 #=============================================================================================
 
-def EXP(w_F, compute_uncertainty=True, is_timeseries=False, return_dict=True):
-    """Estimate free energy difference using one-sided (unidirectional) exponential averaging (EXP).
+def EXP(w_F, compute_uncertainty=True, is_timeseries=False):
+    """Estimate free energy difference using one-sided (unsidirectional) exponential averaging (EXP).
 
     Parameters
     ----------
@@ -63,17 +63,13 @@ def EXP(w_F, compute_uncertainty=True, is_timeseries=False, return_dict=True):
     is_timeseries : bool, default=False
         if True, correlation in data is corrected for by estimation of statisitcal inefficiency (default: False)
         Use this option if you are providing correlated timeseries data and have not subsampled the data to produce uncorrelated samples.
-    return_dict : bool, default True
-        If true, returns are a dictionary, else they are a tuple
 
     Returns
     -------
     'Delta_f' : float
         Free energy difference
-        If return_dict, key is 'Delta_f'
     'dDelta_f': float
         Estimated standard deviation of free energy difference
-        If return_dict, key is 'dDelta_f'
 
     Notes
     -----
@@ -96,7 +92,6 @@ def EXP(w_F, compute_uncertainty=True, is_timeseries=False, return_dict=True):
     """
 
     result_vals = dict()
-    result_list = []
 
     # Get number of work measurements.
     T = float(np.size(w_F))  # number of work measurements
@@ -128,17 +123,10 @@ def EXP(w_F, compute_uncertainty=True, is_timeseries=False, return_dict=True):
         # Return estimate of free energy difference and uncertainty.
         result_vals['Delta_f'] = DeltaF
         result_vals['dDelta_f'] = dDeltaF
-        result_list.append(DeltaF)
-        result_list.append(dDeltaF)
     else:
         result_vals['Delta_f'] = DeltaF
-        result_list.append(DeltaF)
-    if return_dict:
-        return result_vals
-    else:
-        warnings.warn("Returning values as a tuple is deprecated, and will be removed in a future version.",
-                      UserWarning)
-        return tuple(result_list)
+
+    return result_vals
 
 #=============================================================================================
 # Gaussian approximation to exponential averaging (Gauss).
@@ -156,17 +144,15 @@ def EXPGauss(w_F, compute_uncertainty=True, is_timeseries=False):
     is_timeseries : bool, default=False
         if True, correlation in data is corrected for by estimation of statisitcal inefficiency (default: False)
         Use this option if you are providing correlated timeseries data and have not subsampled the data to produce uncorrelated samples.
-    return_dict : bool, default True
-        If true, returns are a dictionary, else they are a tuple
 
     Returns
     -------
+    Results dictionary with keys:
     'Delta_f' : float
         Free energy difference between the two states
-        If return_dict, key is 'Delta_f'
     'dDelta_f': float
         Estimated standard deviation of free energy difference between the two states.
-        If return_dict, key is 'dDelta_f'
+
 
     Notes
     -----
@@ -195,7 +181,6 @@ def EXPGauss(w_F, compute_uncertainty=True, is_timeseries=False):
     DeltaF = np.average(w_F) - 0.5 * var
 
     result_vals = dict()
-    result_list = []
     if compute_uncertainty:
         # Compute effective number of uncorrelated samples.
         g = 1.0  # statistical inefficiency
@@ -213,17 +198,9 @@ def EXPGauss(w_F, compute_uncertainty=True, is_timeseries=False):
         # Return estimate of free energy difference and uncertainty.
         result_vals['Delta_f'] = DeltaF
         result_vals['dDelta_f'] = dDeltaF
-        result_list.append(DeltaF)
-        result_list.append(dDeltaF)
     else:
         result_vals['Delta_f'] = DeltaF
-        result_list.append(DeltaF)
-    if return_dict:
-        return result_vals
-    else:
-        warnings.warn("Returning values as a tuple is deprecated, and will be removed in a future version.",
-                      UserWarning)
-        return tuple(result_list)
+    return result_vals
 
 #=============================================================================================
 # For compatibility with 2.0.1-beta

--- a/pymbar/exp.py
+++ b/pymbar/exp.py
@@ -52,7 +52,7 @@ from pymbar.utils import logsumexp
 #=============================================================================================
 
 def EXP(w_F, compute_uncertainty=True, is_timeseries=False):
-    """Estimate free energy difference using one-sided (unsidirectional) exponential averaging (EXP).
+    """Estimate free energy difference using one-sided (unidirectional) exponential averaging (EXP).
 
     Parameters
     ----------

--- a/pymbar/exp.py
+++ b/pymbar/exp.py
@@ -51,7 +51,7 @@ from pymbar.utils import logsumexp
 # One-sided exponential averaging (EXP).
 #=============================================================================================
 
-def EXP(w_F, compute_uncertainty=True, is_timeseries=False, return_dict=False):
+def EXP(w_F, compute_uncertainty=True, is_timeseries=False, return_dict=True):
     """Estimate free energy difference using one-sided (unidirectional) exponential averaging (EXP).
 
     Parameters
@@ -63,7 +63,7 @@ def EXP(w_F, compute_uncertainty=True, is_timeseries=False, return_dict=False):
     is_timeseries : bool, default=False
         if True, correlation in data is corrected for by estimation of statisitcal inefficiency (default: False)
         Use this option if you are providing correlated timeseries data and have not subsampled the data to produce uncorrelated samples.
-    return_dict : bool, default False
+    return_dict : bool, default True
         If true, returns are a dictionary, else they are a tuple
 
     Returns
@@ -86,10 +86,10 @@ def EXP(w_F, compute_uncertainty=True, is_timeseries=False, return_dict=False):
 
     >>> from pymbar import testsystems
     >>> [w_F, w_R] = testsystems.gaussian_work_example(mu_F=None, DeltaF=1.0, seed=0)
-    >>> results = EXP(w_F, return_dict=True)
+    >>> results = EXP(w_F)
     >>> print('Forward free energy difference is %.3f +- %.3f kT' % (results['Delta_f'], results['dDelta_f']))
     Forward free energy difference is 1.088 +- 0.076 kT
-    >>> results = EXP(w_R, return_dict=True)
+    >>> results = EXP(w_R)
     >>> print('Reverse free energy difference is %.3f +- %.3f kT' % (results['Delta_f'], results['dDelta_f']))
     Reverse free energy difference is -1.073 +- 0.082 kT
 
@@ -135,13 +135,16 @@ def EXP(w_F, compute_uncertainty=True, is_timeseries=False, return_dict=False):
         result_list.append(DeltaF)
     if return_dict:
         return result_vals
-    return tuple(result_list)
+    else:
+        warnings.warn("Returning values as a tuple is deprecated, and will be removed in a future version.",
+                      UserWarning)
+        return tuple(result_list)
 
 #=============================================================================================
 # Gaussian approximation to exponential averaging (Gauss).
 #=============================================================================================
 
-def EXPGauss(w_F, compute_uncertainty=True, is_timeseries=False, return_dict=False):
+def EXPGauss(w_F, compute_uncertainty=True, is_timeseries=False):
     """Estimate free energy difference using gaussian approximation to one-sided (unidirectional) exponential averaging.
 
     Parameters
@@ -153,7 +156,7 @@ def EXPGauss(w_F, compute_uncertainty=True, is_timeseries=False, return_dict=Fal
     is_timeseries : bool, default=False
         if True, correlation in data is corrected for by estimation of statisitcal inefficiency (default: False)
         Use this option if you are providing correlated timeseries data and have not subsampled the data to produce uncorrelated samples.
-    return_dict : bool, default False
+    return_dict : bool, default True
         If true, returns are a dictionary, else they are a tuple
 
     Returns
@@ -175,10 +178,10 @@ def EXPGauss(w_F, compute_uncertainty=True, is_timeseries=False, return_dict=Fal
 
     >>> from pymbar import testsystems
     >>> [w_F, w_R] = testsystems.gaussian_work_example(mu_F=None, DeltaF=1.0, seed=0)
-    >>> results = EXPGauss(w_F, return_dict=True)
+    >>> results = EXPGauss(w_F)
     >>> print('Forward Gaussian approximated free energy difference is %.3f +- %.3f kT' % (results['Delta_f'], results['dDelta_f']))
     Forward Gaussian approximated free energy difference is 1.049 +- 0.089 kT
-    >>> results = EXPGauss(w_R, return_dict=True)
+    >>> results = EXPGauss(w_R)
     >>> print('Reverse Gaussian approximated free energy difference is %.3f +- %.3f kT' % (results['Delta_f'], results['dDelta_f']))
     Reverse Gaussian approximated free energy difference is -1.073 +- 0.080 kT
 
@@ -217,7 +220,10 @@ def EXPGauss(w_F, compute_uncertainty=True, is_timeseries=False, return_dict=Fal
         result_list.append(DeltaF)
     if return_dict:
         return result_vals
-    return tuple(result_list)
+    else:
+        warnings.warn("Returning values as a tuple is deprecated, and will be removed in a future version.",
+                      UserWarning)
+        return tuple(result_list)
 
 #=============================================================================================
 # For compatibility with 2.0.1-beta

--- a/pymbar/mbar.py
+++ b/pymbar/mbar.py
@@ -184,9 +184,6 @@ class MBAR:
         for key, val in kwargs.items():
             print("Warning: parameter {}={} is unrecognized and unused.".format(key, val))
 
-        # string for warning about deprecated return values
-        self.return_value_warn = "Returning values as a tuple is deprecated, and will be removed in a future version."
-
         # Store local copies of necessary data.
         # N_k[k] is the number of samples from state k, some of which might be zero.
         self.N_k = np.array(N_k, dtype=np.int64)
@@ -408,27 +405,25 @@ class MBAR:
         return N_eff
 
     # =========================================================================
-    def computeOverlap(self, return_dict=True):
+    def computeOverlap(self):
         """
         Compute estimate of overlap matrix between the states.
 
         Parameters
         ----------
-        return_dict : bool, Default True
-            If true, results are a dict, else a tuple
+        None
 
         Returns
         -------
+        Results dictionary with the following keys:
+
         'scalar' : np.ndarray, float, shape=(K, K)
             One minus the largest nontrival eigenvalue (largest is 1 or -1)
-            If return_dict, key is 'scalar'
         'eigenvalues' : np.ndarray, float, shape=(K)
             The sorted (descending) eigenvalues of the overlap matrix.
-            If return_dict, key is 'eigenvalues'
         'matrix' : np.ndarray, float, shape=(K, K)
             Estimated state overlap matrix: O[i,j] is an estimate
             of the probability of observing a sample from state i in state j
-            If return_dict, key is 'matrix'
 
         Notes
         -----
@@ -448,7 +443,7 @@ class MBAR:
         >>> from pymbar import testsystems
         >>> (x_kn, u_kn, N_k, s_n) = testsystems.HarmonicOscillatorsTestCase().sample(mode='u_kn')
         >>> mbar = MBAR(u_kn, N_k)
-        >>> results = mbar.computeOverlap(return_dict=True)
+        >>> results = mbar.computeOverlap()
 
         """
 
@@ -464,14 +459,10 @@ class MBAR:
         results_vals['eigenvalues'] = eigenvals
         results_vals['matrix'] = O
 
-        if return_dict:
-            return results_vals
-        else:
-            warnings.warn(self.return_value_warn,UserWarning)
-            return overlap_scalar, eigenvals, O
+        return results_vals
 
     #=========================================================================
-    def getFreeEnergyDifferences(self, compute_uncertainty=True, uncertainty_method=None, warning_cutoff=1.0e-10, return_theta=False, return_dict=True):
+    def getFreeEnergyDifferences(self, compute_uncertainty=True, uncertainty_method=None, warning_cutoff=1.0e-10, return_theta=False):
         """Get the dimensionless free energy differences and uncertainties among all thermodynamic states.
 
 
@@ -488,22 +479,19 @@ class MBAR:
             than this number (default: 1.0e-10)
         return_theta : bool, optional
             Whether or not to return the theta matrix.  Can be useful for complicated differences.
-        return_dict: bool, default True
-            If true, returns are in a dictionary, otherwise a tuple is returned
 
         Returns
         -------
+        Results dictionary with the folowing keys:
+
         'Delta_f' : np.ndarray, float, shape=(K, K)
             Deltaf_ij[i,j] is the estimated free energy difference
-            If return_dict, key is 'Delta_f'
         'dDelta_f' : np.ndarray, float, shape=(K, K)
             If compute_uncertainty==True,
             dDeltaf_ij[i,j] is the estimated statistical uncertainty
             (one standard deviation) in Deltaf_ij[i,j].  Otherwise not included.
-            If return_dict, key is 'dDelta_f'
         'Theta' : np.ndarray, float, shape=(K, K)
             The theta_matrix if return_theta==True, otherwise not included.
-            If return_dict, key is 'Theta'
 
         Notes
         -----
@@ -537,10 +525,8 @@ class MBAR:
         Deltaf_ij = np.array(Deltaf_ij)  # Convert from np.matrix to np.array
 
         result_vals = dict()
-        return_list = []
 
         result_vals['Delta_f'] = Deltaf_ij
-        return_list.append(Deltaf_ij)
 
         if compute_uncertainty or return_theta:
             # Compute asymptotic covariance matrix.
@@ -554,17 +540,11 @@ class MBAR:
             # Return matrix of free energy differences and uncertainties.
             dDeltaf_ij = np.array(dDeltaf_ij)
             result_vals['dDelta_f'] = dDeltaf_ij
-            return_list.append(dDeltaf_ij)
 
         if return_theta:
             result_vals['Theta'] = Theta_ij
-            return_list.append(Theta_ij)
 
-        if return_dict:
-            return result_vals
-        else:
-            warnings.warn(self.return_value_warn,UserWarning)
-            return tuple(return_list)
+        return result_vals
 
     # =========================================================================
     def computeExpectationsInner(self, A_n, u_ln, state_map,
@@ -610,7 +590,7 @@ class MBAR:
         -------
         result_vals : dictionary
 
-        Possible keys in the result_vals dictionary:
+        Keys in the result_vals dictionary:
 
         'observables': np.ndarray, float, shape = (S)
             results_vals['observables'][i] is the estimate for the expectation of A_state_map[i](x) at the state specified by u_n[state_map[i],:]
@@ -896,8 +876,7 @@ class MBAR:
     #=========================================================================
     def computeExpectations(self, A_n, u_kn=None, output='averages', state_dependent=False,
                             compute_uncertainty=True, uncertainty_method=None,
-                            warning_cutoff=1.0e-10, return_theta=False,
-                            return_dict=True):
+                            warning_cutoff=1.0e-10, return_theta=False):
         """Compute the expectation of an observable of a phase space function.
 
         Compute the expectation of an observable of a single phase space
@@ -929,24 +908,21 @@ class MBAR:
 
         state_dependent: bool, whether the expectations are state-dependent.
 
-        return_dict: bool, default True
-            If True, is a dictionary, else its a tuple
-
         Returns
         -------
+        
+        Results dictionary with the following keys
+
         'mu' : np.ndarray, float
             if output is 'averages'
             A_i  (K np float64 array) -  A_i[i] is the estimate for the expectation of A(x) for state i.
             if output is 'differences'
-            if return_dict: key is 'mu'
         'sigma' : np.ndarray, float
             dA_i  (K np float64 array) - dA_i[i] is uncertainty estimate (one standard deviation) for A_i[i]
             or
             dA_ij (K np float64 array) - dA_ij[i,j] is uncertainty estimate (one standard deviation) for the difference in A beteen i and j
             or None, if compute_uncertainty is False.
-            if return_dict: key is 'sigma'
         'Theta' ((KxK np float64 array): Covariance matrix of log weights
-            if return_dict, key is 'Theta'
 
         References
         ----------
@@ -1016,7 +992,6 @@ class MBAR:
                                                       warning_cutoff=warning_cutoff)
 
         result_vals = dict()
-        result_list = []
         if compute_uncertainty or return_theta:
             # we want the theta matrix for the exponentials of the
             # observables, which means we need to make the
@@ -1030,10 +1005,8 @@ class MBAR:
 
         if output == 'averages':
             result_vals['mu'] = inner_results['observables']
-            result_list.append(result_vals['mu'])
             if compute_uncertainty:
                 result_vals['sigma'] = np.sqrt(covA_ij[0:K,0:K].diagonal())
-                result_list.append(result_vals['sigma'])
 
         if output == 'differences':
             A_im = np.matrix(inner_results['observables'])
@@ -1043,22 +1016,15 @@ class MBAR:
             result_list.append(result_vals['mu'])
             if compute_uncertainty:
                 result_vals['sigma'] = self._ErrorOfDifferences(covA_ij,warning_cutoff=warning_cutoff)
-                result_list.append(result_vals['sigma'])
 
         if return_theta:
             result_vals['Theta'] = Theta
-            result_list.append(Theta)
 
-        if return_dict:
-            return result_vals
-        else:
-            warnings.warn(self.return_value_warn,UserWarning)
-            return tuple(result_list)
+        return result_vals
 
     #=========================================================================
     def computeMultipleExpectations(self, A_in, u_n, compute_uncertainty=True, compute_covariance=False,
-                                    uncertainty_method=None, warning_cutoff=1.0e-10, return_theta=False,
-                                    return_dict=True):
+                                    uncertainty_method=None, warning_cutoff=1.0e-10, return_theta=False):
         """Compute the expectations of multiple observables of phase space functions.
 
         Compute the expectations of multiple observables of phase
@@ -1085,24 +1051,20 @@ class MBAR:
             See help for computeAsymptoticCovarianceMatrix() for more information on various methods. (default: None)
         warning_cutoff : float, optional
             Warn if squared-uncertainty is negative and larger in magnitude than this number (default: 1.0e-10)
-        return_dict: bool, default True
-            If True, return is a dictionary, else its a tuple
 
         Returns
         -------------
+        Results dictionary with the following keys
+        
         'mu' : np.ndarray, float, shape=(I)
             result_vals['mu'] is the estimate for the expectation of A_i(x) at the state specified by u_kn
-            If return_dict, key will be 'mu'
         'sigma' : np.ndarray, float, shape = (I)
             result_vals['sigma'] is the uncertainty in the expectation of A_state_map[i](x) at the state specified by u_n[state_map[i],:]
             or None if compute_uncertainty is False
-            If return_dict, key will be 'sigma'
         'covariances' : np.ndarray, float, shape=(I, I)
             result_vals['covariances'] is the COVARIANCE in the estimates of A_i[i] and A_i[j]: we can't actually take a square root
             or None if compute_covariance is False
-            If return_dict, key will be 'covartiances'
         'Theta': np.ndarray, float, shape=(I, I), covariances of the log weights, useful for some additional calculations.
-            If return_dict, key will be 'Theta'
 
         Examples
         --------
@@ -1138,10 +1100,8 @@ class MBAR:
                                                       uncertainty_method=uncertainty_method,
                                                       warning_cutoff=warning_cutoff)
         result_vals = dict()
-        return_list = []
         expectations, uncertainties, covariances = None, None, None
         result_vals['mu'] = inner_results['observables']
-        return_list.append(result_vals['mu'])
 
         if compute_uncertainty or compute_covariance or return_theta:
             Adiag = np.zeros([2*I,2*I],dtype=np.float64)
@@ -1153,25 +1113,18 @@ class MBAR:
             if compute_uncertainty:
                 covA_ij = np.array(Theta[0:I,0:I]+Theta[I:2*I,I:2*I]-Theta[0:I,I:2*I]-Theta[I:2*I,0:I])
                 result_vals['sigma'] = np.sqrt(covA_ij[0:I,0:I].diagonal())
-                return_list.append(result_vals['sigma'])
 
             if compute_covariance:
                 # compute estimate of statistical covariance of the observables
                 result_vals['covariances'] = inner_results['Theta'][0:I,0:I]
-                return_list.append(result_vals['covariances'])
 
             if return_theta:
                 result_vals['Theta'] = Theta
-                return_list.append(result_vals['Theta'])
 
-        if return_dict:
-            return result_vals
-        else:
-            warnings.warn(self.return_value_warn,UserWarning)
-            return tuple(return_list)
+        return result_vals
 
     #=========================================================================
-    def computePerturbedFreeEnergies(self, u_ln, compute_uncertainty=True, uncertainty_method=None, warning_cutoff=1.0e-10, return_dict=True):
+    def computePerturbedFreeEnergies(self, u_ln, compute_uncertainty=True, uncertainty_method=None, warning_cutoff=1.0e-10):
         """Compute the free energies for a new set of states.
 
         Here, we desire the free energy differences among a set of new states, as well as the uncertainty estimates in these differences.
@@ -1188,18 +1141,16 @@ class MBAR:
             See help for computeAsymptoticCovarianceMatrix() for more information on various methods. (default: None)
         warning_cutoff : float, optional
             Warn if squared-uncertainty is negative and larger in magnitude than this number (default: 1.0e-10)
-        return_dict: bool, default True
-            If true, return is a dictionary, else its a tuple
 
         Returns
         -------
+        Results dictionary with the following entries.
+
         'Delta_f' : np.ndarray, float, shape=(L, L)
             result_vals['Delta_f'] = f_j - f_i, the dimensionless free energy difference between new states i and j
-            If return_dict, key is 'Delta_f'
         'dDelta_f' : np.ndarray, float, shape=(L, L)
             result_vals['dDelta_f'] is the estimated statistical uncertainty in result_vals['Delta_f']
             or not included if `compute_uncertainty` is False
-            If return_dict, key is 'dDelta_f'
 
         Examples
         --------
@@ -1234,24 +1185,16 @@ class MBAR:
         f_k = np.matrix(inner_results['f'])
 
         result_vals = dict()
-        results_list = []
         result_vals['Delta_f'] = np.array(f_k - f_k.transpose())
-        results_list.append(result_vals['Delta_f'])
 
         if (compute_uncertainty):
             result_vals['dDelta_f'] = self._ErrorOfDifferences(inner_results['Theta'],warning_cutoff=warning_cutoff)
-            results_list.append(result_vals['dDelta_f'])
 
-        # Return matrix of free energy differences and uncertainties.
-        if return_dict:
-            return result_vals
-        else:
-            print("Warning: returning values as a tuple is deprecated")
-            return tuple(results_list)
+        return result_vals
 
     #=====================================================================
 
-    def computeEntropyAndEnthalpy(self, u_kn=None, uncertainty_method=None, verbose=False, warning_cutoff=1.0e-10, return_dict=True):
+    def computeEntropyAndEnthalpy(self, u_kn=None, uncertainty_method=None, verbose=False, warning_cutoff=1.0e-10):
         """Decompose free energy differences into enthalpy and entropy differences.
 
         Compute the decomposition of the free energy difference between
@@ -1267,29 +1210,23 @@ class MBAR:
             See help for computeAsymptoticCovarianceMatrix() for more information on various methods. (default: None)
         warning_cutoff : float, optional
             Warn if squared-uncertainty is negative and larger in magnitude than this number (default: 1.0e-10)
-        return_dict: bool, default True
-            If true, return is a dictionary, else its a tuple
 
         Returns
         -------
+        Results dictionary with the following keys
+        
         'Delta_f' : np.ndarray, float, shape=(K, K)
             results['Delta_f'] is the dimensionless free energy difference f_j - f_i
-            If return_dict, key is 'Delta_f'
         'dDelta_f' : np.ndarray, float, shape=(K, K)
             uncertainty in results['Delta_f']
-            If return_dict, key is 'dDelta_f'
         'Delta_u' : np.ndarray, float, shape=(K, K)
             results['Delta_u'] is the reduced potential energy difference u_j - u_i
-            If return_dict, key is 'Delta_u'
         'dDelta_u' : np.ndarray, float, shape=(K, K)
             uncertainty in results['Delta_u']
-            If return_dict, key is 'dDelta_u'
         'Delta_s' : np.ndarray, float, shape=(K, K)
             results['Delta_s'] is the reduced entropy difference S/k between states i and j (s_j - s_i)
-            If return_dict, key is 'Delta_s'
         'dDelta_s' : np.ndarray, float, shape=(K, K)
             uncertainty in results['Delta_s']
-            If return_dict, key is 'dDelta_s'
 
         Examples
         --------
@@ -1369,29 +1306,18 @@ class MBAR:
         dDelta_s_ij = self._ErrorOfDifferences(covs,warning_cutoff=warning_cutoff)
 
         result_vals = dict()
-        results_list = []
         result_vals['Delta_f'] = Delta_f_ij
         result_vals['dDelta_f'] = dDelta_f_ij
         result_vals['Delta_u'] = Delta_u_ij
         result_vals['dDelta_u'] = dDelta_u_ij
         result_vals['Delta_s'] = Delta_s_ij
         result_vals['dDelta_s'] = dDelta_s_ij
-        results_list.append(Delta_f_ij)
-        results_list.append(dDelta_f_ij)
-        results_list.append(Delta_u_ij)
-        results_list.append(dDelta_u_ij)
-        results_list.append(Delta_s_ij)
-        results_list.append(dDelta_s_ij)
 
-        if return_dict:
-            return result_vals
-        else:
-            warnings.warn(self.return_value_warn,UserWarning)
-            return tuple(results_list)
+        return result_vals
 
     #=====================================================================
 
-    def computePMF(self, u_n, bin_n, nbins, uncertainties='from-lowest', pmf_reference=None, return_dict=True):
+    def computePMF(self, u_n, bin_n, nbins, uncertainties='from-lowest', pmf_reference=None):
         """
         Compute the free energy of occupying a number of bins.
 
@@ -1416,18 +1342,15 @@ class MBAR:
         pmf_reference : int, optional
             the reference state that is zeroed when uncertainty = 'from-specified'
 
-        return_dict : bool, default True
-            False returns as a Tuple rather than a dict
-
         Returns
         -------
+        Results dictionary with the following keys
+
         'f_i' : np.ndarray, float, shape=(K)
             f_i[i] is the dimensionless free energy of state i, relative to the state of lowest free energy
-            If `return_dict`: result_vals['f_i']
         'df_i' : np.ndarray, float, shape=(K)
             df_i[i] is the uncertainty in the difference of f_i with respect to the state of lowest free energy
             Note: if `all-differences` is set for uncertainty method, then the return is 'df_ij'
-            If `return_dict`: result_vals['df_i']
 
         Notes
         -----
@@ -1570,16 +1493,13 @@ class MBAR:
 
         # return free energy and uncertainty
         # Return dimensionless free energy and uncertainty.
-        if return_dict:
-            result_vals['f_i'] = f_i
-            if uncertainties == 'all-differences':
-                result_vals['df_ij'] = df_ij
-            else:
-                result_vals['df_i'] = df_i
-            return result_vals
+
+        result_vals['f_i'] = f_i
+        if uncertainties == 'all-differences':
+            result_vals['df_ij'] = df_ij
         else:
-            warnings.warn(self.return_value_warn,UserWarning)
-            return f_i, df_i
+            result_vals['df_i'] = df_i
+        return result_vals
 
 
     #=========================================================================

--- a/pymbar/mbar.py
+++ b/pymbar/mbar.py
@@ -1013,7 +1013,6 @@ class MBAR:
             A_ij = A_im - A_im.transpose()
 
             result_vals['mu'] = np.array(A_ij)
-            result_list.append(result_vals['mu'])
             if compute_uncertainty:
                 result_vals['sigma'] = self._ErrorOfDifferences(covA_ij,warning_cutoff=warning_cutoff)
 

--- a/pymbar/mbar.py
+++ b/pymbar/mbar.py
@@ -482,7 +482,7 @@ class MBAR:
 
         Returns
         -------
-        Results dictionary with the folowing keys:
+        Results dictionary with the following keys:
 
         'Delta_f' : np.ndarray, float, shape=(K, K)
             Deltaf_ij[i,j] is the estimated free energy difference

--- a/pymbar/tests/test_covariance.py
+++ b/pymbar/tests/test_covariance.py
@@ -25,9 +25,9 @@ def _test(data_generator):
     name, U, N_k, s_n = data_generator()
     print(name)
     mbar = pymbar.MBAR(U, N_k)
-    results1 = mbar.getFreeEnergyDifferences(uncertainty_method="svd", return_dict=True)
-    fij1_t, dfij1_t = mbar.getFreeEnergyDifferences(uncertainty_method="svd", return_dict=False)
-    results2 = mbar.getFreeEnergyDifferences(uncertainty_method="svd-ew", return_dict=True)
+    results1 = mbar.getFreeEnergyDifferences(uncertainty_method="svd")
+    fij1_t, dfij1_t = mbar.getFreeEnergyDifferences(uncertainty_method="svd")
+    results2 = mbar.getFreeEnergyDifferences(uncertainty_method="svd-ew")
     fij1 = results1['Delta_f']
     dfij1 = results1['dDelta_f']
     fij2 = results2['Delta_f']

--- a/pymbar/tests/test_mbar.py
+++ b/pymbar/tests/test_mbar.py
@@ -71,13 +71,9 @@ def test_mbar_free_energies():
         eq(N_k, N_k_output)
         mbar = MBAR(u_kn, N_k)
 
-        results = mbar.getFreeEnergyDifferences(return_dict=True)
-        fe_t, dfe_t = mbar.getFreeEnergyDifferences(return_dict=False)
+        results = mbar.getFreeEnergyDifferences()
         fe = results['Delta_f']
         fe_sigma = results['dDelta_f']
-
-        eq(fe, fe_t)
-        eq(fe_sigma, dfe_t)
 
         fe, fe_sigma = fe[0,1:], fe_sigma[0,1:]
 
@@ -96,13 +92,9 @@ def test_mbar_computeExpectations_position_averages():
         x_n, u_kn, N_k_output, s_n = test.sample(N_k, mode='u_kn')
         eq(N_k, N_k_output)
         mbar = MBAR(u_kn, N_k)
-        results = mbar.computeExpectations(x_n, return_dict=True)
-        mu_t, sigma_t = mbar.computeExpectations(x_n, return_dict=False)
+        results = mbar.computeExpectations(x_n)
         mu = results['mu']
         sigma = results['sigma' ]
-
-        eq(mu, mu_t)
-        eq(sigma, sigma_t)
 
         mu0 = test.analytical_observable(observable = 'position')
 
@@ -118,7 +110,7 @@ def test_mbar_computeExpectations_position_differences():
         x_n, u_kn, N_k_output, s_n = test.sample(N_k, mode='u_kn')
         eq(N_k, N_k_output)
         mbar = MBAR(u_kn, N_k)
-        results = mbar.computeExpectations(x_n, output = 'differences', return_dict=True)
+        results = mbar.computeExpectations(x_n, output = 'differences')
         mu_ij = results['mu'] 
         sigma_ij = results['sigma'] 
 
@@ -135,7 +127,7 @@ def test_mbar_computeExpectations_position2():
         x_n, u_kn, N_k_output, s_n = test.sample(N_k, mode='u_kn')
         eq(N_k, N_k_output)
         mbar = MBAR(u_kn, N_k)
-        results = mbar.computeExpectations(x_n ** 2, return_dict=True)
+        results = mbar.computeExpectations(x_n ** 2)
         mu = results['mu']
         sigma = results['sigma'] 
         mu0 = test.analytical_observable(observable = 'position^2')
@@ -152,7 +144,7 @@ def test_mbar_computeExpectations_potential():
         x_n, u_kn, N_k_output, s_n = test.sample(N_k, mode='u_kn')
         eq(N_k, N_k_output)
         mbar = MBAR(u_kn, N_k)
-        results = mbar.computeExpectations(u_kn, state_dependent = True, return_dict=True)
+        results = mbar.computeExpectations(u_kn, state_dependent = True)
         mu = results['mu']
         sigma = results['sigma'] 
         mu0 = test.analytical_observable(observable = 'potential energy')
@@ -174,12 +166,10 @@ def test_mbar_computeMultipleExpectations():
         A[0,:] = x_n
         A[1,:] = x_n**2
         state = 1
-        results = mbar.computeMultipleExpectations(A,u_kn[state,:], return_dict=True)
-        mu_t, sigma_t = mbar.computeMultipleExpectations(A,u_kn[state,:], return_dict=False)
+        results = mbar.computeMultipleExpectations(A,u_kn[state,:])
         mu = results['mu']
         sigma = results['sigma']
-        eq(mu, mu_t)
-        eq(sigma, sigma_t)
+
         mu0 = test.analytical_observable(observable = 'position')[state]
         mu1 = test.analytical_observable(observable = 'position^2')[state]
         z = (mu0 - mu[0]) / sigma[0]
@@ -196,21 +186,13 @@ def test_mbar_computeEntropyAndEnthalpy():
         x_n, u_kn, N_k_output, s_n = test.sample(N_k, mode='u_kn')
         eq(N_k, N_k_output)
         mbar = MBAR(u_kn, N_k)
-        results =  mbar.computeEntropyAndEnthalpy(u_kn, return_dict=True)
-        f_t, df_t, u_t, du_t, s_t, ds_t = mbar.computeEntropyAndEnthalpy(u_kn, return_dict=False)
+        results =  mbar.computeEntropyAndEnthalpy(u_kn)
         f_ij = results['Delta_f'] 
         df_ij = results['dDelta_f'] 
         u_ij = results['Delta_u'] 
         du_ij = results['dDelta_u']  
         s_ij = results['Delta_s'] 
         ds_ij = results['dDelta_s']
-
-        eq(f_ij, f_t)
-        eq(df_ij, df_t)
-        eq(u_ij, u_t)
-        eq(du_ij, du_t)
-        eq(s_ij, s_t)
-        eq(ds_ij, ds_t)
 
         fa = test.analytical_free_energies()
         ua = test.analytical_observable('potential energy')
@@ -254,15 +236,10 @@ def test_mbar_computeOverlap():
     x_n, u_kn, N_k_output, s_n = test.sample(even_N_k, mode='u_kn')
     mbar = MBAR(u_kn, even_N_k)
 
-    results = mbar.computeOverlap(return_dict=True)
-    os_t, eig_t, O_t = mbar.computeOverlap(return_dict=False)
+    results = mbar.computeOverlap()
     overlap_scalar = results['scalar']
     eigenval = results['eigenvalues']
     O = results['matrix']
-
-    eq(overlap_scalar, os_t)
-    eq(eigenval, eig_t)
-    eq(O, O_t)
 
     reference_matrix = np.matrix((1.0/d)*np.ones([d,d]))
     reference_eigenvalues = np.zeros(d)
@@ -310,13 +287,9 @@ def test_mbar_computePerturbedFreeEnergeies():
         x_n, u_kn, N_k_output, s_n = test.sample(N_k, mode='u_kn')
         numN = np.sum(N_k[:2])
         mbar = MBAR(u_kn[:2,:numN], N_k[:2])  # only do MBAR with the first and last set
-        results = mbar.computePerturbedFreeEnergies(u_kn[2:,:numN], return_dict=True)
-        f_t, df_t = mbar.computePerturbedFreeEnergies(u_kn[2:, :numN], return_dict=False)
+        results = mbar.computePerturbedFreeEnergies(u_kn[2:,:numN])
         fe = results['Delta_f']
         fe_sigma = results['dDelta_f']
-
-        eq(fe, f_t)
-        eq(fe_sigma, df_t)
 
         fe, fe_sigma = fe[0,1:], fe_sigma[0,1:]
 
@@ -345,13 +318,9 @@ def test_mbar_computePMF():
     bin_n[within_bounds] = 1 + np.floor((x_n[within_bounds]-xmin)/dx)
     # 0 is reserved for samples outside the domain.  We will ignore this state
     range = np.max(bin_n)+1
-    results = mbar.computePMF(u_kn[refstate,:], bin_n, range, uncertainties = 'from-specified', pmf_reference = 1, return_dict=True)
-    f_t, df_t = mbar.computePMF(u_kn[refstate,:], bin_n, range, uncertainties = 'from-specified', pmf_reference = 1, return_dict=False)
+    results = mbar.computePMF(u_kn[refstate,:], bin_n, range, uncertainties = 'from-specified', pmf_reference = 1)
     f_i = results['f_i']
     df_i = results['df_i']
-
-    eq(f_i, f_t)
-    eq(df_i, df_t)
 
     f0_i = 0.5*test.K_k[refstate]*(bin_centers-test.O_k[refstate])**2
     f_i, df_i = f_i[2:], df_i[2:] # first state is ignored, second is zero, with zero uncertainty

--- a/pymbar/tests/test_mbar_solvers.py
+++ b/pymbar/tests/test_mbar_solvers.py
@@ -83,7 +83,7 @@ def test_protocols():
             mbar = pymbar.MBAR(u_kn, N_k, solver_protocol=({'method': solver_protocol},))
             # Solve MBAR with the correct f_k used for the inital weights
             mbar = pymbar.MBAR(u_kn, N_k, initial_f_k=mbar.f_k, solver_protocol=({'method': solver_protocol},))
-            results = mbar.getFreeEnergyDifferences(return_dict=True)
+            results = mbar.getFreeEnergyDifferences()
             fe = results['Delta_f'][0,1:]
             fe_sigma = results['dDelta_f'][0,1:]
             z = (fe - fa) / fe_sigma


### PR DESCRIPTION
First pass at deprecating tuple return types. To keep things roughly backwards compatible, I am proposing that we leave in return_dict, but change the default to False.  Thus, if people want previous behavior, they just need to add a flag, rather than rewriting the code.  

With return_dict=False, however, it will now give a user error that the feature will be removed in future releases.  I used UserWarning rather than DeprecationWarning, since the latter are only printed in developer types, and we want the users to know they should change the way they call it.

Currently, the return is STILL a dict, and the variable is return_dict. I could change return_dict to return_object or something like that, since we may change it into a dict-like object in the future, but I don't know if that is needed now.  We may just drop return_dict before we get around to replacing the dict with a dict-like object.

Still need to change the examples to remove the return_dict keyword, since they already use the new default. 