### PR TITLE
Replace `np.matrix` calls and other warnings

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -6,7 +6,7 @@ dependencies:
     # Base depends
   - python
   - pip
-  - numpy >=1.11
+  - numpy >=1.12
   - scipy
   - numexpr
   - six

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -14,7 +14,7 @@ requirements:
     - toolchain
   run:
     - python
-    - numpy >=1.11
+    - numpy >=1.12
     - scipy
     - numexpr
     - six

--- a/examples/harmonic-oscillators/harmonic-oscillators.py
+++ b/examples/harmonic-oscillators/harmonic-oscillators.py
@@ -51,7 +51,7 @@ def GetAnalytical(beta,K,O,observables):
   sigma = (beta * K)**-0.5
   f_k_analytical = - numpy.log(numpy.sqrt(2 * numpy.pi) * sigma )
 
-  Delta_f_ij_analytical = numpy.matrix(f_k_analytical) - numpy.matrix(f_k_analytical).transpose()
+  Delta_f_ij_analytical = f_k_analytical - numpy.vstack(f_k_analytical)
 
   A_k_analytical = dict()
   A_ij_analytical = dict()
@@ -66,7 +66,7 @@ def GetAnalytical(beta,K,O,observables):
     if observe == 'position^2':    
       A_k_analytical[observe]  = (1+ beta*K*O**2)/(beta*K)        # observable is the position^2
 
-    A_ij_analytical[observe] = A_k_analytical[observe] - numpy.transpose(numpy.matrix(A_k_analytical[observe]))
+    A_ij_analytical[observe] = A_k_analytical[observe] - numpy.vstack(A_k_analytical[observe])
 
   return f_k_analytical, Delta_f_ij_analytical, A_k_analytical, A_ij_analytical
 
@@ -353,7 +353,7 @@ for observe in observables:
   if 'RMS displacement' != observe: # can't test this, because we're actually computing the expectation of
                                     # the mean square displacement, and so the differences are <a_i^2> - <a_j^2>,
                                     # not sqrt<a_i>^2 - sqrt<a_j>^2
-    A_kl_analytical = numpy.matrix(A_k_analytical[observe]) - numpy.matrix(A_k_analytical[observe]).transpose()
+    A_kl_analytical = A_k_analytical[observe] - numpy.vstack(A_k_analytical[observe])
     A_kl_error = A_kl_estimated - A_kl_analytical
     
     print("Analytical estimator of differences of %s is" % (observe))
@@ -424,8 +424,8 @@ if (numpy.max(numpy.abs(diffs2)) > 1.0e-10):
 print("Energies")
 print(Delta_u_ij)
 print(dDelta_u_ij)
-U_k = numpy.matrix(A_k_estimated_all['potential energy'])
-expectations = U_k - U_k.transpose()
+U_k = A_k_estimated_all['potential energy']
+expectations = U_k - numpy.vstack(U_k)
 diffs1 = Delta_u_ij - expectations
 print("maximum difference between values computed here and in computeExpectations is %g" % (numpy.max(diffs1)))
 if (numpy.max(numpy.abs(diffs1)) > 1.0e-10):
@@ -437,8 +437,8 @@ print(Delta_s_ij)
 print(dDelta_s_ij)
 
 #analytical entropy estimate
-s_k_analytical = numpy.matrix(0.5 / beta - f_k_analytical)
-Delta_s_ij_analytical = s_k_analytical - s_k_analytical.transpose()
+s_k_analytical = 0.5 / beta - f_k_analytical
+Delta_s_ij_analytical = s_k_analytical - numpy.vstack(s_k_analytical)
 
 Delta_s_ij_error = Delta_s_ij_analytical - Delta_s_ij
 print("Error in entropies is:")

--- a/pymbar/mbar.py
+++ b/pymbar/mbar.py
@@ -44,7 +44,6 @@ import warnings
 from pymbar import mbar_solvers
 from pymbar.utils import kln_to_kn, kn_to_n, ParameterError, DataError, logsumexp, check_w_normalized
 
-import pdb
 DEFAULT_SOLVER_PROTOCOL = mbar_solvers.DEFAULT_SOLVER_PROTOCOL
 
 # =========================================================================
@@ -1645,7 +1644,7 @@ class MBAR:
             # Compute singular values and right singular vectors of W without using SVD
             # Instead, we compute eigenvalues and eigenvectors of W'W.
             # Note W'W = (U S V')'(U S V') = V S' U' U S V' = V (S'S) V'
-            [S2, V] = linalg.eigh(np.atleast_2d(W).T @ W)
+            [S2, V] = linalg.eigh(W.T @ W)
             # Set any slightly negative eigenvalues to zero.
             S2[np.where(S2 < 0.0)] = 0.0
             # Form matrix of singular values Sigma, and V.

--- a/pymbar/tests/test_covariance.py
+++ b/pymbar/tests/test_covariance.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pytest
 import pymbar
-from pymbar.utils_for_testing import (suppress_derivative_warnings_for_tests, assert_almost_equal,
+from pymbar.utils_for_testing import (suppress_derivative_warnings_for_tests, suppress_matrix_warnings_for_tests,
+                                      assert_almost_equal,
                                       oscillators, exponentials)
 
 
@@ -29,7 +30,8 @@ def _test(statesa, statesb, test_system):
 
     # Test against old MBAR code.
     with suppress_derivative_warnings_for_tests():
-        mbar0 = pymbar.old_mbar.MBAR(U, N_k)
+        with suppress_matrix_warnings_for_tests():
+            mbar0 = pymbar.old_mbar.MBAR(U, N_k)
     fij0, dfij0 = mbar0.getFreeEnergyDifferences(uncertainty_method="svd")
     assert_almost_equal(mbar.f_k, mbar0.f_k, decimal=8)
     assert_almost_equal(np.exp(mbar.Log_W_nk), np.exp(mbar0.Log_W_nk), decimal=5)

--- a/pymbar/tests/test_mbar.py
+++ b/pymbar/tests/test_mbar.py
@@ -24,7 +24,7 @@ def generate_exp(rates=np.array([1.0, 2.0, 3.0, 4.0])):  # Rates, e.g. Lambda
 
 
 def convert_to_differences(x_ij, dx_ij, xa):
-    xa_ij = xa - np.atleast_2d(xa).T  # Safe, non-matrix conversion of np.matrix(...) and still do x-x.T correctly
+    xa_ij = xa - np.vstack(xa)
 
     # add ones to the diagonal of the uncertainties, because they are zero
     for i in range(len(N_k)):

--- a/pymbar/tests/test_mbar.py
+++ b/pymbar/tests/test_mbar.py
@@ -236,7 +236,7 @@ def test_mbar_computeOverlap_analytical():
     eigenval = results['eigenvalues']
     O = results['matrix']
 
-    reference_matrix = np.matrix((1.0/d)*np.ones([d,d]))
+    reference_matrix = (1.0/d)*np.ones([d,d])
     reference_eigenvalues = np.zeros(d)
     reference_eigenvalues[0] = 1.0
     reference_scalar = np.float64(1.0)

--- a/pymbar/tests/test_mbar_solvers.py
+++ b/pymbar/tests/test_mbar_solvers.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pytest
 import pymbar
-from pymbar.utils_for_testing import (suppress_derivative_warnings_for_tests, assert_almost_equal,
+from pymbar.utils_for_testing import (suppress_derivative_warnings_for_tests, suppress_matrix_warnings_for_tests,
+                                      assert_almost_equal,
                                       oscillators, exponentials)
 from pymbar.tests.test_mbar import z_scale_factor
 
@@ -29,7 +30,8 @@ def test_solvers(statesa, statesb, test_system):
 
     # Test against old MBAR code.
     with suppress_derivative_warnings_for_tests():
-        mbar0 = pymbar.old_mbar.MBAR(U, N_k)
+        with suppress_matrix_warnings_for_tests():
+            mbar0 = pymbar.old_mbar.MBAR(U, N_k)
     assert_almost_equal(mbar.f_k, mbar0.f_k, decimal=8)
     assert_almost_equal(np.exp(mbar.Log_W_nk), np.exp(mbar0.Log_W_nk), decimal=5)
 

--- a/pymbar/timeseries.py
+++ b/pymbar/timeseries.py
@@ -1,8 +1,8 @@
 ##############################################################################
 # pymbar: A Python Library for MBAR
 #
-# Copyright 2016-2017 University of Colorado Boulder
-# Copyright 2010-2017 Memorial Sloan-Kettering Cancer Center
+# Copyright 2016-2020 University of Colorado Boulder
+# Copyright 2010-2020 Memorial Sloan-Kettering Cancer Center
 # Portions of this software are Copyright (c) 2010-2016 University of Virginia
 # Portions of this software are Copyright (c) 2006-2007 The Regents of the University of California.  All Rights Reserved.
 # Portions of this software are Copyright (c) 2007-2008 Stanford University and Columbia University.
@@ -56,9 +56,7 @@ __license__ = "MIT"
 # IMPORTS
 # =============================================================================================
 import math
-import warnings
 import numpy as np
-import numpy.linalg
 from pymbar.utils import ParameterError
 
 # =============================================================================================
@@ -804,7 +802,7 @@ def detectEquilibration(A_t, fast=True, nskip=1):
     return (t, g, Neff_max)
 
 
-def statisticalInefficiency_fft(A_n, mintime=3, memsafe=None):
+def statisticalInefficiency_fft(A_n, mintime=3):
     """Compute the (cross) statistical inefficiency of (two) timeseries.
 
     Parameters
@@ -816,10 +814,6 @@ def statisticalInefficiency_fft(A_n, mintime=3, memsafe=None):
         The algorithm terminates after computing the correlation time out to mintime when the
         correlation function first goes negative.  Note that this time may need to be increased
         if there is a strong initial negative peak in the correlation function.
-    memsafe: bool, optional, default=None (in depreciation)
-        If this function is used several times on arrays of comparable size then one might benefit 
-        from setting this option to False. If set to True then clear np.fft cache to avoid a fast 
-        increase in memory consumption when this function is called on many arrays of different sizes.
 
     Returns
     -------
@@ -854,25 +848,6 @@ def statisticalInefficiency_fft(A_n, mintime=3, memsafe=None):
     C_t = sm.tsa.stattools.acf(A_n, fft=True, unbiased=True, nlags=N)
     t_grid = np.arange(N).astype('float')
     g_t = 2.0 * C_t * (1.0 - t_grid / float(N))
-
-    """
-    LNN Note:
-    Numpy 1.12 fft.fftpack swiched from using a Python dict for the cache to a LRU cache which auto prunes.
-    This makes the .clear() method undefined since the LRU does not have such a method.
-
-    Since the LRU *should* remove the problems which this code resolved (GH issue #168), I am removing this code from
-    execution. However, there may still be a problem with the LRU cache so I am leaving the code in case we need to
-    further test it
-    """
-    #make function memory safe by clearing np.fft cache
-    #this assumes that statsmodels uses np.fft
-    #if memsafe:
-    #    np.fft.fftpack._fft_cache.clear()
-    #    np.fft.fftpack._real_fft_cache.clear()
-    if memsafe is not None:
-        warnings.warn("NumPy's FFT pack now uses an LRU cache to fix the very problem that the memsafe keyword "
-                      "was protecting. This argument no longer changes the code and will be removed in a future "
-                      "version.", FutureWarning)
     
     try:
         ind = np.where((C_t <= 0) & (t_grid > mintime))[0][0]
@@ -931,7 +906,7 @@ def detectEquilibration_binary_search(A_t, bs_nodes=10):
         
         for k, t in enumerate(time_grid):
             if t < T-1:
-                g_t[k] = statisticalInefficiency_fft(A_t[t:], memsafe=True)
+                g_t[k] = statisticalInefficiency_fft(A_t[t:])
                 Neff_t[k] = (T - t + 1) / g_t[k]
 
         Neff_max = Neff_t.max()

--- a/pymbar/utils_for_testing.py
+++ b/pymbar/utils_for_testing.py
@@ -35,7 +35,7 @@ __all__ = ['assert_allclose', 'assert_almost_equal', 'assert_approx_equal',
            'assert_array_almost_equal', 'assert_array_almost_equal_nulp',
            'assert_array_equal', 'assert_array_less', 'assert_array_max_ulp',
            'assert_equal', 'assert_raises', 'assert_string_equal', 'assert_warns',
-           'get_fn', 'suppress_derivative_warnings_for_tests',
+           'get_fn', 'suppress_derivative_warnings_for_tests', 'suppress_matrix_warnings_for_tests',
            'oscillators', 'exponentials']
 
 ##############################################################################
@@ -52,6 +52,18 @@ def suppress_derivative_warnings_for_tests():
     warnings.filterwarnings('ignore', '.*does not use the Jacobian.*')
     warnings.filterwarnings('ignore', '.*does not use Hessian.*')
     warnings.filterwarnings('ignore', '.*parameter will change to the default of machine precision.*')
+    yield
+    # Clear warning filters
+    warnings.resetwarnings()
+
+
+@contextlib.contextmanager
+def suppress_matrix_warnings_for_tests():
+    """
+    Suppress specific warnings and then reset when done, used as a with suppress_warnings():
+    """
+    # Supress the numpy matrix warnings
+    warnings.filterwarnings('ignore', '.*the matrix subclass is not*')
     yield
     # Clear warning filters
     warnings.resetwarnings()


### PR DESCRIPTION
This PR is an extension of #333, so it is ~DNM until 333 is done.~ (Ready)

I will refresh this once #333 is to fix the edits, so if you want to hold off on review, thats fine too.

This PR replaces all of the `np.matrix` calls and manipulates the
objects as arrays only. See https://numpy.org/doc/1.18/user/numpy-for-matlab-users.html
for why this needed to be done.

However, that does mean there are some syntax changes I had to make since
`*` on arrays is element-wise (matrix multiplication can be done with
`@` operator since Python 3.5, though you can do `np.matmul(a,b)` to
the same effect ).
And transpose of 1-D arrays doesn't do anything like it does to a matrix, but I found
doing `x - np.astleast_2d(x).T` does, while still being arrays and not
matrices. Note: this is MUCH safer than assuming its 1-D and doing `x - x[np.newaxis].T` 
which will cause very silly things to happen if `x` is already 2-D.

Edit: the `vstack` is better than `atleast_2d`, thanks mrshirts for that suggestion.

That said, there's alot of replacements here and I'm hoping someone
else can look over this and make sure I have the correct matrix operations
(namely element-wise vs matrix-style) in place for the correct results.
This does pass my local tests.