### PR TITLE
Shorten duplicate state check

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,0 +1,73 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'pymbar4'
+      - 'gha'
+  pull_request:
+    branches:
+      - 'master'
+      - 'pymbar4'
+      - 'gha'
+  schedule:
+    # Nightly Tests
+    - cron: '0 0 * * *'
+
+jobs:
+
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macOS-latest, ubuntu-latest, windows-latest]
+        python-version: [3.7, 3.8]
+      # fail-fast: false # Un-comment once finalized
+    env:
+      PYVER: ${{ matrix.python-version }}
+      CI_OS: ${{ matrix.os }}
+      PACKAGE: "pymbar"
+
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v1
+
+    - name: Additional info about the build
+      shell: bash
+      run: |
+        uname -a
+        df -h
+        ulimit -a
+
+    - name: Create environment for package
+      shell: bash
+      run: |
+        . devtools/github-actions/initialize_conda.sh
+        conda activate
+        conda info
+        python devtools/scripts/create_conda_env.py -n=test -p=$PYVER devtools/conda-envs/test_env.yaml
+
+    - name: Install package
+      shell: bash
+      run: |
+        . devtools/github-actions/initialize_conda.sh
+        conda activate test
+        python -m pip install . --no-deps
+        conda list --show-channel-urls
+
+#    - name: Run tests (pytest)
+#        shell: bash
+#        run: |
+#          . devtools/github-actions/initialize_conda.sh
+#          conda activate test
+#          pytest -v --cov=$PACKAGE --cov-report=xml --color=yes $PACKAGE/tests/
+
+    - name: Run tests (nose)
+      shell: bash
+      run: |
+        . devtools/github-actions/initialize_conda.sh
+        conda activate test
+        cd devtools
+        nosetests $PACKAGE --nocapture --verbosity=2 --with-doctest --with-timer
+        cd ..

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -1,0 +1,21 @@
+name: test
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+    # Base depends
+  - python
+  - pip
+  - numpy >=1.11
+  - scipy
+  - numexpr
+  - six
+
+    # Testing
+#  - pytest
+#  - pytest-cov
+  - codecov
+  - nose
+  - nose-timer
+  - statsmodels
+

--- a/devtools/github-actions/initialize_conda.sh
+++ b/devtools/github-actions/initialize_conda.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# $CI_OS is $matrix.os, as exported in GHA *.yaml
+# $CONDA (miniconda installation path) is always defined in the GHA virtual environments
+case ${CI_OS} in
+    windows*)
+        eval "$(${CONDA}/condabin/conda.bat shell.bash hook)";;
+    *)
+        eval "$(${CONDA}/condabin/conda shell.bash hook)";;
+esac

--- a/devtools/scripts/create_conda_env.py
+++ b/devtools/scripts/create_conda_env.py
@@ -1,0 +1,95 @@
+import argparse
+import os
+import re
+import glob
+import shutil
+import subprocess as sp
+from tempfile import TemporaryDirectory
+from contextlib import contextmanager
+# YAML imports
+try:
+    import yaml  # PyYAML
+    loader = yaml.load
+except ImportError:
+    try:
+        import ruamel_yaml as yaml  # Ruamel YAML
+    except ImportError:
+        try:
+            # Load Ruamel YAML from the base conda environment
+            from importlib import util as import_util
+            CONDA_BIN = os.path.dirname(os.environ['CONDA_EXE'])
+            ruamel_yaml_path = glob.glob(os.path.join(CONDA_BIN, '..',
+                                                      'lib', 'python*.*', 'site-packages',
+                                                      'ruamel_yaml', '__init__.py'))[0]
+            # Based on importlib example, but only needs to load_module since its the whole package, not just
+            # a module
+            spec = import_util.spec_from_file_location('ruamel_yaml', ruamel_yaml_path)
+            yaml = spec.loader.load_module()
+        except (KeyError, ImportError, IndexError):
+            raise ImportError("No YAML parser could be found in this or the conda environment. "
+                              "Could not find PyYAML or Ruamel YAML in the current environment, "
+                              "AND could not find Ruamel YAML in the base conda environment through CONDA_EXE path. " 
+                              "Environment not created!")
+    loader = yaml.YAML(typ="safe").load  # typ="safe" avoids odd typing on output
+
+
+@contextmanager
+def temp_cd():
+    """Temporary CD Helper"""
+    cwd = os.getcwd()
+    with TemporaryDirectory() as td:
+        try:
+            os.chdir(td)
+            yield
+        finally:
+            os.chdir(cwd)
+
+
+# Args
+parser = argparse.ArgumentParser(description='Creates a conda environment from file for a given Python version.')
+parser.add_argument('-n', '--name', type=str,
+                    help='The name of the created Python environment')
+parser.add_argument('-p', '--python', type=str,
+                    help='The version of the created Python environment')
+parser.add_argument('conda_file',
+                    help='The file for the created Python environment')
+
+args = parser.parse_args()
+
+# Open the base file
+with open(args.conda_file, "r") as handle:
+    yaml_script = loader(handle.read())
+
+python_replacement_string = "python {}*".format(args.python)
+
+try:
+    for dep_index, dep_value in enumerate(yaml_script['dependencies']):
+        if re.match('python([ ><=*]+[0-9.*]*)?$', dep_value):  # Match explicitly 'python' and its formats
+            yaml_script['dependencies'].pop(dep_index)
+            break  # Making the assumption there is only one Python entry, also avoids need to enumerate in reverse
+except (KeyError, TypeError):
+    # Case of no dependencies key, or dependencies: None
+    yaml_script['dependencies'] = []
+finally:
+    # Ensure the python version is added in. Even if the code does not need it, we assume the env does
+    yaml_script['dependencies'].insert(0, python_replacement_string)
+
+# Figure out conda path
+if "CONDA_EXE" in os.environ:
+    conda_path = os.environ["CONDA_EXE"]
+else:
+    conda_path = shutil.which("conda")
+if conda_path is None:
+    raise RuntimeError("Could not find a conda binary in CONDA_EXE variable or in executable search path")
+
+print("CONDA ENV NAME  {}".format(args.name))
+print("PYTHON VERSION  {}".format(args.python))
+print("CONDA FILE NAME {}".format(args.conda_file))
+print("CONDA PATH      {}".format(conda_path))
+
+# Write to a temp directory which will always be cleaned up
+with temp_cd():
+    temp_file_name = "temp_script.yaml"
+    with open(temp_file_name, 'w') as f:
+        f.write(yaml.dump(yaml_script))
+    sp.call("{} env create -n {} -f {}".format(conda_path, args.name, temp_file_name), shell=True)

--- a/examples/constant-force-optical-trap/force-bias-optical-trap.py
+++ b/examples/constant-force-optical-trap/force-bias-optical-trap.py
@@ -234,7 +234,7 @@ print("analysis took %f seconds" % elapsed_time)
 # compute observed and expected histograms at each state
 for l in range(0,K):
     # compute PMF at state l
-    results = mbar.computePMF(u_kln[:,l,:], bin_kn, nbins, return_dict=True)
+    results = mbar.computePMF(u_kln[:,l,:], bin_kn, nbins)
     f_i = results['f_i']
     df_i = results['df_i']
     # compute estimate of PMF including Jacobian term

--- a/examples/harmonic-oscillators/harmonic-oscillators-distributions.py
+++ b/examples/harmonic-oscillators/harmonic-oscillators-distributions.py
@@ -135,7 +135,7 @@ for replicate_index in range(0,nreplicates):
 
   # Initialize the MBAR class, determining the free energies.
   mbar = MBAR(u_kln, N_k, relative_tolerance=1.0e-10,verbose=False) # use fast Newton-Raphson solver
-  results = mbar.getFreeEnergyDifferences(return_dict=True)
+  results = mbar.getFreeEnergyDifferences()
   Deltaf_ij_estimated = results['Delta_f']
   dDeltaf_ij_estimated = results['dDelta_f']
 

--- a/examples/harmonic-oscillators/harmonic-oscillators.py
+++ b/examples/harmonic-oscillators/harmonic-oscillators.py
@@ -143,7 +143,7 @@ print("=============================================")
 print("      Testing getFreeEnergyDifferences       ")
 print("=============================================")
 
-results = mbar.getFreeEnergyDifferences(return_dict=True)
+results = mbar.getFreeEnergyDifferences()
 Delta_f_ij_estimated = results['Delta_f']
 dDelta_f_ij_estimated = results['dDelta_f']
 
@@ -175,7 +175,7 @@ for i in range(Knon-1):
   k1 = nonzero_indices[i+1]
   w_F = u_kln[k, k1, 0:N_k[k]]   - u_kln[k, k, 0:N_k[k]]       # forward work                                  
   w_R = u_kln[k1, k, 0:N_k[k1]] - u_kln[k1, k1, 0:N_k[k1]]    # reverse work                                  
-  results = BAR(w_F, w_R, return_dict=True)
+  results = BAR(w_F, w_R)
   df_bar = results['Delta_f']
   ddf_bar = results['dDelta_f']
   bar_analytical = (f_k_analytical[k1]-f_k_analytical[k]) 
@@ -191,7 +191,7 @@ print("EXP forward free energy")
 for k in range(K-1):
   if N_k[k] != 0:
     w_F = u_kln[k, k+1, 0:N_k[k]]   - u_kln[k, k, 0:N_k[k]]       # forward work
-    results = EXP(w_F, return_dict=True)
+    results = EXP(w_F)
     df_exp = results['Delta_f']
     ddf_exp = results['dDelta_f']
     exp_analytical = (f_k_analytical[k+1]-f_k_analytical[k]) 
@@ -203,7 +203,7 @@ print("EXP reverse free energy")
 for k in range(1,K):
   if N_k[k] != 0:
     w_R = u_kln[k, k-1, 0:N_k[k]] - u_kln[k, k, 0:N_k[k]]         # reverse work                                  
-    (df_exp,ddf_exp) = EXP(w_R, return_dict=True)
+    (df_exp,ddf_exp) = EXP(w_R)
     df_exp = -results['Delta_f']
     ddf_exp = results['dDelta_f']
     exp_analytical = (f_k_analytical[k]-f_k_analytical[k-1]) 
@@ -219,7 +219,7 @@ print("Gaussian forward estimate")
 for k in range(K-1):
   if N_k[k] != 0:
     w_F = u_kln[k, k+1, 0:N_k[k]]   - u_kln[k, k, 0:N_k[k]]       # forward work                                  
-    results = EXPGauss(w_F, return_dict=True)
+    results = EXPGauss(w_F)
     df_gauss = results['Delta_f']
     ddf_gauss = results['dDelta_f']
     gauss_analytical = (f_k_analytical[k+1]-f_k_analytical[k]) 
@@ -231,7 +231,7 @@ print("Gaussian reverse estimate")
 for k in range(1,K):
   if N_k[k] != 0:
     w_R = u_kln[k, k-1, 0:N_k[k]] - u_kln[k, k, 0:N_k[k]]         # reverse work                                  
-    results = EXPGauss(w_R, return_dict=True)
+    results = EXPGauss(w_R)
     df_gauss = results['Delta_f']
     ddf_gauss = results['dDelta_f']
     gauss_analytical = (f_k_analytical[k]-f_k_analytical[k-1]) 
@@ -287,7 +287,7 @@ for observe in observables:
     for k in range(0,K):
       A_kn[k,0:N_k[k]] = x_kn[k,0:N_k[k]]**2
 
-  results = mbar.computeExpectations(A_kn, state_dependent = state_dependent, return_dict=True)
+  results = mbar.computeExpectations(A_kn, state_dependent = state_dependent)
   A_k_estimated = results['mu']
   dA_k_estimated = results['sigma']
 
@@ -341,7 +341,7 @@ for observe in observables:
   stdevs = numpy.abs(As_k_error[Nk_ne_zero]/dAs_k_estimated[Nk_ne_zero])
   print(stdevs)
 
-  results = mbar.computeExpectations(A_kn, state_dependent = state_dependent, output = 'differences', return_dict=True)
+  results = mbar.computeExpectations(A_kn, state_dependent = state_dependent, output = 'differences')
   A_kl_estimated = results['mu']  
   dA_kl_estimated = results['sigma']
 
@@ -384,7 +384,7 @@ A_ikn = numpy.zeros([len(observables_single), K, N_k.max()], numpy.float64)
 for i,observe in enumerate(observables_single):
   A_ikn[i,:,:] = A_kn_all[observe]
 for i in range(K):
-  results = mbar.computeMultipleExpectations(A_ikn, u_kln[:,i,:], compute_covariance=True, return_dict=True)
+  results = mbar.computeMultipleExpectations(A_ikn, u_kln[:,i,:], compute_covariance=True)
   A_i = results['mu']
   dA_ij = results['sigma']
   Ca_ij = results['covariances']
@@ -399,7 +399,7 @@ print("============================================")
 print("      Testing computeEntropyAndEnthalpy")
 print("============================================")
 
-results = mbar.computeEntropyAndEnthalpy(u_kn = u_kln, verbose = True, return_dict=True)
+results = mbar.computeEntropyAndEnthalpy(u_kn = u_kln, verbose = True)
 Delta_f_ij = results['Delta_f']
 dDelta_f_ij = results['dDelta_f']
 Delta_u_ij = results['Delta_u']
@@ -468,7 +468,7 @@ for k in range(K):
     for l in range(L):
       unew_kln[k,l,0:N_k[k]] = (K_extra[l]/2.0) * (x_kn[k,0:N_k[k]]-O_extra[l])**2
 
-results = mbar.computePerturbedFreeEnergies(unew_kln, return_dict=True)
+results = mbar.computePerturbedFreeEnergies(unew_kln)
 Delta_f_ij_estimated = results['Delta_f']
 dDelta_f_ij_estimated = results['dDelta_f']
 
@@ -520,7 +520,7 @@ for observe in observables:
     A_kn = A_kn_all['position^2']
 
   A_k_estimated, dA_k_estimated 
-  results = mbar.computeExpectations(A_kn,unew_kln[:,[nth],:],state_dependent=state_dependent, return_dict=True)
+  results = mbar.computeExpectations(A_kn,unew_kln[:,[nth],:],state_dependent=state_dependent)
   A_k_estimated = results['mu'] 
   dA_k_estimated = results['sigma']
   # need to additionally transform to get the square root
@@ -544,7 +544,7 @@ print("============================================")
 print("      Testing computeOverlap   ")
 print("============================================")
 
-results = mbar.computeOverlap(return_dict=True)
+results = mbar.computeOverlap()
 O = results['scalar']
 O_i = results['eigenvalues']
 O_ij = results['matrix']
@@ -578,7 +578,7 @@ print("We should have that with MBAR, err_MBAR = sqrt(N_k/N_eff)*err_standard,")
 print("so standard (scaled) results should be very close to MBAR results.")
 print("No standard estimate exists for states that are not sampled.")
 A_kn = x_kn
-results = mbar.computeExpectations(A_kn, return_dict=True)
+results = mbar.computeExpectations(A_kn)
 val_mbar = results['mu']
 err_mbar = results['sigma']
 err_standard = numpy.zeros([K],dtype = numpy.float64)
@@ -745,7 +745,7 @@ for i in range(nbins):
 
 # Compute PMF.
 print("Computing PMF ...")
-results = mbar.computePMF(u_n, bin_n, nbins, uncertainties = 'from-specified', pmf_reference = zeroindex, return_dict=True)
+results = mbar.computePMF(u_n, bin_n, nbins, uncertainties = 'from-specified', pmf_reference = zeroindex)
 f_i = results['f_i']
 df_i = results['df_i']
 
@@ -834,7 +834,7 @@ for i in range(nbins):
 # Compute PMF.          
 print("Computing PMF ...")
 [f_i, df_i] 
-results = mbar.computePMF(u_n, bin_n, nbins, uncertainties = 'from-specified', pmf_reference = zeroindex, return_dict=True)
+results = mbar.computePMF(u_n, bin_n, nbins, uncertainties = 'from-specified', pmf_reference = zeroindex)
 f_i = results['f_i']
 df_i = results['df_i']
 

--- a/examples/heat-capacity/heat-capacity.py
+++ b/examples/heat-capacity/heat-capacity.py
@@ -281,23 +281,23 @@ for n in range(nBoots_work):
     E_kln = u_kln  # not a copy, we are going to write over it, but we don't need it any more.
     for k in range(K):
         E_kln[:,k,:]*=beta_k[k]**(-1)  # get the 'unreduced' potential -- we can't take differences of reduced potentials because the beta is different; math is much more confusing with derivatives of the reduced potentials.
-    results = mbar.computeExpectations(E_kln, state_dependent = True, return_dict=True)
+    results = mbar.computeExpectations(E_kln, state_dependent = True)
     E_expect = results['mu']
     dE_expect = results['sigma']
     allE_expect[:,n] = E_expect[:]
 
     # expectations for the differences, which we need for numerical derivatives
-    results = mbar.computeExpectations(E_kln,output='differences', state_dependent = True, return_dict=True)
+    results = mbar.computeExpectations(E_kln,output='differences', state_dependent = True)
     DeltaE_expect = results['mu']
     dDeltaE_expect = results['sigma']
     print("Computing Expectations for E^2...")
 
-    results = mbar.computeExpectations(E_kln**2, state_dependent = True, return_dict=True)
+    results = mbar.computeExpectations(E_kln**2, state_dependent = True)
     E2_expect = results['mu']
     dE2_expect = results['sigma']
     allE2_expect[:,n] = E2_expect[:]
 
-    results = mbar.getFreeEnergyDifferences(return_dict=True)
+    results = mbar.getFreeEnergyDifferences()
     df_ij = results['Delta_f']
     ddf_ij = results['dDelta_f']
 

--- a/examples/parallel-tempering-2dpmf/parallel-tempering-2dpmf.py
+++ b/examples/parallel-tempering-2dpmf/parallel-tempering-2dpmf.py
@@ -293,7 +293,7 @@ u_kn = target_beta * U_kn
 # f_i[i] is the dimensionless free energy of bin i (in kT) at the temperature of interest
 # df_i[i,j] is an estimate of the covariance in the estimate of (f_i[i] - f_j[j], with reference
 # the lowest free energy state.
-results = mbar.computePMF(u_kn, bin_kn, nbins, uncertainties='from-lowest', return_dict=True)
+results = mbar.computePMF(u_kn, bin_kn, nbins, uncertainties='from-lowest')
 f_i = results['f_i']
 df_i = results['df_i']
 

--- a/examples/umbrella-sampling-pmf/umbrella-sampling.py
+++ b/examples/umbrella-sampling-pmf/umbrella-sampling.py
@@ -147,7 +147,7 @@ print("Running MBAR...")
 mbar = pymbar.MBAR(u_kln, N_k, verbose = True)
 
 # Compute PMF in unbiased potential (in units of kT).
-results = mbar.computePMF(u_kn, bin_kn, nbins, return_dict=True)
+results = mbar.computePMF(u_kn, bin_kn, nbins)
 f_i = results['f_i']
 df_i = results['df_i']
 

--- a/pymbar/bar.py
+++ b/pymbar/bar.py
@@ -147,7 +147,7 @@ def BARzero(w_F, w_R, DeltaF):
     return fzero
 
 
-def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR',maximum_iterations=500, relative_tolerance=1.0e-12, verbose=False, method='false-position', iterated_solution=True, return_dict=False):
+def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR',maximum_iterations=500, relative_tolerance=1.0e-12, verbose=False, method='false-position', iterated_solution=True):
     """Compute free energy difference using the Bennett acceptance ratio (BAR) method.
 
     Parameters
@@ -176,17 +176,15 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
     iterated_solution : bool, optional, default=True
         whether to fully solve the optimized BAR equation to consistency, or to stop after one step, to be 
         equivalent to transition matrix sampling.
-    return_dict : bool, default False
-        If true, returns are a dict, else they are a tuple
 
     Returns
     -------
+    Results dictionary with the following keys:
+
     'Delta_f' : float
         Free energy difference
-        If return_dict, key is 'Delta_f'
     'dDelta_f': float
         Estimated standard deviation of free energy difference
-        If return_dict, key is 'dDelta_f'
 
 
     References
@@ -205,15 +203,15 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
 
     >>> from pymbar import testsystems
     >>> [w_F, w_R] = testsystems.gaussian_work_example(mu_F=None, DeltaF=1.0, seed=0)
-    >>> results = BAR(w_F, w_R, return_dict=True)
+    >>> results = BAR(w_F, w_R)
     >>> print('Free energy difference is {:.3f} +- {:.3f} kT'.format(results['Delta_f'], results['dDelta_f']))
     Free energy difference is 1.088 +- 0.050 kT
 
     Test completion of various other schemes.
 
-    >>> results = BAR(w_F, w_R, method='self-consistent-iteration', return_dict=True)
-    >>> results = BAR(w_F, w_R, method='false-position', return_dict=True)
-    >>> results = BAR(w_F, w_R, method='bisection', return_dict=True)
+    >>> results = BAR(w_F, w_R, method='self-consistent-iteration')
+    >>> results = BAR(w_F, w_R, method='false-position')
+    >>> results = BAR(w_F, w_R, method='bisection')
 
     """
 
@@ -230,8 +228,8 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
         nfunc = 0
 
     if method == 'bisection' or method == 'false-position':
-        UpperB = EXP(w_F, return_dict=True)['Delta_f']
-        LowerB = -EXP(w_R, return_dict=True)['Delta_f']
+        UpperB = EXP(w_F)['Delta_f']
+        LowerB = -EXP(w_R)['Delta_f']
 
         FUpperB = BARzero(w_F, w_R, UpperB)
         FLowerB = BARzero(w_F, w_R, LowerB)
@@ -244,15 +242,12 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
             if compute_uncertainty:
                 result_vals['Delta_f'] = 0.0 
                 result_vals['dDelta_f'] = 0.0
-                if return_dict:
-                    return result_vals
-                return 0.0, 0.0
+                return result_vals
+
             else:
                 result_vals['Delta_f'] = 0.0
-                if return_dict:
-                    return result_vals
-                return 0.0
-
+                return result_vals
+            
         while FUpperB * FLowerB > 0:
             # if they have the same sign, they do not bracket.  Widen the bracket until they have opposite signs.
             # There may be a better way to do this, and the above bracket should rarely fail.
@@ -347,7 +342,9 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
 
         Compute asymptotic variance estimate using Eq. 10a of Bennett,
         1976 (except with n_1<f>_1^2 in the second denominator, it is
-        an error in the original NOTE: The 'BAR' and 'MBAR' estimators
+        an error in the original.
+
+        NOTE: The 'BAR' and 'MBAR' estimators
         do not agree for poor overlap. This is not because of
         numerical precision, but because they are fundamentally
         different estimators. For poor overlap, 'MBAR' diverges high,
@@ -493,16 +490,13 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
             print("DeltaF = {:8.3f} +- {:8.3f}".format(DeltaF, dDeltaF))
         result_vals['Delta_f'] = DeltaF
         result_vals['dDelta_f'] = dDeltaF
-        if return_dict:
-            return result_vals
-        return DeltaF, dDeltaF
+        return result_vals
+
     else:
         if verbose:
             print("DeltaF = {:8.3f}".format(DeltaF))
         result_vals['Delta_f'] = DeltaF
-        if return_dict:
-            return result_vals
-        return DeltaF
+        return result_vals
 
 #=============================================================================================
 # For compatibility with 2.0.1-beta

--- a/pymbar/exp.py
+++ b/pymbar/exp.py
@@ -51,7 +51,7 @@ from pymbar.utils import logsumexp
 # One-sided exponential averaging (EXP).
 #=============================================================================================
 
-def EXP(w_F, compute_uncertainty=True, is_timeseries=False, return_dict=False):
+def EXP(w_F, compute_uncertainty=True, is_timeseries=False):
     """Estimate free energy difference using one-sided (unidirectional) exponential averaging (EXP).
 
     Parameters
@@ -63,17 +63,13 @@ def EXP(w_F, compute_uncertainty=True, is_timeseries=False, return_dict=False):
     is_timeseries : bool, default=False
         if True, correlation in data is corrected for by estimation of statisitcal inefficiency (default: False)
         Use this option if you are providing correlated timeseries data and have not subsampled the data to produce uncorrelated samples.
-    return_dict : bool, default False
-        If true, returns are a dictionary, else they are a tuple
 
     Returns
     -------
     'Delta_f' : float
         Free energy difference
-        If return_dict, key is 'Delta_f'
     'dDelta_f': float
         Estimated standard deviation of free energy difference
-        If return_dict, key is 'dDelta_f'
 
     Notes
     -----
@@ -86,17 +82,16 @@ def EXP(w_F, compute_uncertainty=True, is_timeseries=False, return_dict=False):
 
     >>> from pymbar import testsystems
     >>> [w_F, w_R] = testsystems.gaussian_work_example(mu_F=None, DeltaF=1.0, seed=0)
-    >>> results = EXP(w_F, return_dict=True)
+    >>> results = EXP(w_F)
     >>> print('Forward free energy difference is %.3f +- %.3f kT' % (results['Delta_f'], results['dDelta_f']))
     Forward free energy difference is 1.088 +- 0.076 kT
-    >>> results = EXP(w_R, return_dict=True)
+    >>> results = EXP(w_R)
     >>> print('Reverse free energy difference is %.3f +- %.3f kT' % (results['Delta_f'], results['dDelta_f']))
     Reverse free energy difference is -1.073 +- 0.082 kT
 
     """
 
     result_vals = dict()
-    result_list = []
 
     # Get number of work measurements.
     T = float(np.size(w_F))  # number of work measurements
@@ -128,20 +123,16 @@ def EXP(w_F, compute_uncertainty=True, is_timeseries=False, return_dict=False):
         # Return estimate of free energy difference and uncertainty.
         result_vals['Delta_f'] = DeltaF
         result_vals['dDelta_f'] = dDeltaF
-        result_list.append(DeltaF)
-        result_list.append(dDeltaF)
     else:
         result_vals['Delta_f'] = DeltaF
-        result_list.append(DeltaF)
-    if return_dict:
-        return result_vals
-    return tuple(result_list)
+
+    return result_vals
 
 #=============================================================================================
 # Gaussian approximation to exponential averaging (Gauss).
 #=============================================================================================
 
-def EXPGauss(w_F, compute_uncertainty=True, is_timeseries=False, return_dict=False):
+def EXPGauss(w_F, compute_uncertainty=True, is_timeseries=False):
     """Estimate free energy difference using gaussian approximation to one-sided (unidirectional) exponential averaging.
 
     Parameters
@@ -153,17 +144,15 @@ def EXPGauss(w_F, compute_uncertainty=True, is_timeseries=False, return_dict=Fal
     is_timeseries : bool, default=False
         if True, correlation in data is corrected for by estimation of statisitcal inefficiency (default: False)
         Use this option if you are providing correlated timeseries data and have not subsampled the data to produce uncorrelated samples.
-    return_dict : bool, default False
-        If true, returns are a dictionary, else they are a tuple
 
     Returns
     -------
+    Results dictionary with keys:
     'Delta_f' : float
         Free energy difference between the two states
-        If return_dict, key is 'Delta_f'
     'dDelta_f': float
         Estimated standard deviation of free energy difference between the two states.
-        If return_dict, key is 'dDelta_f'
+
 
     Notes
     -----
@@ -175,10 +164,10 @@ def EXPGauss(w_F, compute_uncertainty=True, is_timeseries=False, return_dict=Fal
 
     >>> from pymbar import testsystems
     >>> [w_F, w_R] = testsystems.gaussian_work_example(mu_F=None, DeltaF=1.0, seed=0)
-    >>> results = EXPGauss(w_F, return_dict=True)
+    >>> results = EXPGauss(w_F)
     >>> print('Forward Gaussian approximated free energy difference is %.3f +- %.3f kT' % (results['Delta_f'], results['dDelta_f']))
     Forward Gaussian approximated free energy difference is 1.049 +- 0.089 kT
-    >>> results = EXPGauss(w_R, return_dict=True)
+    >>> results = EXPGauss(w_R)
     >>> print('Reverse Gaussian approximated free energy difference is %.3f +- %.3f kT' % (results['Delta_f'], results['dDelta_f']))
     Reverse Gaussian approximated free energy difference is -1.073 +- 0.080 kT
 
@@ -192,7 +181,6 @@ def EXPGauss(w_F, compute_uncertainty=True, is_timeseries=False, return_dict=Fal
     DeltaF = np.average(w_F) - 0.5 * var
 
     result_vals = dict()
-    result_list = []
     if compute_uncertainty:
         # Compute effective number of uncorrelated samples.
         g = 1.0  # statistical inefficiency
@@ -210,14 +198,9 @@ def EXPGauss(w_F, compute_uncertainty=True, is_timeseries=False, return_dict=Fal
         # Return estimate of free energy difference and uncertainty.
         result_vals['Delta_f'] = DeltaF
         result_vals['dDelta_f'] = dDeltaF
-        result_list.append(DeltaF)
-        result_list.append(dDeltaF)
     else:
         result_vals['Delta_f'] = DeltaF
-        result_list.append(DeltaF)
-    if return_dict:
-        return result_vals
-    return tuple(result_list)
+    return result_vals
 
 #=============================================================================================
 # For compatibility with 2.0.1-beta

--- a/pymbar/mbar.py
+++ b/pymbar/mbar.py
@@ -226,16 +226,30 @@ class MBAR:
 
         # perform consistency checks on the data.
 
-        # if, for any set of data, all reduced potential energies are the same,
-        # they are probably the same state.  We check to within
-        # relative_tolerance.
-
         self.samestates = []
         if self.verbose:
+
+            # if, for any set of data, all reduced potential energies are the same,
+            # they are probably the same state.
+            #
+            # This can take quite a while, so we do it on just
+            # the first few data points.
+            #
+            # determine if there are less than 50 points to compare energies.
+            # (the number 50 is pretty arbitrary)
+            # If so, use that number instead of 50.
+
+            maxpoint = 50
+            if np.sum(self.N_k) < maxpoint:
+                maxpoint = np.sum(self.N_k[k])
+
+            # this could possibly be made faster with np.unique(axis=0,return_indices=True)
+            # but not clear if needed.
+
             for k in range(K):
                 for l in range(k):
                     diffsum = 0
-                    uzero = u_kn[k, :] - u_kn[l, :]
+                    uzero = u_kn[k, :maxpoint] - u_kn[l, :maxpoint]
                     diffsum += np.dot(uzero, uzero)
                     if (diffsum < relative_tolerance):
                         self.samestates.append([k, l])

--- a/pymbar/tests/test_covariance.py
+++ b/pymbar/tests/test_covariance.py
@@ -25,9 +25,9 @@ def _test(data_generator):
     name, U, N_k, s_n = data_generator()
     print(name)
     mbar = pymbar.MBAR(U, N_k)
-    results1 = mbar.getFreeEnergyDifferences(uncertainty_method="svd", return_dict=True)
-    fij1_t, dfij1_t = mbar.getFreeEnergyDifferences(uncertainty_method="svd", return_dict=False)
-    results2 = mbar.getFreeEnergyDifferences(uncertainty_method="svd-ew", return_dict=True)
+    results1 = mbar.getFreeEnergyDifferences(uncertainty_method="svd")
+    fij1_t, dfij1_t = mbar.getFreeEnergyDifferences(uncertainty_method="svd")
+    results2 = mbar.getFreeEnergyDifferences(uncertainty_method="svd-ew")
     fij1 = results1['Delta_f']
     dfij1 = results1['dDelta_f']
     fij2 = results2['Delta_f']

--- a/pymbar/tests/test_mbar.py
+++ b/pymbar/tests/test_mbar.py
@@ -71,13 +71,9 @@ def test_mbar_free_energies():
         eq(N_k, N_k_output)
         mbar = MBAR(u_kn, N_k)
 
-        results = mbar.getFreeEnergyDifferences(return_dict=True)
-        fe_t, dfe_t = mbar.getFreeEnergyDifferences(return_dict=False)
+        results = mbar.getFreeEnergyDifferences()
         fe = results['Delta_f']
         fe_sigma = results['dDelta_f']
-
-        eq(fe, fe_t)
-        eq(fe_sigma, dfe_t)
 
         fe, fe_sigma = fe[0,1:], fe_sigma[0,1:]
 
@@ -96,13 +92,9 @@ def test_mbar_computeExpectations_position_averages():
         x_n, u_kn, N_k_output, s_n = test.sample(N_k, mode='u_kn')
         eq(N_k, N_k_output)
         mbar = MBAR(u_kn, N_k)
-        results = mbar.computeExpectations(x_n, return_dict=True)
-        mu_t, sigma_t = mbar.computeExpectations(x_n, return_dict=False)
+        results = mbar.computeExpectations(x_n)
         mu = results['mu']
         sigma = results['sigma' ]
-
-        eq(mu, mu_t)
-        eq(sigma, sigma_t)
 
         mu0 = test.analytical_observable(observable = 'position')
 
@@ -118,7 +110,7 @@ def test_mbar_computeExpectations_position_differences():
         x_n, u_kn, N_k_output, s_n = test.sample(N_k, mode='u_kn')
         eq(N_k, N_k_output)
         mbar = MBAR(u_kn, N_k)
-        results = mbar.computeExpectations(x_n, output = 'differences', return_dict=True)
+        results = mbar.computeExpectations(x_n, output = 'differences')
         mu_ij = results['mu'] 
         sigma_ij = results['sigma'] 
 
@@ -135,7 +127,7 @@ def test_mbar_computeExpectations_position2():
         x_n, u_kn, N_k_output, s_n = test.sample(N_k, mode='u_kn')
         eq(N_k, N_k_output)
         mbar = MBAR(u_kn, N_k)
-        results = mbar.computeExpectations(x_n ** 2, return_dict=True)
+        results = mbar.computeExpectations(x_n ** 2)
         mu = results['mu']
         sigma = results['sigma'] 
         mu0 = test.analytical_observable(observable = 'position^2')
@@ -152,7 +144,7 @@ def test_mbar_computeExpectations_potential():
         x_n, u_kn, N_k_output, s_n = test.sample(N_k, mode='u_kn')
         eq(N_k, N_k_output)
         mbar = MBAR(u_kn, N_k)
-        results = mbar.computeExpectations(u_kn, state_dependent = True, return_dict=True)
+        results = mbar.computeExpectations(u_kn, state_dependent = True)
         mu = results['mu']
         sigma = results['sigma'] 
         mu0 = test.analytical_observable(observable = 'potential energy')
@@ -174,12 +166,10 @@ def test_mbar_computeMultipleExpectations():
         A[0,:] = x_n
         A[1,:] = x_n**2
         state = 1
-        results = mbar.computeMultipleExpectations(A,u_kn[state,:], return_dict=True)
-        mu_t, sigma_t = mbar.computeMultipleExpectations(A,u_kn[state,:], return_dict=False)
+        results = mbar.computeMultipleExpectations(A,u_kn[state,:])
         mu = results['mu']
         sigma = results['sigma']
-        eq(mu, mu_t)
-        eq(sigma, sigma_t)
+
         mu0 = test.analytical_observable(observable = 'position')[state]
         mu1 = test.analytical_observable(observable = 'position^2')[state]
         z = (mu0 - mu[0]) / sigma[0]
@@ -196,21 +186,13 @@ def test_mbar_computeEntropyAndEnthalpy():
         x_n, u_kn, N_k_output, s_n = test.sample(N_k, mode='u_kn')
         eq(N_k, N_k_output)
         mbar = MBAR(u_kn, N_k)
-        results =  mbar.computeEntropyAndEnthalpy(u_kn, return_dict=True)
-        f_t, df_t, u_t, du_t, s_t, ds_t = mbar.computeEntropyAndEnthalpy(u_kn, return_dict=False)
+        results =  mbar.computeEntropyAndEnthalpy(u_kn)
         f_ij = results['Delta_f'] 
         df_ij = results['dDelta_f'] 
         u_ij = results['Delta_u'] 
         du_ij = results['dDelta_u']  
         s_ij = results['Delta_s'] 
         ds_ij = results['dDelta_s']
-
-        eq(f_ij, f_t)
-        eq(df_ij, df_t)
-        eq(u_ij, u_t)
-        eq(du_ij, du_t)
-        eq(s_ij, s_t)
-        eq(ds_ij, ds_t)
 
         fa = test.analytical_free_energies()
         ua = test.analytical_observable('potential energy')
@@ -254,15 +236,10 @@ def test_mbar_computeOverlap():
     x_n, u_kn, N_k_output, s_n = test.sample(even_N_k, mode='u_kn')
     mbar = MBAR(u_kn, even_N_k)
 
-    results = mbar.computeOverlap(return_dict=True)
-    os_t, eig_t, O_t = mbar.computeOverlap(return_dict=False)
+    results = mbar.computeOverlap()
     overlap_scalar = results['scalar']
     eigenval = results['eigenvalues']
     O = results['matrix']
-
-    eq(overlap_scalar, os_t)
-    eq(eigenval, eig_t)
-    eq(O, O_t)
 
     reference_matrix = np.matrix((1.0/d)*np.ones([d,d]))
     reference_eigenvalues = np.zeros(d)
@@ -310,13 +287,9 @@ def test_mbar_computePerturbedFreeEnergeies():
         x_n, u_kn, N_k_output, s_n = test.sample(N_k, mode='u_kn')
         numN = np.sum(N_k[:2])
         mbar = MBAR(u_kn[:2,:numN], N_k[:2])  # only do MBAR with the first and last set
-        results = mbar.computePerturbedFreeEnergies(u_kn[2:,:numN], return_dict=True)
-        f_t, df_t = mbar.computePerturbedFreeEnergies(u_kn[2:, :numN], return_dict=False)
+        results = mbar.computePerturbedFreeEnergies(u_kn[2:,:numN])
         fe = results['Delta_f']
         fe_sigma = results['dDelta_f']
-
-        eq(fe, f_t)
-        eq(fe_sigma, df_t)
 
         fe, fe_sigma = fe[0,1:], fe_sigma[0,1:]
 
@@ -345,13 +318,9 @@ def test_mbar_computePMF():
     bin_n[within_bounds] = 1 + np.floor((x_n[within_bounds]-xmin)/dx)
     # 0 is reserved for samples outside the domain.  We will ignore this state
     range = np.max(bin_n)+1
-    results = mbar.computePMF(u_kn[refstate,:], bin_n, range, uncertainties = 'from-specified', pmf_reference = 1, return_dict=True)
-    f_t, df_t = mbar.computePMF(u_kn[refstate,:], bin_n, range, uncertainties = 'from-specified', pmf_reference = 1, return_dict=False)
+    results = mbar.computePMF(u_kn[refstate,:], bin_n, range, uncertainties = 'from-specified', pmf_reference = 1)
     f_i = results['f_i']
     df_i = results['df_i']
-
-    eq(f_i, f_t)
-    eq(df_i, df_t)
 
     f0_i = 0.5*test.K_k[refstate]*(bin_centers-test.O_k[refstate])**2
     f_i, df_i = f_i[2:], df_i[2:] # first state is ignored, second is zero, with zero uncertainty

--- a/pymbar/tests/test_mbar_solvers.py
+++ b/pymbar/tests/test_mbar_solvers.py
@@ -83,7 +83,7 @@ def test_protocols():
             mbar = pymbar.MBAR(u_kn, N_k, solver_protocol=({'method': solver_protocol},))
             # Solve MBAR with the correct f_k used for the inital weights
             mbar = pymbar.MBAR(u_kn, N_k, initial_f_k=mbar.f_k, solver_protocol=({'method': solver_protocol},))
-            results = mbar.getFreeEnergyDifferences(return_dict=True)
+            results = mbar.getFreeEnergyDifferences()
             fe = results['Delta_f'][0,1:]
             fe_sigma = results['dDelta_f'][0,1:]
             z = (fe - fa) / fe_sigma


### PR DESCRIPTION
Reduce the cost of checking for duplicate states. Previously, all of the samples was compared, which is unnecessary; this PR has it just check the first 50 samples in all states (unless there are les than 50 total samples), which is much faster.  This is almost certainly sufficient in essentially all cases.  This is an optional test that only occurs with verbose on.

This could potentially be made shorter and a little faster with clever use of numpy.unique(), but it's not clear that would really help that much besides shortening the number of lines code, since with this change, the speed cost is mostly removed. numpy unique does an unnecessary sort as well.