### PR TITLE
Reused the gradient calculation in the adaptive algorithm.

### DIFF
--- a/pymbar/mbar_solvers.py
+++ b/pymbar/mbar_solvers.py
@@ -287,8 +287,13 @@ def adaptive(u_kn, N_k, f_k, tol = 1.0e-12, options = None):
     f_nr = np.zeros(len(f_k), dtype=np.float64)
 
     # Perform Newton-Raphson iterations (with sci computed on the way)
+
+    # usually calculated at the end of the loop and saved, but we need
+    # to calculate the first time.
+    g = mbar_gradient(u_kn, N_k, f_k)  # Objective function gradient.
+
     for iteration in range(0, options['maximum_iterations']):
-        g = mbar_gradient(u_kn, N_k, f_k)  # Objective function gradient
+
         H = mbar_hessian(u_kn, N_k, f_k)  # Objective function hessian
         Hinvg = np.linalg.lstsq(H, g, rcond=-1)[0]
         Hinvg -= Hinvg[0]
@@ -313,6 +318,7 @@ def adaptive(u_kn, N_k, f_k, tol = 1.0e-12, options = None):
         f_old = f_k
         if (gnorm_sci < gnorm_nr or sci_iter < 2):
             f_k = f_sci
+            g = g_sci
             sci_iter += 1
             if options['verbose']:
                 if sci_iter < 2:
@@ -321,6 +327,7 @@ def adaptive(u_kn, N_k, f_k, tol = 1.0e-12, options = None):
                     print("Choosing self-consistent iteration for lower gradient on iteration %d" % iteration)
         else:
             f_k = f_nr
+            g = g_nr
             nr_iter += 1
             if options['verbose']:
                 print("Newton-Raphson used on iteration %d" % iteration)


### PR DESCRIPTION
The adaptive algorithm was calculating the gradient an extra type per cycle.  It needs to calculate the gradient twice, to figure out how close the self-consistent iteration and NR steps are, but it was calculating it again a third time to start the loop.  Now, it instead stores the gradient that has the lowest norm for the next cycle. It turns out that hessian calculations are not that much slower than gradient calculations in many cases, so eliminating the gradient call helps.

This reduces the number of gradient calls by 1/3 with no loss of accuracy. For a sample large problem (500 states, 1000 samples / state) it reduced the total time taken by ~10%, which is good for 3 lines of code and no loss of accuracy.