### PR TITLE
Reduce the cost of check for duplicate states

### DIFF
--- a/pymbar/mbar.py
+++ b/pymbar/mbar.py
@@ -226,16 +226,30 @@ class MBAR:
 
         # perform consistency checks on the data.
 
-        # if, for any set of data, all reduced potential energies are the same,
-        # they are probably the same state.  We check to within
-        # relative_tolerance.
-
         self.samestates = []
         if self.verbose:
+
+            # if, for any set of data, all reduced potential energies are the same,
+            # they are probably the same state.
+            #
+            # This can take quite a while, so we do it on just
+            # the first few data points.
+            #
+            # determine if there are less than 50 points to compare energies.
+            # (the number 50 is pretty arbitrary)
+            # If so, use that number instead of 50.
+
+            maxpoint = 50
+            if np.sum(self.N_k) < maxpoint:
+                maxpoint = np.sum(self.N_k[k])
+
+            # this could possibly be made faster with np.unique(axis=0,return_indices=True)
+            # but not clear if needed.
+
             for k in range(K):
                 for l in range(k):
                     diffsum = 0
-                    uzero = u_kn[k, :] - u_kn[l, :]
+                    uzero = u_kn[k, :maxpoint] - u_kn[l, :maxpoint]
                     diffsum += np.dot(uzero, uzero)
                     if (diffsum < relative_tolerance):
                         self.samestates.append([k, l])

--- a/pymbar/mbar.py
+++ b/pymbar/mbar.py
@@ -236,20 +236,23 @@ class MBAR:
             # the first few data points.
             #
             # determine if there are less than 50 points to compare energies.
-            # (the number 50 is pretty arbitrary)
             # If so, use that number instead of 50.
+            # (the number 50 is pretty arbitrary)
 
             maxpoint = 50
-            if np.sum(self.N_k) < maxpoint:
-                maxpoint = np.sum(self.N_k[k])
+            if self.N < maxpoint:
+                maxpoint = self.N
 
             # this could possibly be made faster with np.unique(axis=0,return_indices=True)
             # but not clear if needed.
 
+            # pick random indices
+            indices = np.random.choice(np.arange(self.N),maxpoint)
+
             for k in range(K):
                 for l in range(k):
                     diffsum = 0
-                    uzero = u_kn[k, :maxpoint] - u_kn[l, :maxpoint]
+                    uzero = u_kn[k, indices] - u_kn[l, indices]
                     diffsum += np.dot(uzero, uzero)
                     if (diffsum < relative_tolerance):
                         self.samestates.append([k, l])


### PR DESCRIPTION
Reduce the cost of checking for duplicate states. Previously, all of the samples was compared, which is unnecessary; this PR has it just check the first 50 samples in all states (unless there are les than 50 total samples), which is much faster. This is almost certainly sufficient in essentially all cases. This is an optional test that only occurs with verbose on.

This could potentially be made shorter and a little faster with clever use of numpy.unique(), but it's not clear that would really help that much besides shortening the number of lines code, since with this change, the speed cost is mostly removed. numpy unique does an unnecessary sort as well.