### PR TITLE
Start Coverage Improvements (Mbar.py)

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,11 @@
 # Codecov configuration to make it a bit less noisy
 coverage:
+  ignore:
+    - pymbar/tests/.*
+    - pymbar/testsystems/.*
+    - setup.py
+    - pymbar/version.py
+    - pymbar/old_mbar.py
   status:
     patch: false
     project:

--- a/pymbar/mbar.py
+++ b/pymbar/mbar.py
@@ -72,7 +72,7 @@ class MBAR:
     # =========================================================================
 
     def __init__(self, u_kn, N_k, maximum_iterations=10000, relative_tolerance=1.0e-7, verbose=False, initial_f_k=None,
-                 solver_protocol=None, initialize='zeros', x_kindices=None, **kwargs):
+                 solver_protocol=None, initialize='zeros', x_kindices=None):
         """Initialize multistate Bennett acceptance ratio (MBAR) on a set of simulation data.
 
         Upon initialization, the dimensionless free energies for all states are computed.
@@ -181,8 +181,6 @@ class MBAR:
         >>> mbar = MBAR(u_kn, N_k)
 
         """
-        for key, val in kwargs.items():
-            print("Warning: parameter {}={} is unrecognized and unused.".format(key, val))
 
         # Store local copies of necessary data.
         # N_k[k] is the number of samples from state k, some of which might be zero.
@@ -1629,7 +1627,7 @@ class MBAR:
             V = Vt.T
 
             # Compute covariance
-            Theta = V @ Sigma * self._pseudoinverse(
+            Theta = V @ Sigma @ self._pseudoinverse(
                 I - Sigma @ V.T @ Ndiag @ V @ Sigma) @ Sigma @ V.T
 
         elif method == 'svd-ew':
@@ -1714,7 +1712,7 @@ class MBAR:
                     # kickstart NR.
                     import pymbar.bar
                     self.f_k[l] = self.f_k[k] + pymbar.bar.BAR(
-                        w_F, w_R, relative_tolerance=0.000001, verbose=False, compute_uncertainty=False)
+                        w_F, w_R, relative_tolerance=0.000001, verbose=False, compute_uncertainty=False)['Delta_f']
                 else:
                     # no states observed, so we don't need to initialize this free energy anyway, as
                     # the solution is noniterative.


### PR DESCRIPTION
This PR starts the coverage improvements for the package as a whole.
The focus here is on the mbar.py file as well as some initial ignores
for the CodeCov configs.

I also found and fixed 2 bugs with this:
- `svd` method missed a `@` operator (introduced in #334 by me)
- "BAR" init method failed due to dict return.

One outstanding question I have is the `computeCovarianceOfSums`
function. It's not used anywhere in the code and the last time it was
used was some time ago (I can go find the commit again if need be).
GitHub also does not seem to think anyone other than PyMBAR clones
use the function either.
If we want to keep this function around, is there a decent test which
can be written for it? The one I added simply runs it, not sure if its
accurate though.