### PR TITLE
Even more coverage! [WIP]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ pip-log.txt
 .coverage
 .tox
 nosetests.xml
+coverage.xml
+htmlcov
 
 # Translations
 *.mo

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -16,4 +16,5 @@ dependencies:
   - pytest-cov
   - codecov
   - statsmodels
+  - scikit-learn  # Provides the sklearn module
 

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -9,7 +9,6 @@ dependencies:
   - numpy >=1.12
   - scipy
   - numexpr
-  - six
 
     # Testing
   - pytest

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -9,7 +9,6 @@ requirements:
   build:
     - python
     - setuptools
-    - six
     - numpy 1.11.*
     - toolchain
   run:
@@ -17,7 +16,6 @@ requirements:
     - numpy >=1.12
     - scipy
     - numexpr
-    - six
 
 test:
   requires:

--- a/pymbar/pmf.py
+++ b/pymbar/pmf.py
@@ -382,7 +382,10 @@ class PMF:
 
             self.kdes = list()
 
-            from sklearn.neighbors import KernelDensity
+            try:
+                from sklearn.neighbors import KernelDensity
+            except ImportError:
+                raise ImportError("Cannot use 'kde' type PMF without the scikit-learn module. Could not import sklearn")
             kde = KernelDensity()
             # get the default params to set them.
             kde_defaults = kde.get_params()
@@ -1170,10 +1173,11 @@ class PMF:
             if self.nbootstraps == 0:
                 df_i = None
             else:
-                fall = np.zeros([len(x), self.nbootstraps])
+                dim_breakdown = [d for d in x.shape] + [self.nbootstraps]
+                fall = np.zeros(dim_breakdown)
                 for b in range(self.nbootstraps):
-                    fall[:, b] = self.pmf_functions[b](x) - fmin
-                df_i = np.std(fall, axis=1)
+                    fall[:, :, b] = self.pmf_functions[b](x) - fmin
+                df_i = np.std(fall, axis=-1)
 
             # uncertainites "from normalization" reference is applied, since
             # the density is normalized.

--- a/pymbar/pmf.py
+++ b/pymbar/pmf.py
@@ -225,8 +225,19 @@ class PMF:
 
         self.mbar = pmf_mbar
 
+        self._random = np.random
+        self._seed = None
+
         if self.verbose:
             print("PMF initialized")
+
+    @property
+    def seed(self):
+        return self._seed
+
+    def reset_random(self):
+        self._random = np.random
+        self._seed = None
 
     def generatePMF(
             self,
@@ -236,9 +247,8 @@ class PMF:
             histogram_parameters=None,
             kde_parameters=None,
             spline_parameters=None,
-            uncertainties='from-lowest',
             nbootstraps=0,
-            nseed=-1,
+            seed=-1,
             ):
         """
         Given an intialized MBAR object, a set of points,
@@ -286,8 +296,17 @@ class PMF:
             - 'nspline': number of spline points
             - 'kdegree': degree of the spline.  Default is cubic ('3')
             - 'objective': - 'ml','map' # whether to fit the maximum likelihood or the maximum a posteriori
-        
-        Returns:
+
+        nbootstraps : int, 0 or > 1, Default: 0
+            Number of bootstraps to create an uncertainty estimate. If 0, no bootstrapping is done.
+
+        seed : int, Default: -1
+            Set the randomization seed. This does not ensure true randomization, but should get the randomization
+            (assuming the same calls are made in the same order) to return the same numbers.
+            This is local to this class and will not change any other random objects.
+
+        Returns
+        -------
 
             - result_vals: dictionary of results.
 
@@ -343,10 +362,14 @@ class PMF:
 
         self.u_n = u_n
 
-        if nseed >= 0:
-            np.random.seed(nseed)
+        if seed >= 0:
+            # Set a better seeded random state
+            self._random = np.random.RandomState(seed=seed)
+            self._seed = seed
 
         # we need to save this for calculating uncertainties.
+        if not np.issubdtype(type(nbootstraps), np.integer) or nbootstraps == 1:
+            raise ValueError(f"nbootstraps must be an integer of 0 or >=2, it was set to {nbootstraps}")
         self.nbootstraps = nbootstraps
 
         if self.timings:
@@ -473,7 +496,7 @@ class PMF:
                     scipy_tol = None # this is just the default anyway.
                 if spline_parameters['optimization_algorithm'] not in [
                         'Newton-CG', 'CG', 'BFGS', 'L-BFGS-B', 'TNC', 'SLSQP']:
-                    raise ParameterErrorr(
+                    raise ParameterError(
                         'Optimization method {:s} is not supported'.format(
                             spline_parameters['optimization_algorithm']))
             else:
@@ -484,12 +507,11 @@ class PMF:
 
             if spline_parameters['spline_initialize'] == 'bias_free_energies':
 
+                initivals = self.mbar.f_k
                 # initialize to the bias free energies
                 if 'bias_centers' in spline_parameters:  # if we are provided bias center, use them
                     bias_centers = spline_parameters['bias_centers']
                     sort_indices = np.argsort(bias_centers)
-                    initivals = self.mbar.f_k
-
                     K = self.mbar.K
                     if K < 2 * nspline:
                         noverfit = int(np.round(K / 2))
@@ -500,18 +522,18 @@ class PMF:
                         tinit[noverfit + 1:noverfit + kdegree + 1] = xrange[1]
                         # problem: bin centers might not actually be sorted.
                         binit = make_lsq_spline(
-                            bias_centers[sort_indices], initvals[sort_indices],
+                            bias_centers[sort_indices], initivals[sort_indices],
                             tinit, k=kdegree)
                         xinit = np.linspace(xrange[0], xrange[1], num=2 * nspline)
                         yinit = binit(xinit)
                     else:
                         xinit = bias_centers[sort_indices]
-                        yinit = initvals[sort_indices]
+                        yinit = initivals[sort_indices]
                 else:
                     # assume equally spaced bias scenters
                     xinit = np.linspace(
                         xrange[0], xrange[1], self.mbar.K + 1)[1:-1]
-                    yinit = initvals
+                    yinit = initivals
 
             elif spline_parameters['spline_initialize'] == 'explicit':
                 if 'xinit' in spline_parameters:
@@ -602,7 +624,7 @@ class PMF:
             else:
                 index = 0
                 for k in range(K):
-                    bootstrap_indices[index:index + N_k[k]] = index + np.random.randint(0, N_k[k], size=N_k[k])
+                    bootstrap_indices[index:index + N_k[k]] = index + self._random.randint(0, N_k[k], size=N_k[k])
                     index += N_k[k]
                     # recompute MBAR.
                     mbar = pymbar.MBAR(
@@ -930,7 +952,7 @@ class PMF:
                 raise DataError(
                     'coordinates have inconsistent dimension with the PMF.')
 
-        if uncertainties is 'from-specified' and pmf_reference is None:
+        if uncertainties == 'from-specified' and pmf_reference is None:
             raise ParameterError(
                 "No reference state specified for PMF using uncertainties = from-specified")
 
@@ -982,11 +1004,14 @@ class PMF:
 
                 df_i = np.zeros(len(self.histogram_data['f']), np.float64)
                 
-                if (uncertainties == 'from-lowest'):
+                if uncertainties == 'from-lowest':
                     # Determine bin index with lowest free energy.
                     j = self.histogram_data['f'].argmin()
-                elif (uncertainties == 'from-specified'):
+                elif uncertainties == 'from-specified':
                     j = self.histogram_data['fbin_index'][tuple(pmf_ref_grid)]
+                elif uncertainties == 'all-differences':
+                    raise ParameterError("Uncertainty method of 'all-differences' is not yet supported for histogram "
+                                         "PMF types (not implemented)")
 
                 if self.nbootstraps == 0:
                     # Compute uncertainties in free energy at each gridpoint by
@@ -1032,23 +1057,25 @@ class PMF:
                 raise ParameterError(
                     'uncertainty method \'from-normalization\' is not currently supported for histograms')
 
-                # Compute bin probabilities p_i
-                p_i = np.exp(-self.fbin - logsumexp(-self.fbin))
+                # Currently unreachable code
 
-                # todo -- eliminate triple loop over nbins!
-                # Compute uncertainties in bin probabilities.
-                d2p_i = np.zeros([nbins], np.float64)
-                for k in range(nbins):
-                    for i in range(nbins):
-                        for j in range(nbins):
-                            delta_ik = 1.0 * (i == k)
-                            delta_jk = 1.0 * (j == k)
-                            d2p_i[k] += p_i[k] * (p_i[i] - delta_ik) * p_i[k] * (
-                                p_i[j] - delta_jk) * Theta_ij[K + i, K + j]
-
-                # Transform from d2p_i to df_i
-                d2f_i = d2p_i / p_i ** 2
-                df_i = np.sqrt(d2f_i)
+                # # Compute bin probabilities p_i
+                # p_i = np.exp(-self.fbin - logsumexp(-self.fbin))
+                #
+                # # todo -- eliminate triple loop over nbins!
+                # # Compute uncertainties in bin probabilities.
+                # d2p_i = np.zeros([nbins], np.float64)
+                # for k in range(nbins):
+                #     for i in range(nbins):
+                #         for j in range(nbins):
+                #             delta_ik = 1.0 * (i == k)
+                #             delta_jk = 1.0 * (j == k)
+                #             d2p_i[k] += p_i[k] * (p_i[i] - delta_ik) * p_i[k] * (
+                #                 p_i[j] - delta_jk) * Theta_ij[K + i, K + j]
+                #
+                # # Transform from d2p_i to df_i
+                # d2f_i = d2p_i / p_i ** 2
+                # df_i = np.sqrt(d2f_i)
 
             fx_vals = np.zeros(len(x))
             dfx_vals = np.zeros(len(x))
@@ -1085,7 +1112,7 @@ class PMF:
                 result_vals['df_i'] = dfx_vals
 
             if uncertainties == 'all-differences':
-                if nbootstraps == 0:
+                if self.nbootstraps == 0:
                     # Report uncertainties in all free energy differences as
                     # well.
                     diag = Theta_ij.diagonal()
@@ -1144,6 +1171,8 @@ class PMF:
                 fmin = - \
                     self.kde.score_samples(np.array(pmf_reference).reshape(1, -1))
                 f_i = f_i - fmin
+            else:
+                raise ParameterError(f"Uncertainty method {uncertainties} for kde is unavailable")
 
             if self.nbootstraps == 0:
                 df_i = None
@@ -1168,7 +1197,7 @@ class PMF:
 
             elif uncertainties == 'from-specified':
                 fmin = - \
-                    self.pmf_functions(np.array(pmf_reference).reshape(1, -1))
+                    self.pmf_function(np.array(pmf_reference).reshape(1, -1))
                 f_i = f_i - fmin
             if self.nbootstraps == 0:
                 df_i = None
@@ -1507,9 +1536,9 @@ class PMF:
 
         self.cold = self.bspline.c
         psize = len(self.cold)
-        rchange = stepsize * np.random.normal()
+        rchange = stepsize * self._random.normal()
         cnew = self.cold.copy()
-        ci = np.random.randint(psize)
+        ci = self._random.randint(psize)
         cnew[ci] += rchange
         self.newspline.c = cnew
 
@@ -1531,7 +1560,7 @@ class PMF:
         if dlogposterior <= 0:
             accept = True
         if dlogposterior > 0:
-            if np.random.random() < np.exp(-dlogposterior):
+            if self._random.random() < np.exp(-dlogposterior):
                 accept = True
 
         if accept:
@@ -1867,7 +1896,7 @@ class PMF:
         """ 
         wrapper for integration in case we decide to replace quad with something analytical
         """
-        if method is 'quad':
+        if method == 'quad':
             # just use scipy quadrature
             results = quad(func,xlow,xhigh,args)[0]
         else:
@@ -1893,9 +1922,9 @@ class PMF:
         xnew[0] = (self.bspline).c[0]
         xnew[1:] = x
         bspline = BSpline((self.bspline).t, xnew, (self.bspline).k)
-        if form is 'exp':
+        if form == 'exp':
             return lambda x: -np.log(bspline(x))
-        elif form is 'log':
+        elif form == 'log':
             return bspline
         elif form is None: 
             return bspline

--- a/pymbar/tests/test_mbar_solvers.py
+++ b/pymbar/tests/test_mbar_solvers.py
@@ -20,7 +20,7 @@ def base_oscillator():
      (200, 50, exponentials)]
 )
 def test_solvers(statesa, statesb, test_system):
-    name, U, N_k, s_n = test_system(statesa, statesb)
+    name, U, N_k, s_n, _ = test_system(statesa, statesb, provide_test=True)
     print(name)
     mbar = pymbar.MBAR(U, N_k)
     assert_almost_equal(pymbar.mbar_solvers.mbar_gradient(U, N_k, mbar.f_k), np.zeros(N_k.shape), decimal=8)

--- a/pymbar/tests/test_pmf.py
+++ b/pymbar/tests/test_pmf.py
@@ -4,16 +4,24 @@ from pymbar import MBAR
 from pymbar import PMF
 from pymbar.testsystems import harmonic_oscillators, exponential_distributions
 from pymbar.utils_for_testing import assert_equal, assert_almost_equal
-import pdb
+try:
+    import sklearn
+    has_sklearn = True
+except ImportError:
+    has_sklearn = False
+
 
 beta = 1.0
 z_scale_factor = 12.0
 
-def generate_pmf_data(ndim=1, nbinsperdim=15, nsamples=1000, K0=20.0, Ku=100.0, gridscale=0.2, xrange=[[-3,3]]):
 
-    x0 = np.zeros([ndim]) # center of base potential
+def generate_pmf_data(ndim=1, nsamples=1000, K0=20.0, Ku=100.0, gridscale=0.2, xrange=None):
+
+    x0 = np.zeros([ndim])  # center of base potential
     numbrellas = 1
-    nperdim = np.zeros([ndim],int)
+    nperdim = np.zeros([ndim], int)
+    if xrange is None:
+        xrange = [[-3, 3]] * ndim
     for d in range(ndim):
         nperdim[d] = xrange[d][1] - xrange[d][0] + 1
         numbrellas *= nperdim[d]
@@ -25,12 +33,12 @@ def generate_pmf_data(ndim=1, nbinsperdim=15, nsamples=1000, K0=20.0, Ku=100.0, 
 
     ksum = (Ku+K0)/beta
     kprod = (Ku*K0)/(beta*beta)
-    f_k_analytical = np.zeros(numbrellas);
-    xu_i = np.zeros([numbrellas, ndim]) # xu_i[i,:] is the center of umbrella i
+    f_k_analytical = np.zeros(numbrellas)
+    xu_i = np.zeros([numbrellas, ndim])  # xu_i[i,:] is the center of umbrella i
     
-    dp = np.zeros(ndim,int)
+    dp = np.zeros(ndim, int)
     dp[0] = 1
-    for d in range(1,ndim):
+    for d in range(1, ndim):
         dp[d] = nperdim[d]*dp[d-1]
 
     umbrella_zero = 0
@@ -40,10 +48,10 @@ def generate_pmf_data(ndim=1, nbinsperdim=15, nsamples=1000, K0=20.0, Ku=100.0, 
             val = gridscale*((int(i//dp[d])) % nperdim[d] + xrange[d][0])
             center.append(val)
         center = np.array(center)
-        xu_i[i,:] = center
-        mu2 = np.dot(center,center)
-        f_k_analytical[i] = np.log((ndim*np.pi/ksum)**(3.0/2.0) *np.exp(-kprod*mu2/(2.0*ksum)))
-        if np.all(center==0.0):  # assumes that we have one state that is at the zero.
+        xu_i[i, :] = center
+        mu2 = np.dot(center, center)
+        f_k_analytical[i] = np.log((ndim*np.pi/ksum)**(3.0/2.0) * np.exp(-kprod*mu2/(2.0*ksum)))
+        if np.all(center == 0.0):  # assumes that we have one state that is at the zero.
             umbrella_zero = i
         i += 1
         f_k_analytical -= f_k_analytical[umbrella_zero]
@@ -59,50 +67,66 @@ def generate_pmf_data(ndim=1, nbinsperdim=15, nsamples=1000, K0=20.0, Ku=100.0, 
             # c = C(a/A+b/B)
             # A = 1/K0, B = 1/Ku
             sigma = 1.0 / (K0 + Ku)
-            mu = sigma * (x0[dim]*K0 + xu_i[i,dim]*Ku)
+            mu = sigma * (x0[dim]*K0 + xu_i[i, dim]*Ku)
             # Generate normal deviates for this dimension.
-            x_n[i*nsamples:(i+1)*nsamples,dim] = np.random.normal(mu, np.sqrt(sigma), [nsamples])
+            x_n[i*nsamples:(i+1)*nsamples, dim] = np.random.normal(mu, np.sqrt(sigma), [nsamples])
 
     u_kn = np.zeros([numbrellas, nsamples*numbrellas])
     # Compute reduced potential due to V0.
-    u_n = beta*(K0/2)*np.sum((x_n[:,:] - x0)**2, axis=1)
+    u_n = beta*(K0/2)*np.sum((x_n[:, :] - x0)**2, axis=1)
     for k in range(numbrellas):
-        uu = beta*(Ku/2)*np.sum((x_n[:,:] - xu_i[k,:])**2, axis=1) # reduced potential due to umbrella k
-        u_kn[k,:] = u_n + uu
+        uu = beta*(Ku/2)*np.sum((x_n[:, :] - xu_i[k, :])**2, axis=1)  # reduced potential due to umbrella k
+        u_kn[k, :] = u_n + uu
 
     pmf_const = K0/2.0  # using a quadratic surface, so has same multpliciative value everywhere.
 
+    def bias_potential(x, k_bias):
+        dx = x - xu_i[k_bias, :]
+        return beta*(Ku/2.0) * np.dot(dx, dx)
 
-    def bias_potential(x,k):
-        dx = x - xu_i[k,:]
-        return beta*(Ku/2.0) * np.dot(dx,dx)
-
-    bias_potentials = [(lambda x, klocal=k: bias_potential(x,klocal)) for k in range(numbrellas)]
+    bias_potentials = [(lambda x, klocal=k: bias_potential(x, klocal)) for k in range(numbrellas)]
 
     return u_kn, u_n, x_n, f_k_analytical, pmf_const, bias_potentials
 
 
-def test_pmf_getPMF_1d():
+@pytest.fixture(scope='module')
+def pmf_1d():
 
-    """ testing pmf_generatePMF and pmf_getPMF in 1D """
-
-    gridscale = 0.2 
+    gridscale = 0.2
     nbinsperdim = 15
-    xrange = [[-3,3]]
+    xrange = [[-3, 3]]
     ndim = 1
     nsamples = 1000
+    K0 = 20.0
+    Ku = 100
+
+    payload = {
+        'gridscale': gridscale,
+        'nbinsperdim': nbinsperdim,
+        'xrange': xrange,
+        'ndim': ndim,
+        'nsamples': nsamples,
+        'K0': K0,
+        'Ku': Ku
+    }
+
     u_kn, u_n, x_n, f_k_analytical, pmf_const, bias_potentials = generate_pmf_data(
-        K0=20.0, Ku = 100.0, ndim=ndim, nbinsperdim=nbinsperdim, nsamples=nsamples, gridscale=gridscale, xrange=xrange)
+        K0=K0,
+        Ku=Ku,
+        ndim=ndim,
+        nsamples=nsamples,
+        gridscale=gridscale,
+        xrange=xrange)
     numbrellas = (np.shape(u_kn))[0]
-    N_k = nsamples*np.ones([numbrellas], int)
-    
+    N_k = nsamples * np.ones([numbrellas], int)
+
     # Histogram bins are indexed using the scheme:
-    xmin = gridscale*(np.min(xrange[0][0])-1/2.0)
-    xmax = gridscale*(np.max(xrange[0][1])+1/2.0)
-    dx = (xmax-xmin)/nbinsperdim
-    nbins = nbinsperdim**ndim
-    bin_edges = [np.linspace(xmin,xmax,nbins+1)] # list of bin edges.
-    bin_centers = np.zeros([nbins,ndim])
+    xmin = gridscale * (np.min(xrange[0][0]) - 1 / 2.0)
+    xmax = gridscale * (np.max(xrange[0][1]) + 1 / 2.0)
+    dx = (xmax - xmin) / nbinsperdim
+    nbins = nbinsperdim ** ndim
+    bin_edges = [np.linspace(xmin, xmax, nbins + 1)]  # list of bin edges.
+    bin_centers = np.zeros([nbins, ndim])
 
     ibin = 0
     pmf_analytical = np.zeros([nbins])
@@ -111,84 +135,121 @@ def test_pmf_getPMF_1d():
     # construct the bins and the pmf
     for i in range(nbins):
         xbin = xmin + dx * (i + 0.5)
-        bin_centers[ibin,0] = xbin
-        mu2 = xbin*xbin
+        bin_centers[ibin, 0] = xbin
+        mu2 = xbin * xbin
         if (mu2 < minmu2):
             minmu2 = mu2
             zeroindex = ibin
-        pmf_analytical[ibin] = pmf_const*mu2
+        pmf_analytical[ibin] = pmf_const * mu2
         ibin += 1
     fzero = pmf_analytical[zeroindex]
     pmf_analytical -= fzero
-    bin_n = -1*np.ones([numbrellas*nsamples], int)
+    bin_n = -1 * np.ones([numbrellas * nsamples], int)
 
     # Determine indices of those within bounds.
-    within_bounds = (x_n[:,0] >= xmin) & (x_n[:,0] < xmax)
+    within_bounds = (x_n[:, 0] >= xmin) & (x_n[:, 0] < xmax)
     # Determine states for these.
-    bin_n[within_bounds] = np.floor((x_n[within_bounds,0]-xmin)/dx)
+    bin_n[within_bounds] = np.floor((x_n[within_bounds, 0] - xmin) / dx)
     # Determine indices of bins that are not empty.
     bin_counts = np.zeros([nbins], int)
     for i in range(nbins):
         bin_counts[i] = (bin_n == i).sum()
-    # Compute PMF.
-    # print("Solving for free energies of state to initialize PMF...")
-    pmf = PMF(u_kn,N_k)
-    # print("Computing PMF ...")
+
+    pmf = PMF(u_kn, N_k)
+
+    payload['pmf'] = pmf
+    payload['u_kn'] = u_kn
+    payload['N_k'] = N_k
+    payload['u_n'] = u_n
+    payload['x_n'] = x_n
+    payload['dx'] = dx
+    payload['nbins'] = nbins
+    payload['bin_edges'] = bin_edges
+    payload['bin_centers'] = bin_centers
+    payload['pmf_const'] = pmf_const
+    payload['pmf_analytical'] = pmf_analytical
+    payload['f_k_analytical'] = f_k_analytical
+    payload['bias_potentials'] = bias_potentials
+
+    return payload
+
+
+def test_1d_pmf_histogram(pmf_1d):
+
+    pmf = pmf_1d['pmf']
 
     histogram_parameters = dict()
-    histogram_parameters['bin_edges'] = bin_edges
-    pmf.generatePMF(u_n, x_n, histogram_parameters = histogram_parameters)
-    results = pmf.getPMF(bin_centers, uncertainties='from-specified', pmf_reference = 0.0)
+    histogram_parameters['bin_edges'] = pmf_1d['bin_edges']
+    pmf.generatePMF(pmf_1d['u_n'], pmf_1d['x_n'], histogram_parameters=histogram_parameters)
+    results = pmf.getPMF(pmf_1d['bin_centers'], uncertainties='from-specified', pmf_reference=0.0)
     f_ih = results['f_i']
     df_ih = results['df_i']
 
-    z = np.zeros(nbins)
-    for i in range(0,nbins):
+    z = np.zeros(pmf_1d['nbins'])
+    for i in range(0, pmf_1d['nbins']):
         if df_ih[i] != 0:
-            z[i] = np.abs(pmf_analytical[i]-f_ih[i])/df_ih[i]
+            z[i] = np.abs(pmf_1d['pmf_analytical'][i]-f_ih[i])/df_ih[i]
         else:
             z[i] = 0
     assert_almost_equal(z / z_scale_factor, np.zeros(len(z)), decimal=0)
 
-    # now KDE
-    #kde_parameters = dict()
-    #kde_parameters['bandwidth'] = 0.5*dx
-    #pmf.generatePMF(u_n, x_n, pmf_type = 'kde', kde_parameters = kde_parameters)
-    #results_kde = pmf.getPMF(bin_centers, uncertainties='from-specified', pmf_reference = 0.0)
-    #f_ik = results_kde['f_i']
-    ## no analytical undertainty for kde yet
 
-    #for i in range(0,nbins):
-    #    if df_ih[i] != 0:
-    #        z[i] = np.abs(pmf_analytical[i]-f_ik[i])/df_ih[i]
-    #    else:
-    #        z[i] = 0
-    #assert_almost_equal(z / z_scale_factor, np.zeros(len(z)), decimal=0)
+@pytest.mark.skipif(not has_sklearn, reason="Must have sklearn installed to use KDE type PMF")
+def test_1d_pmf_kde(pmf_1d):
+
+    pmf = pmf_1d['pmf']
+
+    kde_parameters = dict()
+    kde_parameters['bandwidth'] = 0.5*pmf_1d['dx']
+    # no analytical uncertainty for kde yet, have to use bootstraps
+    pmf.generatePMF(pmf_1d['u_n'], pmf_1d['x_n'], pmf_type='kde', kde_parameters=kde_parameters, nbootstraps=10)
+    results_kde = pmf.getPMF(pmf_1d['bin_centers'], uncertainties='from-specified', pmf_reference=0.0)
+    f_ik = results_kde['f_i']
+    df_ih = results_kde['df_i']  # Bootstrapped
+
+    z = np.zeros(pmf_1d['nbins'])
+    for i in range(0, pmf_1d['nbins']):
+       if df_ih[i] != 0:
+           z[i] = np.abs(pmf_1d['pmf_analytical'][i]-f_ik[i])/df_ih[i]
+       else:
+           z[i] = 0
+    assert_almost_equal(z / z_scale_factor, np.zeros(len(z)), decimal=0)
+
+
+def test_1d_pmf_spline(pmf_1d):
+
+    pmf = pmf_1d['pmf']
+    bin_centers = pmf_1d['bin_centers']
+    pmf_analytical = pmf_1d['pmf_analytical']
 
     # now spline
     spline_parameters = dict()
-    spline_parameters['spline_weights'] = 'simplesum' # fastest spline method
+    spline_parameters['spline_weights'] = 'simplesum'  # fastest spline method
     spline_parameters['nspline'] = 4
     spline_parameters['spline_initialize'] = 'explicit'
 
-    spline_parameters['xinit'] = bin_centers[:,0]
-    spline_parameters['yinit'] = pmf_analytical #(cheat by starting with "true" answer - for speed)
+    spline_parameters['xinit'] = bin_centers[:, 0]
+    spline_parameters['yinit'] = pmf_analytical  # cheat by starting with "true" answer - for speed
 
-    spline_parameters['xrange'] = xrange[0]
-    spline_parameters['fkbias'] = bias_potentials
+    spline_parameters['xrange'] = pmf_1d['xrange'][0]
+    spline_parameters['fkbias'] = pmf_1d['bias_potentials']
 
     spline_parameters['kdegree'] = 3
     spline_parameters['optimization_algorithm'] = 'Newton-CG'
-    spline_parameters['optimize_options'] = {'disp':True, 'tol':10**(-6)}
+    spline_parameters['optimize_options'] = {'disp': True, 'tol': 10**(-6)}
     spline_parameters['objective'] = 'ml'
     spline_parameters['map_data'] = None
 
-    pmf.generatePMF(u_kn, x_n, pmf_type = 'spline', spline_parameters=spline_parameters)
-    results_spline = pmf.getPMF(bin_centers, uncertainties='from-lowest') # sometthing wrong with unbiased state?
+    # TODO: Is this u_kn for spline or u_n like all the others? Right now I have it as u_kn as thats what it was
+    # no analytical uncertainty for kde yet, have to use bootstraps
+    pmf.generatePMF(pmf_1d['u_kn'], pmf_1d['x_n'], pmf_type='spline', spline_parameters=spline_parameters,
+                    nbootstraps=1)
+    results_spline = pmf.getPMF(bin_centers, uncertainties='from-lowest')  # something wrong with unbiased state?
     f_is = results_spline['f_i']
-    # no analytical undertainty for spline
+    df_ih = results_spline['df_i']  # Bootstrapped
 
-    for i in range(0,nbins):
+    z = np.zeros(pmf_1d['nbins'])
+    for i in range(0, pmf_1d['nbins']):
         if df_ih[i] != 0:
             z[i] = np.abs(pmf_analytical[i]-f_is[i])/df_ih[i]
         else:
@@ -207,7 +268,7 @@ def test_pmf_getPMF_2d():
     gridscale = 0.2
 
     u_kn, u_n, x_n, f_k_analytical, pmf_const, bias_potentials = generate_pmf_data(
-        K0=20.0, Ku=100.0, ndim=ndim, nbinsperdim = nbinsperdim, nsamples = nsamples, gridscale = gridscale, xrange=xrange)
+        K0=20.0, Ku=100.0, ndim=ndim, nsamples = nsamples, gridscale = gridscale, xrange=xrange)
     numbrellas = (np.shape(u_kn))[0]
     N_k = nsamples*np.ones([numbrellas], int)
     # print("Solving for free energies of state ...")

--- a/pymbar/tests/test_utils.py
+++ b/pymbar/tests/test_utils.py
@@ -1,6 +1,8 @@
 import numpy as np
+import pytest
 import pymbar
 from pymbar.utils_for_testing import assert_equal, assert_almost_equal
+from pymbar.utils import ParameterError, ensure_type, TypeCastPerformanceWarning
 try:
     from scipy.special import logsumexp
 except ImportError:
@@ -16,6 +18,13 @@ def test_logsumexp():
         ans_scipy = logsumexp(a, axis=axis)
         assert_equal(ans_ne, ans_no_ne)
         assert_equal(ans_ne, ans_scipy)
+
+
+def test_logsumexp_single_infinite():
+    a = np.inf
+    ans = pymbar.utils.logsumexp(a)
+    ans_scipy = logsumexp(a)
+    assert_equal(ans, ans_scipy)
 
 
 def test_logsumexp_b():
@@ -35,3 +44,92 @@ def test_logsum():
     y1 = pymbar.utils.logsumexp(u)
     y2 = pymbar.utils._logsum(u)
     assert_almost_equal(y1, y2, decimal=12)
+
+
+@pytest.mark.xfail(raises=ParameterError)
+def test_non_normalized_w_badrow():
+    w = np.array([[0.5, 0.5,
+                   0.75, 0.25]])
+    n_k = np.array([1, 1])
+    pymbar.utils.check_w_normalized(w, n_k)
+
+
+@pytest.mark.xfail(raises=ParameterError)
+def test_non_normalized_w_badcol():
+    w = np.array([[0.5, 0.5],
+                  [0.5, 0.5]])
+    n_k = np.array([1, 0])
+    pymbar.utils.check_w_normalized(w, n_k)
+
+
+@pytest.mark.parametrize('fn_args_and_kwargs,expected,warn',
+                         [
+                             ({'val': None, 'dtype': int, 'ndim': 1, 'name': 'thetest', 'can_be_none': True}, None, None),
+                             ({'val': 0, 'dtype': int, 'ndim': 1, 'name': 'thetest', 'add_newaxis_on_deficient_ndim': True}, np.array([0]), None),
+                             pytest.param({'val': 0, 'dtype': int, 'ndim': 1, 'name': 'thetest', 'add_newaxis_on_deficient_ndim': False}, 'Should Fail', None, marks=pytest.mark.xfail),
+                             pytest.param({'val': [], 'dtype': int, 'ndim': 1, 'name': 'thetest', 'add_newaxis_on_deficient_ndim': True}, 'Should Fail', None, marks=pytest.mark.xfail),
+                             ({'val': np.array([1.0]), 'dtype': int, 'ndim': 1, 'name': 'thetest', 'warn_on_cast': True}, np.array([1]), TypeCastPerformanceWarning),
+                             ({'val': np.array([1]), 'dtype': int, 'ndim': 2, 'name': 'thetest', 'add_newaxis_on_deficient_ndim': True}, np.array([[1]]), None),
+                             pytest.param({'val': np.array([1]), 'dtype': int, 'ndim': 3, 'name': 'thetest', 'add_newaxis_on_deficient_ndim': True}, 'Should Fail', None, marks=pytest.mark.xfail),
+                             pytest.param({'val': np.array([1, 2, 3]), 'dtype': int, 'ndim': 1, 'name': 'thetest', 'length': 4}, 'Should Fail', None, marks=pytest.mark.xfail),
+                             ({'val': np.array([[1, 2, 3], [4, 5, 6]]), 'dtype': int, 'ndim': 2, 'name': 'thetest', 'shape': (2, 3)}, np.array([[1, 2, 3], [4, 5, 6]]), None),
+                             ({'val': np.array([[1, 2, 3], [4, 5, 6]]), 'dtype': int, 'ndim': 2, 'name': 'thetest', 'shape': (None, 3)}, np.array([[1, 2, 3], [4, 5, 6]]), None),
+                             pytest.param({'val': np.array([[1, 2, 3], [4, 5, 6]]), 'dtype': int, 'ndim': 2, 'name': 'thetest', 'shape': (2,)}, 'Should Fail', None, marks=pytest.mark.xfail),
+                             pytest.param({'val': np.array([[1, 2, 3], [4, 5, 6]]), 'dtype': int, 'ndim': 2, 'name': 'thetest', 'shape': (3, 1)}, 'Should Fail', None, marks=pytest.mark.xfail),
+
+                         ])
+def test_type_ensure(fn_args_and_kwargs, expected, warn):
+    if warn is not None:
+        with pytest.warns(warn):
+            ret = ensure_type(**fn_args_and_kwargs)
+    else:
+        ret = ensure_type(**fn_args_and_kwargs)
+    if isinstance(ret, np.ndarray):
+        assert np.allclose(ret, expected)
+        assert ret.shape == expected.shape
+    else:
+        assert ret == expected
+
+
+@pytest.mark.parametrize("n_k", [None, np.array([3]*3)])
+def test_kln_to_nk_to_k(n_k):
+    # 3 samples per state
+    # 3 states
+    # Samples energies are (state index + 1)*(relative state index)
+    u_kln = np.array([
+        # k=0
+        [[0, 0, 0],  # l=0: n=1*0
+         [1, 1, 1],  # l=1: n=1*1
+         [2, 2, 2]  # l=2: n=1*2
+        ],
+        # k=1
+        [[-2, -2, -2],  # l=0: n=2*-1
+         [0, 0, 0],  # l=1: n=2*0
+         [2, 2, 2]  # l=2: n=2*1
+        ],
+        # k=2
+        [[-6, -6, -6],  # l=0: n=3*-2
+         [-3, -3, -3],  # l=1: n=3*-1
+         [0, 0, 0]  # l=2: n=3*0
+         ],
+    ]
+    )
+    u_kn = np.array(
+        [   # n 1 2 3...
+            [0, 0, 0, -2, -2, -2, -6, -6, -6],  # k = 0
+            [1, 1, 1,  0,  0,  0, -3, -3, -3],  # k = 1
+            [2, 2, 2,  2,  2,  2,  0,  0,  0]   # k = 3
+        ]
+    )
+    u_n = np.array(
+        [0, 0, 0, -2, -2, -2, -6, -6, -6, 1, 1, 1,  0,  0,  0, -3, -3, -3, 2, 2, 2,  2,  2,  2,  0,  0,  0]
+    )
+    u_kn_out = pymbar.utils.kln_to_kn(u_kln, N_k=n_k, cleanup=True)
+    assert np.allclose(u_kn, u_kn_out)
+    if n_k is not None:
+        # Because we're testing both None _and_ set N_k, we have to assume the u_kn we fed in was reset for
+        # this second test. If we didn't, then the behavior for N_k=None is ambiguous or assumes things about
+        # a state (programming/object) it has no knowledge of.
+        n_k = np.array([9]*3)
+    u_n_out = pymbar.utils.kn_to_n(u_kn, N_k=n_k, cleanup=True)
+    assert np.allclose(u_n, u_n_out)

--- a/pymbar/utils.py
+++ b/pymbar/utils.py
@@ -23,15 +23,10 @@
 # imports
 ##############################################################################
 
-from six.moves import zip_longest
+from itertools import zip_longest
 import warnings
 import numpy as np
-
-try:  # numexpr used in logsumexp when available.
-    import numexpr
-    HAVE_NUMEXPR = True
-except ImportError:
-    HAVE_NUMEXPR = False
+import numexpr
 
 
 ##############################################################################
@@ -43,26 +38,22 @@ class TypeCastPerformanceWarning(RuntimeWarning):
     pass
 
 
-def kln_to_kn(kln, N_k = None, cleanup = False):
+def kln_to_kn(kln, N_k=None, cleanup=False):
 
     """ Convert KxKxN_max array to KxN max array
-
-    if self.N is not initialized, it will be here.
 
     Parameters
     ----------
     u_kln : np.ndarray, float, shape=(KxLxN_max)
-    N_k (optional) : np.array
+    N_k : np.array, optional
         the N_k matrix from the previous formatting form
-    cleanup (optional) : bool
+    cleanup : bool, optional
         optional command to clean up, since u_kln can get very large
 
     Outputs
     -------
     u_kn: np.ndarray, float, shape=(LxN)
     """
-
-    #print "warning: KxLxN_max arrays deprecated; convering into new preferred KxN shape"
 
     # rewrite into kn shape
     [K, L, N_max] = np.shape(kln)
@@ -85,16 +76,16 @@ def kln_to_kn(kln, N_k = None, cleanup = False):
     return kn
 
 
-def kn_to_n(kn, N_k = None, cleanup = False):
+def kn_to_n(kn, N_k=None, cleanup=False):
 
     """ Convert KxN_max array to N array
 
     Parameters
     ----------
     u_kn: np.ndarray, float, shape=(KxN_max)
-    N_k (optional) : np.array
+    N_k : np.array, optional
         the N_k matrix from the previous formatting form
-    cleanup (optional) : bool
+    cleanup : bool, optional
         optional command to clean up, since u_kln can get very large
 
     Outputs
@@ -268,6 +259,7 @@ def _logsum(a_n):
 
     return log_sum
 
+
 def logsumexp(a, axis=None, b=None, use_numexpr=True):
     """Compute the log of the sum of exponentials of input elements.
 
@@ -313,12 +305,12 @@ def logsumexp(a, axis=None, b=None, use_numexpr=True):
 
     if b is not None:
         b = np.asarray(b)
-        if use_numexpr and HAVE_NUMEXPR:
+        if use_numexpr:
             out = np.log(numexpr.evaluate("b * exp(a - a_max)").sum(axis))
         else:
             out = np.log(np.sum(b * np.exp(a - a_max), axis=axis))
     else:
-        if use_numexpr and HAVE_NUMEXPR:
+        if use_numexpr:
             out = np.log(numexpr.evaluate("exp(a - a_max)").sum(axis))
         else:
             out = np.log(np.sum(np.exp(a - a_max), axis=axis))

--- a/pymbar/utils_for_testing.py
+++ b/pymbar/utils_for_testing.py
@@ -19,13 +19,11 @@
 # You should have received a copy of the MIT License along with pymbar.
 ##############################################################################
 
-import os
 import numpy as np
 from numpy.testing import (assert_allclose, assert_almost_equal,
                            assert_approx_equal, assert_array_almost_equal, assert_array_almost_equal_nulp,
                            assert_array_equal, assert_array_less, assert_array_max_ulp, assert_equal,
                            assert_raises, assert_string_equal, assert_warns)
-from pkg_resources import resource_filename
 import warnings
 import contextlib
 
@@ -35,7 +33,7 @@ __all__ = ['assert_allclose', 'assert_almost_equal', 'assert_approx_equal',
            'assert_array_almost_equal', 'assert_array_almost_equal_nulp',
            'assert_array_equal', 'assert_array_less', 'assert_array_max_ulp',
            'assert_equal', 'assert_raises', 'assert_string_equal', 'assert_warns',
-           'get_fn', 'suppress_derivative_warnings_for_tests', 'suppress_matrix_warnings_for_tests',
+           'suppress_derivative_warnings_for_tests', 'suppress_matrix_warnings_for_tests',
            'oscillators', 'exponentials']
 
 ##############################################################################
@@ -67,29 +65,6 @@ def suppress_matrix_warnings_for_tests():
     yield
     # Clear warning filters
     warnings.resetwarnings()
-
-
-def get_fn(name):
-    """Get the full path to one of the reference files shipped for testing
-
-    In the source distribution, these files are in ``MDTraj/testing/reference``,
-    but on installation, they're moved to somewhere in the user's python
-    site-packages directory.
-
-    Parameters
-    ----------
-    name : str
-        Name of the file to load (with respect to the reference/ folder).
-
-    """
-
-    fn = resource_filename('mdtraj', os.path.join('testing/reference', name))
-
-    if not os.path.exists(fn):
-        raise ValueError('Sorry! {} does not exists. If you just '
-                         'added it, you\'ll have to re install'.format(fn))
-
-    return fn
 
 
 def oscillators(n_states, n_samples, provide_test=False):

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,8 @@ description-file = README.md
 
 [aliases]
 test = pytest
+
+[tool:pytest]
+filterwarnings =
+    ignore::DeprecationWarning:patsy.*
+    ignore::PendingDeprecationWarning

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ from setuptools import setup, Extension, find_packages
 import numpy
 import os
 import subprocess
-import six
 
 ##########################
 VERSION = "3.0.5"
@@ -106,7 +105,6 @@ def buildKeywordDictionary():
     setupKeywords["zip_safe"]          = False
     #setupKeywords["py_modules"]        = ["pymbar", "timeseries", "testsystems", "confidenceintervals"]
     setupKeywords["data_files"]        = [('pymbar', ["pymbar/_pymbar.c"])]  # Ensures the _pymbar.c files are shipped regardless of Py Version
-    setupKeywords["ext_modules"]       = [CMBAR] if six.PY2 else []
     # setupKeywords["test_suite"]        = "tests" # requires we migrate to setuptools
     setupKeywords["platforms"]         = ["Linux", "Mac OS X", "Windows"]
     setupKeywords["description"]       = "Python implementation of the multistate Bennett acceptance ratio (MBAR) method."


### PR DESCRIPTION
This PR works to bring even more coverage of tests. I got utils coverage all the way up. However, I want to discuss the plan for PMF and some of the other choices I plan on making:

* The PMF module has many code paths which I can explore and test. Do we want to run down all of them? 
* For PMF methods without analytical errors, do we want to rely on the bootstrap to test them? I started doing this, but adding many bootstraps will significantly slow down the process.
* My IDE caught a bunch of syntax typos which were not hit in the tests, I'll try to fix them as I run into them.
* The Spline PMF test makes this call: 
    ```python
    pmf.generatePMF(u_kn, x_n,...)
    ```
    which uses `u_kn` instead of `u_n` like the histogram and KDE tests. I don't know if that was a typo so I wanted to ask.
* I assumed `numexpr` is required since we do require it in both the Conda env/recipe and in the setup.py
* I dropped the old `get_fn` which wasn't used and I think left over from copying the MDTraj utilities a long while back
* I plan on completely dropping `six` as a dependency, any objections?