### PR TITLE
From print to logging

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "python.linting.enabled": true,
+    "python.linting.pylintEnabled": true,
+    "python.pythonPath": "/home/jaime/.conda/envs/pymbar/bin/python"
+}

--- a/pymbar/bar.py
+++ b/pymbar/bar.py
@@ -46,10 +46,15 @@ __license__ = "MIT"
 #=============================================================================================
 # IMPORTS
 #=============================================================================================
+import logging
 import numpy as np
 import numpy.linalg
 from pymbar.utils import ParameterError, ConvergenceError, BoundsError, logsumexp
 from pymbar.exp import EXP
+
+
+logger = logging.getLogger(__name__)
+
 
 def BARzero(w_F, w_R, DeltaF):
     """A function that when zeroed is equivalent to the solution of
@@ -120,7 +125,7 @@ def BARzero(w_F, w_R, DeltaF):
         log_f_F = - max_arg_F - np.log(np.exp(-max_arg_F) + np.exp(exp_arg_F - max_arg_F))
     except:
         # give up; if there's overflow, return zero
-        print("The input data results in overflow in BAR")
+        logger.info("The input data results in overflow in BAR")
         return np.nan
     log_numer = logsumexp(log_f_F)
 
@@ -136,7 +141,7 @@ def BARzero(w_F, w_R, DeltaF):
     try:
         log_f_R = - max_arg_R - np.log(np.exp(-max_arg_R) + np.exp(exp_arg_R - max_arg_R))
     except:
-        print("The input data results in overflow in BAR")
+        logger.info("The input data results in overflow in BAR")
         return np.nan
     log_denom = logsumexp(log_f_R)
 
@@ -244,7 +249,7 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
         if (np.isnan(FUpperB) or np.isnan(FLowerB)):
             # this data set is returning NAN -- will likely not work.  Return 0, print a warning:
             # consider returning more information about failure
-            print("Warning: BAR is likely to be inaccurate because of poor overlap. Improve the sampling, or decrease the spacing betweeen states.  For now, guessing that the free energy difference is 0 with no uncertainty.")
+            logger.warning("BAR is likely to be inaccurate because of poor overlap. Improve the sampling, or decrease the spacing betweeen states.  For now, guessing that the free energy difference is 0 with no uncertainty.")
             if compute_uncertainty:
                 result_vals['Delta_f'] = 0.0 
                 result_vals['dDelta_f'] = 0.0
@@ -258,7 +263,7 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
             # if they have the same sign, they do not bracket.  Widen the bracket until they have opposite signs.
             # There may be a better way to do this, and the above bracket should rarely fail.
             if verbose:
-                print('Initial brackets did not actually bracket, widening them')
+                logger.debug('Initial brackets did not actually bracket, widening them')
             FAve = (UpperB + LowerB) / 2
             UpperB = UpperB - max(abs(UpperB - FAve), 0.1)
             LowerB = LowerB + max(abs(LowerB - FAve), 0.1)
@@ -285,7 +290,7 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
             if FNew == 0:
                 # Convergence is achieved.
                 if verbose:
-                    print('Convergence achieved.')
+                    logger.debug('Convergence achieved.')
                 relative_change = 10 ** (-15)
                 break
 
@@ -303,18 +308,18 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
         if (DeltaF == 0.0):
             # The free energy difference appears to be zero -- return.
             if verbose:
-                print('The free energy difference appears to be zero.')
+                logger.debug('The free energy difference appears to be zero.')
             break
 
         if iterated_solution:
             relative_change = abs((DeltaF - DeltaF_old) / DeltaF)
             if verbose:
-                print("relative_change = {:12.3f}".format(relative_change))
+                logger.debug("relative_change = {:12.3f}".format(relative_change))
 
             if ((iteration > 0) and (relative_change < relative_tolerance)):
                 # Convergence is achieved.
                 if verbose:
-                    print("Convergence achieved.")
+                    logger.debug("Convergence achieved.")
                 break
 
         if method == 'false-position' or method == 'bisection':
@@ -331,13 +336,13 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
                 raise BoundsError(message)
 
         if verbose:
-            print("iteration {:5d}: DeltaF = {:16.3f}".format(iteration, DeltaF))
+            logger.debug("iteration {:5d}: DeltaF = {:16.3f}".format(iteration, DeltaF))
 
     # Report convergence, or warn user if not achieved.
     if iterated_solution:
         if iteration < maximum_iterations:
             if verbose:
-                print('Converged to tolerance of {:e} in {:d} iterations ({:d} function evaluations)'.format(relative_change, iteration, nfunc))
+                logger.debug('Converged to tolerance of {:e} in {:d} iterations ({:d} function evaluations)'.format(relative_change, iteration, nfunc))
         else:
             message = 'WARNING: Did not converge to within specified tolerance. max_delta = {:f}, TOLERANCE = {:f}, MAX_ITS = {:d}'.format(relative_change, relative_tolerance, maximum_iterations)
             raise ConvergenceError(message)
@@ -493,14 +498,14 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
             raise ParameterError(message)
 
         if verbose:
-            print("DeltaF = {:8.3f} +- {:8.3f}".format(DeltaF, dDeltaF))
+            logger.debug("DeltaF = {:8.3f} +- {:8.3f}".format(DeltaF, dDeltaF))
         result_vals['Delta_f'] = DeltaF
         result_vals['dDelta_f'] = dDeltaF
         return result_vals
 
     else:
         if verbose:
-            print("DeltaF = {:8.3f}".format(DeltaF))
+            logger.debug("DeltaF = {:8.3f}".format(DeltaF))
         result_vals['Delta_f'] = DeltaF
         return result_vals
 

--- a/pymbar/bar.py
+++ b/pymbar/bar.py
@@ -263,7 +263,7 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
             # if they have the same sign, they do not bracket.  Widen the bracket until they have opposite signs.
             # There may be a better way to do this, and the above bracket should rarely fail.
             if verbose:
-                logger.debug('Initial brackets did not actually bracket, widening them')
+                logger.info('Initial brackets did not actually bracket, widening them')
             FAve = (UpperB + LowerB) / 2
             UpperB = UpperB - max(abs(UpperB - FAve), 0.1)
             LowerB = LowerB + max(abs(LowerB - FAve), 0.1)
@@ -290,7 +290,7 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
             if FNew == 0:
                 # Convergence is achieved.
                 if verbose:
-                    logger.debug('Convergence achieved.')
+                    logger.info('Convergence achieved.')
                 relative_change = 10 ** (-15)
                 break
 
@@ -308,18 +308,18 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
         if (DeltaF == 0.0):
             # The free energy difference appears to be zero -- return.
             if verbose:
-                logger.debug('The free energy difference appears to be zero.')
+                logger.info('The free energy difference appears to be zero.')
             break
 
         if iterated_solution:
             relative_change = abs((DeltaF - DeltaF_old) / DeltaF)
             if verbose:
-                logger.debug("relative_change = {:12.3f}".format(relative_change))
+                logger.info("relative_change = {:12.3f}".format(relative_change))
 
             if ((iteration > 0) and (relative_change < relative_tolerance)):
                 # Convergence is achieved.
                 if verbose:
-                    logger.debug("Convergence achieved.")
+                    logger.info("Convergence achieved.")
                 break
 
         if method == 'false-position' or method == 'bisection':
@@ -336,13 +336,13 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
                 raise BoundsError(message)
 
         if verbose:
-            logger.debug("iteration {:5d}: DeltaF = {:16.3f}".format(iteration, DeltaF))
+            logger.info("iteration {:5d}: DeltaF = {:16.3f}".format(iteration, DeltaF))
 
     # Report convergence, or warn user if not achieved.
     if iterated_solution:
         if iteration < maximum_iterations:
             if verbose:
-                logger.debug('Converged to tolerance of {:e} in {:d} iterations ({:d} function evaluations)'.format(relative_change, iteration, nfunc))
+                logger.info('Converged to tolerance of {:e} in {:d} iterations ({:d} function evaluations)'.format(relative_change, iteration, nfunc))
         else:
             message = 'WARNING: Did not converge to within specified tolerance. max_delta = {:f}, TOLERANCE = {:f}, MAX_ITS = {:d}'.format(relative_change, relative_tolerance, maximum_iterations)
             raise ConvergenceError(message)
@@ -498,14 +498,14 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
             raise ParameterError(message)
 
         if verbose:
-            logger.debug("DeltaF = {:8.3f} +- {:8.3f}".format(DeltaF, dDeltaF))
+            logger.info("DeltaF = {:8.3f} +- {:8.3f}".format(DeltaF, dDeltaF))
         result_vals['Delta_f'] = DeltaF
         result_vals['dDelta_f'] = dDeltaF
         return result_vals
 
     else:
         if verbose:
-            logger.debug("DeltaF = {:8.3f}".format(DeltaF))
+            logger.info("DeltaF = {:8.3f}".format(DeltaF))
         result_vals['Delta_f'] = DeltaF
         return result_vals
 

--- a/pymbar/confidenceintervals.py
+++ b/pymbar/confidenceintervals.py
@@ -19,10 +19,16 @@
 # You should have received a copy of the MIT License along with pymbar.
 ##############################################################################
 
+import logging
+from textwrap import dedent
 import numpy as np
 import scipy
 import scipy.special
 import scipy.stats
+
+
+logger = logging.getLogger(__name__)
+
 
 def OrderReplicates(replicates, K):
 
@@ -176,25 +182,25 @@ def generateConfidenceIntervals(replicates, K):
     #
     # If the error is normal, we should have
     #   P(error < alpha sigma) = erf(alpha / sqrt(2))
-
-    print("The uncertainty estimates are tested in this section.")
-    print("If the error is normally distributed, the actual error will be less than a")
-    print("multiplier 'alpha' times the computed uncertainty 'sigma' a fraction of")
-    print("time given by:")
-    print("P(error < alpha sigma) = erf(alpha / sqrt(2))")
-    print("For example, the true error should be less than 1.0 * sigma")
-    print("(one standard deviation) a total of 68% of the time, and")
-    print("less than 2.0 * sigma (two standard deviations) 95% of the time.")
-    print("The observed fraction of the time that error < alpha sigma, and its")
-    print("uncertainty, is given as 'obs' (with uncertainty 'obs err') below.")
-    print("This should be compared to the column labeled 'normal'.")
-    print("A weak lower bound that holds regardless of how the error is distributed is given")
-    print("by Chebyshev's inequality, and is listed as 'cheby' below.")
-    print("Uncertainty estimates are tested for both free energy differences and expectations.")
-    print("")
+    msg = """
+    The uncertainty estimates are tested in this section.
+    If the error is normally distributed, the actual error will be less than a
+    multiplier 'alpha' times the computed uncertainty 'sigma' a fraction of
+    time given by:
+    P(error < alpha sigma) = erf(alpha / sqrt(2))
+    For example, the true error should be less than 1.0 * sigma
+    (one standard deviation) a total of 68% of the time, and
+    less than 2.0 * sigma (two standard deviations) 95% of the time.
+    The observed fraction of the time that error < alpha sigma, and its
+    uncertainty, is given as 'obs' (with uncertainty 'obs err') below.
+    This should be compared to the column labeled 'normal'.
+    A weak lower bound that holds regardless of how the error is distributed is given
+    by Chebyshev's inequality, and is listed as 'cheby' below.
+    Uncertainty estimates are tested for both free energy differences and expectations.
+    """
+    logger.info(dedent(msg[1:]))
 
     # error bounds
-
     min_alpha = 0.1
     max_alpha = 4.0
     nalpha = 40
@@ -218,11 +224,11 @@ def generateConfidenceIntervals(replicates, K):
             # We only count differences where the analytical difference is larger than a cutoff, so that the results will not be limited by machine precision.
             if (dim == 0):
                 if np.isnan(replicate['error']) or np.isnan(replicate['destimated']):
-                    print("replicate {:d}".format(replicate_index))
-                    print("error")
-                    print(replicate['error'])
-                    print("destimated")
-                    print(replicate['destimated'])
+                    logger.warning("replicate {:d}".format(replicate_index))
+                    logger.warning("error")
+                    logger.warning(replicate['error'])
+                    logger.warning("destimated")
+                    logger.warning(replicate['destimated'])
                     raise ArithmaticError("Encountered isnan in computation")
                 else:
                     if abs(replicate['error']) <= alpha * replicate['destimated']:
@@ -233,11 +239,11 @@ def generateConfidenceIntervals(replicates, K):
             elif (dim == 1):
                 for i in range(0, K):
                     if np.isnan(replicate['error'][i]) or np.isnan(replicate['destimated'][i]):
-                        print("replicate {:d}".format(replicate_index))
-                        print("error")
-                        print(replicate['error'])
-                        print("destimated")
-                        print(replicate['destimated'])
+                        logger.warning("replicate {:d}".format(replicate_index))
+                        logger.warning("error")
+                        logger.warning(replicate['error'])
+                        logger.warning("destimated")
+                        logger.warning(replicate['destimated'])
                         raise ArithmaticError("Encountered isnan in computation")
                     else:
                         if abs(replicate['error'][i]) <= alpha * replicate['destimated'][i]:
@@ -249,11 +255,11 @@ def generateConfidenceIntervals(replicates, K):
                 for i in range(0, K):
                     for j in range(0, i):
                         if np.isnan(replicate['error'][i, j]) or np.isnan(replicate['destimated'][i, j]):
-                            print("replicate {:d}".format(replicate_index))
-                            print("ij_error")
-                            print(replicate['error'])
-                            print("ij_estimated")
-                            print(replicate['destimated'])
+                            logger.warning("replicate {:d}".format(replicate_index))
+                            logger.warning("ij_error")
+                            logger.warning(replicate['error'])
+                            logger.warning("ij_estimated")
+                            logger.warning(replicate['destimated'])
                             raise ArithmaticError("Encountered isnan in computation")
                         else:
                             if abs(replicate['error'][i, j]) <= alpha * replicate['destimated'][i, j]:
@@ -267,12 +273,12 @@ def generateConfidenceIntervals(replicates, K):
         dPobs[alpha_index] = np.sqrt(a * b / ((a + b) ** 2 * (a + b + 1)))
 
     # Write error as a function of sigma.
-    print("Error vs. alpha")
-    print("{:5s} {:10s} {:10s} {:16s} {:17s}".format('alpha', 'cheby', 'obs', 'obs err', 'normal'))
+    logger.info("Error vs. alpha")
+    logger.info("{:5s} {:10s} {:10s} {:16s} {:17s}".format('alpha', 'cheby', 'obs', 'obs err', 'normal'))
     Pnorm = scipy.special.erf(alpha_values / np.sqrt(2.))
     for alpha_index in range(0, nalpha):
         alpha = alpha_values[alpha_index]
-        print("{:5.1f} {:10.6f} {:10.6f} ({:10.6f},{:10.6f}) {:10.6f}".format(alpha, 1. - 1. / alpha ** 2, Pobs[alpha_index], Plow[alpha_index], Phigh[alpha_index], Pnorm[alpha_index]))
+        logger.info("{:5.1f} {:10.6f} {:10.6f} ({:10.6f},{:10.6f}) {:10.6f}".format(alpha, 1. - 1. / alpha ** 2, Pobs[alpha_index], Plow[alpha_index], Phigh[alpha_index], Pnorm[alpha_index]))
 
     # compute bias, average, etc - do it by replicate, not by bias
     if dim == 0:
@@ -317,9 +323,9 @@ def generateConfidenceIntervals(replicates, K):
     ave_std = (np.average(d2, axis=0)) ** (1.0 / 2.0)
 
     # for now, just print out the data at the end for each
-    print("")
-    print("     i      average    bias      rms_error     stddev  ave_analyt_std")
-    print("---------------------------------------------------------------------")
+    logger.info("")
+    logger.info("     i      average    bias      rms_error     stddev  ave_analyt_std")
+    logger.info("---------------------------------------------------------------------")
     if dim == 0:
         pave = aveval
         pbias = bias
@@ -333,7 +339,7 @@ def generateConfidenceIntervals(replicates, K):
             prms = rms_error[i]
             pstdev = standarddev[i]
             pavestd = ave_std[i]
-            print("{:7d} {:10.4f}  {:10.4f}  {:10.4f}  {:10.4f} {:10.4f}".format(i, pave, pbias, prms, pstdev, pavestd))
+            logger.info("{:7d} {:10.4f}  {:10.4f}  {:10.4f}  {:10.4f} {:10.4f}".format(i, pave, pbias, prms, pstdev, pavestd))
     elif dim == 2:
         for i in range(0, K):
             pave = aveval[0, i]
@@ -341,8 +347,8 @@ def generateConfidenceIntervals(replicates, K):
             prms = rms_error[0, i]
             pstdev = standarddev[0, i]
             pavestd = ave_std[0, i]
-            print("{:7d} {:10.4f}  {:10.4f}  {:10.4f}  {:10.4f} {:10.4f}".format(i, pave, pbias, prms, pstdev, pavestd))
+            logger.info("{:7d} {:10.4f}  {:10.4f}  {:10.4f}  {:10.4f} {:10.4f}".format(i, pave, pbias, prms, pstdev, pavestd))
 
-    print("Totals: {:10.4f}  {:10.4f}  {:10.4f}  {:10.4f} {:10.4f}".format(pave, pbias, prms, pstdev, pavestd))
+    logger.info("Totals: {:10.4f}  {:10.4f}  {:10.4f}  {:10.4f} {:10.4f}".format(pave, pbias, prms, pstdev, pavestd))
 
     return alpha_values, Pobs, Plow, Phigh, dPobs, Pnorm

--- a/pymbar/mbar.py
+++ b/pymbar/mbar.py
@@ -37,6 +37,8 @@ This module contains implementations of
 
 """
 
+from textwrap import dedent
+import logging
 import math
 import numpy as np
 import numpy.linalg as linalg
@@ -44,6 +46,7 @@ import warnings
 from pymbar import mbar_solvers
 from pymbar.utils import kln_to_kn, kn_to_n, ParameterError, DataError, logsumexp, check_w_normalized
 
+logger = logging.getLogger(__name__)
 DEFAULT_SOLVER_PROTOCOL = mbar_solvers.DEFAULT_SOLVER_PROTOCOL
 
 # =========================================================================
@@ -198,7 +201,7 @@ class MBAR:
         K, N = np.shape(u_kn)
 
         if verbose:
-            print("K (total states) = {:d}, total samples = {:d}".format(K, N))
+            logger.debug("K (total states) = {:d}, total samples = {:d}".format(K, N))
 
         if np.sum(self.N_k) != N:
             raise ParameterError(
@@ -255,17 +258,18 @@ class MBAR:
                     if (diffsum < relative_tolerance):
                         self.samestates.append([k, l])
                         self.samestates.append([l, k])
-                        print('')
-                        print('Warning: states {:d} and {:d} have the same energies on the dataset.'.format(l, k))
-                        print('They are therefore likely to to be the same thermodynamic state.  This can occasionally cause')
-                        print('numerical problems with computing the covariance of their energy difference, which must be')
-                        print('identically zero in any case. Consider combining them into a single state.')
-                        print('')
+                        msg = """
+                        States {:d} and {:d} have the same energies on the dataset.
+                        They are therefore likely to to be the same thermodynamic state. This can occasionally cause
+                        numerical problems with computing the covariance of their energy difference, which must be
+                        identically zero in any case. Consider combining them into a single state.
+                        """.format(l, k)
+                        logger.warning(dedent(msg[1:]))
 
         # Print number of samples from each state.
         if self.verbose:
-            print("N_k = ")
-            print(self.N_k)
+            logger.debug("N_k = ")
+            logger.debug(self.N_k)
 
         # Determine list of k indices for which N_k != 0
         self.states_with_samples = np.where(self.N_k != 0)[0]
@@ -274,7 +278,7 @@ class MBAR:
         # Number of states with samples.
         self.K_nonzero = self.states_with_samples.size
         if verbose:
-            print("There are {:d} states with samples.".format(self.K_nonzero))
+            logger.debug("There are {:d} states with samples.".format(self.K_nonzero))
 
         # Initialize estimate of relative dimensionless free energy of each state to zero.
         # Note that f_k[0] will be constrained to be zero throughout.
@@ -285,7 +289,7 @@ class MBAR:
         # specified, start with that.
         if initial_f_k is not None:
             if self.verbose:
-                print("Initializing f_k with provided initial guess.")
+                logger.debug("Initializing f_k with provided initial guess.")
             # Cast to np array.
             initial_f_k = np.array(initial_f_k, dtype=np.float64)
             # Check shape
@@ -295,7 +299,7 @@ class MBAR:
             # Initialize f_k with provided guess.
             self.f_k = initial_f_k
             if self.verbose:
-                print(self.f_k)
+                logger.debug(self.f_k)
             # Shift all free energies such that f_0 = 0.
             self.f_k[:] = self.f_k[:] - self.f_k[0]
         else:
@@ -303,9 +307,9 @@ class MBAR:
             self._initializeFreeEnergies(verbose, method=initialize)
 
             if self.verbose:
-                print("Initial dimensionless free energies with method {}".format(initialize))
-                print("f_k = ")
-                print(self.f_k)
+                logger.debug("Initial dimensionless free energies with method {}".format(initialize))
+                logger.debug("f_k = ")
+                logger.debug(self.f_k)
 
         if solver_protocol is None:
             solver_protocol = ({'method': None},)
@@ -322,12 +326,12 @@ class MBAR:
 
         # Print final dimensionless free energies.
         if self.verbose:
-            print("Final dimensionless free energies")
-            print("f_k = ")
-            print(self.f_k)
+            logger.debug("Final dimensionless free energies")
+            logger.debug("f_k = ")
+            logger.debug(self.f_k)
 
         if self.verbose:
-            print("MBAR initialization complete.")
+            logger.debug("MBAR initialization complete.")
 
     @property
     def W_nk(self):
@@ -414,8 +418,8 @@ class MBAR:
             w = np.exp(self.Log_W_nk[:,k])
             N_eff[k] = 1/np.sum(w**2)
             if verbose:
-                print("Effective number of sample in state {:d} is {:10.3f}".format(k,N_eff[k]))
-                print("Efficiency for state {:d} is {:6f}/{:d} = {:10.4f}".format(k,N_eff[k],len(w),N_eff[k]/len(w)))
+                logger.debug("Effective number of sample in state {:d} is {:10.3f}".format(k,N_eff[k]))
+                logger.debug("Efficiency for state {:d} is {:6f}/{:d} = {:10.4f}".format(k,N_eff[k],len(w),N_eff[k]/len(w)))
 
         return N_eff
 
@@ -956,7 +960,7 @@ class MBAR:
         dims = len(np.shape(A_n))
 
         if dims > 2:
-            print("Warning: dim=3 for (state_dependent==True) matrices for observables and dim=2 for (state_dependent==False) observables are deprecated; we suggest you convert to NxK form instead of NxKxK form.")
+            logger.warning("dim=3 for (state_dependent==True) matrices for observables and dim=2 for (state_dependent==False) observables are deprecated; we suggest you convert to NxK form instead of NxKxK form.")
 
         if not state_dependent:
             if dims==2:
@@ -1245,7 +1249,7 @@ class MBAR:
 
         """
         if verbose:
-            print("Computing average energy and entropy by MBAR.")
+            logger.debug("Computing average energy and entropy by MBAR.")
 
         dims = len(np.shape(u_kn))
         if dims==3:
@@ -1343,7 +1347,7 @@ class MBAR:
         # check for any numbers below zero.
         if np.any(d2 < 0.0):
             if np.any(d2 < cutoff):
-                print("A squared uncertainty is negative. Largest Magnitude = {0:f}".format(
+                logger.warning("A squared uncertainty is negative. Largest Magnitude = {0:f}".format(
                     abs(np.min(d2[d2 < cutoff]))))
             else:
                 d2[np.logical_and(0 > d2, d2 > cutoff)] = 0.0
@@ -1505,18 +1509,18 @@ class MBAR:
         if (method == 'zeros'):
             # Use zeros for initial free energies.
             if verbose:
-                print("Initializing free energies to zero.")
+                logger.debug("Initializing free energies to zero.")
             self.f_k[:] = 0.0
         elif (method == 'mean-reduced-potential'):
             # Compute initial guess at free energies from the mean reduced
             # potential from each state
             if verbose:
-                print("Initializing free energies with mean reduced potential for each state.")
+                logger.debug("Initializing free energies with mean reduced potential for each state.")
             means = np.zeros([self.K], float)
             for k in self.states_with_samples:
                 means[k] = self.u_kn[k, 0:self.N_k[k]].mean()
             if (np.max(np.abs(means)) < 0.000001):
-                print("Warning: All mean reduced potentials are close to zero. If you are using energy differences in the u_kln matrix, then the mean reduced potentials will be zero, and this is expected behavoir.")
+                logger.warning("Warning: All mean reduced potentials are close to zero. If you are using energy differences in the u_kln matrix, then the mean reduced potentials will be zero, and this is expected behavoir.")
             self.f_k = means
         elif (method == 'BAR'):
             # For now, make a simple list of those states with samples.

--- a/pymbar/mbar.py
+++ b/pymbar/mbar.py
@@ -201,7 +201,7 @@ class MBAR:
         K, N = np.shape(u_kn)
 
         if verbose:
-            logger.debug("K (total states) = {:d}, total samples = {:d}".format(K, N))
+            logger.info("K (total states) = {:d}, total samples = {:d}".format(K, N))
 
         if np.sum(self.N_k) != N:
             raise ParameterError(
@@ -268,8 +268,8 @@ class MBAR:
 
         # Print number of samples from each state.
         if self.verbose:
-            logger.debug("N_k = ")
-            logger.debug(self.N_k)
+            logger.info("N_k = ")
+            logger.info(self.N_k)
 
         # Determine list of k indices for which N_k != 0
         self.states_with_samples = np.where(self.N_k != 0)[0]
@@ -278,7 +278,7 @@ class MBAR:
         # Number of states with samples.
         self.K_nonzero = self.states_with_samples.size
         if verbose:
-            logger.debug("There are {:d} states with samples.".format(self.K_nonzero))
+            logger.info("There are {:d} states with samples.".format(self.K_nonzero))
 
         # Initialize estimate of relative dimensionless free energy of each state to zero.
         # Note that f_k[0] will be constrained to be zero throughout.
@@ -289,7 +289,7 @@ class MBAR:
         # specified, start with that.
         if initial_f_k is not None:
             if self.verbose:
-                logger.debug("Initializing f_k with provided initial guess.")
+                logger.info("Initializing f_k with provided initial guess.")
             # Cast to np array.
             initial_f_k = np.array(initial_f_k, dtype=np.float64)
             # Check shape
@@ -299,7 +299,7 @@ class MBAR:
             # Initialize f_k with provided guess.
             self.f_k = initial_f_k
             if self.verbose:
-                logger.debug(self.f_k)
+                logger.info(self.f_k)
             # Shift all free energies such that f_0 = 0.
             self.f_k[:] = self.f_k[:] - self.f_k[0]
         else:
@@ -307,9 +307,9 @@ class MBAR:
             self._initializeFreeEnergies(verbose, method=initialize)
 
             if self.verbose:
-                logger.debug("Initial dimensionless free energies with method {}".format(initialize))
-                logger.debug("f_k = ")
-                logger.debug(self.f_k)
+                logger.info("Initial dimensionless free energies with method {}".format(initialize))
+                logger.info("f_k = ")
+                logger.info(self.f_k)
 
         if solver_protocol is None:
             solver_protocol = ({'method': None},)
@@ -326,12 +326,12 @@ class MBAR:
 
         # Print final dimensionless free energies.
         if self.verbose:
-            logger.debug("Final dimensionless free energies")
-            logger.debug("f_k = ")
-            logger.debug(self.f_k)
+            logger.info("Final dimensionless free energies")
+            logger.info("f_k = ")
+            logger.info(self.f_k)
 
         if self.verbose:
-            logger.debug("MBAR initialization complete.")
+            logger.info("MBAR initialization complete.")
 
     @property
     def W_nk(self):
@@ -418,8 +418,8 @@ class MBAR:
             w = np.exp(self.Log_W_nk[:,k])
             N_eff[k] = 1/np.sum(w**2)
             if verbose:
-                logger.debug("Effective number of sample in state {:d} is {:10.3f}".format(k,N_eff[k]))
-                logger.debug("Efficiency for state {:d} is {:6f}/{:d} = {:10.4f}".format(k,N_eff[k],len(w),N_eff[k]/len(w)))
+                logger.info("Effective number of sample in state {:d} is {:10.3f}".format(k,N_eff[k]))
+                logger.info("Efficiency for state {:d} is {:6f}/{:d} = {:10.4f}".format(k,N_eff[k],len(w),N_eff[k]/len(w)))
 
         return N_eff
 
@@ -1249,7 +1249,7 @@ class MBAR:
 
         """
         if verbose:
-            logger.debug("Computing average energy and entropy by MBAR.")
+            logger.info("Computing average energy and entropy by MBAR.")
 
         dims = len(np.shape(u_kn))
         if dims==3:
@@ -1509,13 +1509,13 @@ class MBAR:
         if (method == 'zeros'):
             # Use zeros for initial free energies.
             if verbose:
-                logger.debug("Initializing free energies to zero.")
+                logger.info("Initializing free energies to zero.")
             self.f_k[:] = 0.0
         elif (method == 'mean-reduced-potential'):
             # Compute initial guess at free energies from the mean reduced
             # potential from each state
             if verbose:
-                logger.debug("Initializing free energies with mean reduced potential for each state.")
+                logger.info("Initializing free energies with mean reduced potential for each state.")
             means = np.zeros([self.K], float)
             for k in self.states_with_samples:
                 means[k] = self.u_kn[k, 0:self.N_k[k]].mean()

--- a/pymbar/mbar_solvers.py
+++ b/pymbar/mbar_solvers.py
@@ -1,9 +1,12 @@
 from __future__ import division  # Ensure same division behavior in py2 and py3
+import logging
 import numpy as np
 import math
 import scipy.optimize
 from pymbar.utils import ensure_type, logsumexp, check_w_normalized
 import warnings
+
+logger = logging.getLogger(__name__)
 
 # Below are the recommended default protocols (ordered sequence of minimization algorithms / NLE solvers) for solving the MBAR equations.
 # Note: we use tuples instead of lists to avoid accidental mutability.
@@ -275,10 +278,10 @@ def adaptive(u_kn, N_k, f_k, tol = 1.0e-12, options = None):
     gamma = options['gamma']
     doneIterating = False
     if options['verbose'] == True:
-        print("Determining dimensionless free energies by Newton-Raphson / self-consistent iteration.")
+        logger.debug("Determining dimensionless free energies by Newton-Raphson / self-consistent iteration.")
 
     if tol < 1.5e-15:
-        print("Tolerance may be too close to machine precision to converge.")
+        logger.info("Tolerance may be too close to machine precision to converge.")
     # keep track of Newton-Raphson and self-consistent iterations
     nr_iter = 0
     sci_iter = 0
@@ -313,7 +316,7 @@ def adaptive(u_kn, N_k, f_k, tol = 1.0e-12, options = None):
         # compute since we are doing the Hessian anyway.
 
         if options['verbose']:
-            print("self consistent iteration gradient norm is %10.5g, Newton-Raphson gradient norm is %10.5g" % (gnorm_sci, gnorm_nr))
+            logger.debug("self consistent iteration gradient norm is %10.5g, Newton-Raphson gradient norm is %10.5g" % (gnorm_sci, gnorm_nr))
         # decide which directon to go depending on size of gradient norm
         f_old = f_k
         if (gnorm_sci < gnorm_nr or sci_iter < 2):
@@ -322,15 +325,15 @@ def adaptive(u_kn, N_k, f_k, tol = 1.0e-12, options = None):
             sci_iter += 1
             if options['verbose']:
                 if sci_iter < 2:
-                    print("Choosing self-consistent iteration on iteration %d" % iteration)
+                    logger.debug("Choosing self-consistent iteration on iteration %d" % iteration)
                 else:
-                    print("Choosing self-consistent iteration for lower gradient on iteration %d" % iteration)
+                    logger.debug("Choosing self-consistent iteration for lower gradient on iteration %d" % iteration)
         else:
             f_k = f_nr
             g = g_nr
             nr_iter += 1
             if options['verbose']:
-                print("Newton-Raphson used on iteration %d" % iteration)
+                logger.debug("Newton-Raphson used on iteration %d" % iteration)
 
         div = np.abs(f_k[1:]) # what we will divide by to get relative difference
         zeroed = np.abs(f_k[1:])< np.min([10**-8,tol]) # check which values are near enough to zero, hard coded max for now.
@@ -342,17 +345,17 @@ def adaptive(u_kn, N_k, f_k, tol = 1.0e-12, options = None):
 
     if doneIterating:
         if options['verbose']:
-            print('Converged to tolerance of {:e} in {:d} iterations.'.format(max_delta, iteration + 1))
-            print('Of {:d} iterations, {:d} were Newton-Raphson iterations and {:d} were self-consistent iterations'.format(iteration + 1, nr_iter, sci_iter))
+            logger.debug('Converged to tolerance of {:e} in {:d} iterations.'.format(max_delta, iteration + 1))
+            logger.debug('Of {:d} iterations, {:d} were Newton-Raphson iterations and {:d} were self-consistent iterations'.format(iteration + 1, nr_iter, sci_iter))
             if np.all(f_k == 0.0):
                 # all f_k appear to be zero
-                print('WARNING: All f_k appear to be zero.')
+                logger.debug('WARNING: All f_k appear to be zero.')
     else:
-        print('WARNING: Did not converge to within specified tolerance.')
+        logger.warning('WARNING: Did not converge to within specified tolerance.')
         if options['maximum_iterations'] <= 0:
-            print("No iterations ran be cause maximum_iterations was <= 0 ({})!".format(options['maximum_iterations']))
+            logger.warning("No iterations ran be cause maximum_iterations was <= 0 ({})!".format(options['maximum_iterations']))
         else:
-            print('max_delta = {:e}, tol = {:e}, maximum_iterations = {:d}, iterations completed = {:d}'.format(max_delta,tol, options['maximum_iterations'], iteration))
+            logger.warning('max_delta = {:e}, tol = {:e}, maximum_iterations = {:d}, iterations completed = {:d}'.format(max_delta,tol, options['maximum_iterations'], iteration))
     return f_k
 
 
@@ -467,7 +470,7 @@ def solve_mbar_once(u_kn_nonzero, N_k_nonzero, f_k_nonzero, method="hybr", tol=1
             # Ensure MBAR solved correctly
             w_nk_check = mbar_W_nk(u_kn_nonzero, N_k_nonzero, f_k_nonzero)
             check_w_normalized(w_nk_check, N_k_nonzero)
-            print("MBAR weights converged within tolerance, despite the SciPy Warnings. Please validate your results.")
+            logger.warning("MBAR weights converged within tolerance, despite the SciPy Warnings. Please validate your results.")
 
     return f_k_nonzero, results
 

--- a/pymbar/mbar_solvers.py
+++ b/pymbar/mbar_solvers.py
@@ -278,7 +278,7 @@ def adaptive(u_kn, N_k, f_k, tol = 1.0e-12, options = None):
     gamma = options['gamma']
     doneIterating = False
     if options['verbose'] == True:
-        logger.debug("Determining dimensionless free energies by Newton-Raphson / self-consistent iteration.")
+        logger.info("Determining dimensionless free energies by Newton-Raphson / self-consistent iteration.")
 
     if tol < 1.5e-15:
         logger.info("Tolerance may be too close to machine precision to converge.")
@@ -316,7 +316,7 @@ def adaptive(u_kn, N_k, f_k, tol = 1.0e-12, options = None):
         # compute since we are doing the Hessian anyway.
 
         if options['verbose']:
-            logger.debug("self consistent iteration gradient norm is %10.5g, Newton-Raphson gradient norm is %10.5g" % (gnorm_sci, gnorm_nr))
+            logger.info("self consistent iteration gradient norm is %10.5g, Newton-Raphson gradient norm is %10.5g" % (gnorm_sci, gnorm_nr))
         # decide which directon to go depending on size of gradient norm
         f_old = f_k
         if (gnorm_sci < gnorm_nr or sci_iter < 2):
@@ -325,15 +325,15 @@ def adaptive(u_kn, N_k, f_k, tol = 1.0e-12, options = None):
             sci_iter += 1
             if options['verbose']:
                 if sci_iter < 2:
-                    logger.debug("Choosing self-consistent iteration on iteration %d" % iteration)
+                    logger.info("Choosing self-consistent iteration on iteration %d" % iteration)
                 else:
-                    logger.debug("Choosing self-consistent iteration for lower gradient on iteration %d" % iteration)
+                    logger.info("Choosing self-consistent iteration for lower gradient on iteration %d" % iteration)
         else:
             f_k = f_nr
             g = g_nr
             nr_iter += 1
             if options['verbose']:
-                logger.debug("Newton-Raphson used on iteration %d" % iteration)
+                logger.info("Newton-Raphson used on iteration %d" % iteration)
 
         div = np.abs(f_k[1:]) # what we will divide by to get relative difference
         zeroed = np.abs(f_k[1:])< np.min([10**-8,tol]) # check which values are near enough to zero, hard coded max for now.
@@ -345,11 +345,11 @@ def adaptive(u_kn, N_k, f_k, tol = 1.0e-12, options = None):
 
     if doneIterating:
         if options['verbose']:
-            logger.debug('Converged to tolerance of {:e} in {:d} iterations.'.format(max_delta, iteration + 1))
-            logger.debug('Of {:d} iterations, {:d} were Newton-Raphson iterations and {:d} were self-consistent iterations'.format(iteration + 1, nr_iter, sci_iter))
+            logger.info('Converged to tolerance of {:e} in {:d} iterations.'.format(max_delta, iteration + 1))
+            logger.info('Of {:d} iterations, {:d} were Newton-Raphson iterations and {:d} were self-consistent iterations'.format(iteration + 1, nr_iter, sci_iter))
             if np.all(f_k == 0.0):
                 # all f_k appear to be zero
-                logger.debug('WARNING: All f_k appear to be zero.')
+                logger.info('WARNING: All f_k appear to be zero.')
     else:
         logger.warning('WARNING: Did not converge to within specified tolerance.')
         if options['maximum_iterations'] <= 0:

--- a/pymbar/pmf.py
+++ b/pymbar/pmf.py
@@ -229,7 +229,7 @@ class PMF:
         self._seed = None
 
         if self.verbose:
-            logger.debug("PMF initialized")
+            logger.info("PMF initialized")
 
     @property
     def seed(self):
@@ -1346,7 +1346,7 @@ class PMF:
         g_mc = None
 
         if verbose:
-            logger.debug("Done MC sampling")
+            logger.info("Done MC sampling")
 
         if decorrelate:
             t_mc, g_mc, Neff = timeseries.detectEquilibration(logposteriors)
@@ -1354,12 +1354,12 @@ class PMF:
             equil_logp = logposteriors[t_mc:]
             g_mc = timeseries.statisticalInefficiency(equil_logp)
             if verbose:
-                logger.debug("Statistical inefficiency of log posterior is {:.3g}".format(g_mc))
+                logger.info("Statistical inefficiency of log posterior is {:.3g}".format(g_mc))
             g_c = np.zeros(len(c))
             for nc in range(len(c)):
                 g_c[nc] = timeseries.statisticalInefficiency(csamples[nc,t_mc:])
             if verbose:
-                logger.debug("Time series for spline parameters are: {:s}".format(str(g_c))) 
+                logger.info("Time series for spline parameters are: {:s}".format(str(g_c))) 
             maxgc = np.max(g_c)
             meangc = np.mean(g_c)
             guse = g_mc  # doesn't affect the distribution that much
@@ -1367,14 +1367,14 @@ class PMF:
             logposteriors = equil_logp[indices]
             csamples = (csamples[:,t_mc:])[:,indices]
             if verbose:
-                logger.debug("samples after decorrelation: {:d}".format(np.shape(csamples)[1]))
+                logger.info("samples after decorrelation: {:d}".format(np.shape(csamples)[1]))
 
         self.mc_data['samples'] = csamples
         self.mc_data['logposteriors'] = logposteriors
         self.mc_data['mc_parameters'] = mc_parameters
         self.mc_data['acceptance ratio'] = self.naccept / niterations
         if verbose:
-            logger.debug("Acceptance rate: {:5.3f}".format(self.mc_data['acceptance ratio']))
+            logger.info("Acceptance rate: {:5.3f}".format(self.mc_data['acceptance ratio']))
         self.mc_data['nequil'] = t_mc # the start of the "equilibrated" data set
         self.mc_data['g_logposterior'] = g_mc # statistical efficiency of the log posterior
         self.mc_data['g_parameters'] = g_c # statistical efficiency of the parametere

--- a/pymbar/pmf.py
+++ b/pymbar/pmf.py
@@ -21,6 +21,7 @@ A module implementing calculation of potentials of mean force from biased simula
 
 """
 
+import logging
 import math
 import itertools as it
 import numpy as np
@@ -39,8 +40,9 @@ from scipy.optimize import minimize
 
 from timeit import default_timer as timer  # may remove timing?
 
-import pdb  # delete when done
+import pdb  # TODO: delete when done
 
+logger = logging.getLogger(__name__)
 DEFAULT_SOLVER_PROTOCOL = mbar_solvers.DEFAULT_SOLVER_PROTOCOL
 
 # =========================================================================
@@ -149,9 +151,7 @@ class PMF:
 
         """
         for key, val in kwargs.items():
-            print(
-                "Warning: parameter {}={} is unrecognized and unused.".format(
-                    key, val))
+            logging.warning("Warning: parameter {}={} is unrecognized and unused.".format(key, val))
 
         # Store local copies of necessary data.
         # N_k[k] is the number of samples from state k, some of which might be
@@ -229,7 +229,7 @@ class PMF:
         self._seed = None
 
         if self.verbose:
-            print("PMF initialized")
+            logger.debug("PMF initialized")
 
     @property
     def seed(self):
@@ -842,7 +842,7 @@ class PMF:
                         xi = xold - dx
                         if spline_parameters['optimize_options']['disp']:
                             dg = np.sqrt(np.dot(g, g))
-                            print(
+                            logger.info(
                                 "f = {:.10f}. gradient norm = {:.10f}".format(
                                     f, np.sqrt(dg)))
                     self.bspline = self._val_to_spline(xi, form = 'log')
@@ -1289,7 +1289,7 @@ class PMF:
                 "Need to generate a splined PMF using GeneratePMF before performing MCMC sampling")
 
         if mc_parameters is None:
-            print('Using default MC parameters')
+            logger.info('Using default MC parameters')
             mc_parameters = dict()
 
         if 'niterations' not in mc_parameters:
@@ -1346,20 +1346,20 @@ class PMF:
         g_mc = None
 
         if verbose:
-            print("Done MC sampling")
+            logger.debug("Done MC sampling")
 
         if decorrelate:
             t_mc, g_mc, Neff = timeseries.detectEquilibration(logposteriors)
-            print("First equilibration sample is {:d} of {:d}".format(t_mc,len(logposteriors)))
+            logger.info("First equilibration sample is {:d} of {:d}".format(t_mc,len(logposteriors)))
             equil_logp = logposteriors[t_mc:]
             g_mc = timeseries.statisticalInefficiency(equil_logp)
             if verbose:
-                print("Statistical inefficiency of log posterior is {:.3g}".format(g_mc))
+                logger.debug("Statistical inefficiency of log posterior is {:.3g}".format(g_mc))
             g_c = np.zeros(len(c))
             for nc in range(len(c)):
                 g_c[nc] = timeseries.statisticalInefficiency(csamples[nc,t_mc:])
             if verbose:
-                print("Time series for spline parameters are: {:s}".format(str(g_c))) 
+                logger.debug("Time series for spline parameters are: {:s}".format(str(g_c))) 
             maxgc = np.max(g_c)
             meangc = np.mean(g_c)
             guse = g_mc  # doesn't affect the distribution that much
@@ -1367,14 +1367,14 @@ class PMF:
             logposteriors = equil_logp[indices]
             csamples = (csamples[:,t_mc:])[:,indices]
             if verbose:
-                print("samples after decorrelation: {:d}".format(np.shape(csamples)[1]))
+                logger.debug("samples after decorrelation: {:d}".format(np.shape(csamples)[1]))
 
         self.mc_data['samples'] = csamples
         self.mc_data['logposteriors'] = logposteriors
         self.mc_data['mc_parameters'] = mc_parameters
         self.mc_data['acceptance ratio'] = self.naccept / niterations
         if verbose:
-            print("Acceptance rate: {:5.3f}".format(self.mc_data['acceptance ratio']))
+            logger.debug("Acceptance rate: {:5.3f}".format(self.mc_data['acceptance ratio']))
         self.mc_data['nequil'] = t_mc # the start of the "equilibrated" data set
         self.mc_data['g_logposterior'] = g_mc # statistical efficiency of the log posterior
         self.mc_data['g_parameters'] = g_c # statistical efficiency of the parametere

--- a/pymbar/tests/test_mbar.py
+++ b/pymbar/tests/test_mbar.py
@@ -109,14 +109,13 @@ def test_ukln(mbar_and_test_kln):
     free_energies_almost_equal(fe, fe_sigma, test.analytical_free_energies())
 
 
-def test_duplicate_state(fixed_harmonic_sample, capsys):
+def test_duplicate_state(fixed_harmonic_sample, caplog):
     """Test that MBAR's duplicate state check is working"""
     _, u_kn, _, _ = fixed_harmonic_sample.sample(N_k, mode='u_kn')
     u_kn_dup = np.append(u_kn, u_kn[[0], :], axis=0)
     N_k_dup = np.append(N_k, [0])
     mbar = MBAR(u_kn_dup, N_k_dup, verbose=True)
-    captured = capsys.readouterr()
-    assert "likely to to be the same thermodynamic state" in captured.out
+    assert "likely to to be the same thermodynamic state" in caplog.text
     results = mbar.getFreeEnergyDifferences()
     fe = results['Delta_f']
     assert np.allclose(fe[0], fe[-1])

--- a/pymbar/timeseries.py
+++ b/pymbar/timeseries.py
@@ -325,7 +325,7 @@ def statisticalInefficiencyMultiple(A_kn, fast=False, return_correlation_functio
 
         # compute normalized fluctuation correlation function at time t
         C = C / sigma2
-        # logger.debug("C[{:5d}] = {:16f} ({:16f} / {:16f})".format(t, C, numerator, denominator))
+        # logger.info("C[{:5d}] = {:16f} ({:16f} / {:16f})".format(t, C, numerator, denominator))
 
         # Store estimate of correlation function.
         Ct.append((t, C))
@@ -704,16 +704,16 @@ def subsampleCorrelatedData(A_t, g=None, fast=False, conservative=False, verbose
     # Compute the statistical inefficiency for the timeseries.
     if not g:
         if verbose:
-            logger.debug("Computing statistical inefficiency...")
+            logger.info("Computing statistical inefficiency...")
         g = statisticalInefficiency(A_t, A_t, fast=fast)
         if verbose:
-            logger.debug("g = {:f}".format(g))
+            logger.info("g = {:f}".format(g))
 
     if conservative:
         # Round g up to determine the stride we can use to pick out regularly-spaced uncorrelated samples.
         stride = int(math.ceil(g))
         if verbose:
-            logger.debug("conservative subsampling: using stride of {:d}".format(stride))
+            logger.info("conservative subsampling: using stride of {:d}".format(stride))
 
         # Assemble list of indices of uncorrelated snapshots.
         indices = range(0, T, stride)
@@ -728,13 +728,13 @@ def subsampleCorrelatedData(A_t, g=None, fast=False, conservative=False, verbose
                 indices.append(t)
             n += 1
         if verbose:
-            logger.debug("standard subsampling: using average stride of {:f}".format(g))
+            logger.info("standard subsampling: using average stride of {:f}".format(g))
 
     # Number of samples in subsampled timeseries.
     N = len(indices)
 
     if verbose:
-        logger.debug("The resulting subsampled set has {:d} samples (original timeseries had {:d}).".format(N, T))
+        logger.info("The resulting subsampled set has {:d} samples (original timeseries had {:d}).".format(N, T))
 
     # Return the list of indices of uncorrelated snapshots.
     return indices

--- a/pymbar/timeseries.py
+++ b/pymbar/timeseries.py
@@ -55,6 +55,7 @@ __license__ = "MIT"
 # =============================================================================================
 # IMPORTS
 # =============================================================================================
+import logging
 import math
 import numpy as np
 from pymbar.utils import ParameterError
@@ -63,8 +64,13 @@ from pymbar.utils import ParameterError
 # Issue warning on import.
 # =============================================================================================
 
-LongWarning = "Warning on use of the timeseries module: If the inherent timescales of the system are long compared to those being analyzed, this statistical inefficiency may be an underestimate.  The estimate presumes the use of many statistically independent samples.  Tests should be performed to assess whether this condition is satisfied.   Be cautious in the interpretation of the data."
-
+logger = logging.getLogger(__name__)
+LongWarning = ("Warning on use of the timeseries module: If the inherent timescales of the system "
+               "are long compared to those being analyzed, this statistical inefficiency may be an underestimate.  "
+               "The estimate presumes the use of many statistically independent samples.  "
+               "Tests should be performed to assess whether this condition is satisfied.   "
+               "Be cautious in the interpretation of the data.")
+logger.warning(LongWarning)
 #sys.stderr.write(LongWarning + '\n')
 
 # =============================================================================================
@@ -319,7 +325,7 @@ def statisticalInefficiencyMultiple(A_kn, fast=False, return_correlation_functio
 
         # compute normalized fluctuation correlation function at time t
         C = C / sigma2
-        # print("C[{:5d}] = {:16f} ({:16f} / {:16f})".format(t, C, numerator, denominator))
+        # logger.debug("C[{:5d}] = {:16f} ({:16f} / {:16f})".format(t, C, numerator, denominator))
 
         # Store estimate of correlation function.
         Ct.append((t, C))
@@ -698,16 +704,16 @@ def subsampleCorrelatedData(A_t, g=None, fast=False, conservative=False, verbose
     # Compute the statistical inefficiency for the timeseries.
     if not g:
         if verbose:
-            print("Computing statistical inefficiency...")
+            logger.debug("Computing statistical inefficiency...")
         g = statisticalInefficiency(A_t, A_t, fast=fast)
         if verbose:
-            print("g = {:f}".format(g))
+            logger.debug("g = {:f}".format(g))
 
     if conservative:
         # Round g up to determine the stride we can use to pick out regularly-spaced uncorrelated samples.
         stride = int(math.ceil(g))
         if verbose:
-            print("conservative subsampling: using stride of {:d}".format(stride))
+            logger.debug("conservative subsampling: using stride of {:d}".format(stride))
 
         # Assemble list of indices of uncorrelated snapshots.
         indices = range(0, T, stride)
@@ -722,13 +728,13 @@ def subsampleCorrelatedData(A_t, g=None, fast=False, conservative=False, verbose
                 indices.append(t)
             n += 1
         if verbose:
-            print("standard subsampling: using average stride of {:f}".format(g))
+            logger.debug("standard subsampling: using average stride of {:f}".format(g))
 
     # Number of samples in subsampled timeseries.
     N = len(indices)
 
     if verbose:
-        print("The resulting subsampled set has {:d} samples (original timeseries had {:d}).".format(N, T))
+        logger.debug("The resulting subsampled set has {:d} samples (original timeseries had {:d}).".format(N, T))
 
     # Return the list of indices of uncorrelated snapshots.
     return indices


### PR DESCRIPTION
Converted `print` calls to `logging`.

Criteria for the levels:

- By default, they use `logger.info`.
- If the message was prefixed with `Warning` or was part of a check, it uses `logger.warning`.
- If the `print` call is part of a `if verbose:` block, they use `logger.debug`.


## Todo

- [ ] Remove `if verbose` lines and replace with a `logger.setLevel` call.
- [ ] Provide handlers and formatters as necessary.