### PR TITLE
Apply black to the whole package

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -39,13 +39,13 @@ jobs:
         uname -a
         df -h
         ulimit -a
-    
+
     - name: Fix conda in MacOS
       shell: bash
       if: startsWith(matrix.os, 'macOS')
       run: |
         sudo chown -R $(id -u):$(id -g) ${CONDA}
-    
+
     - name: Create environment for package
       shell: bash
       run: |
@@ -77,7 +77,7 @@ jobs:
         flags: unittests
         yml: ./.codecov.yml
 
-  lint:
+  lint-format:
     runs-on: ubuntu-latest
     env:
       CI_OS: ubuntu-latest
@@ -88,18 +88,26 @@ jobs:
     - name: Checkout the code
       uses: actions/checkout@v1
 
-    - name: Install linter
+    - name: Install linter and formatter
       shell: bash
       run: |
         . devtools/github-actions/initialize_conda.sh
         conda activate
         python devtools/scripts/create_conda_env.py -n=test -p=$PYVER devtools/conda-envs/test_env.yaml
         conda activate test
-        conda install pylint
+        conda install pylint black
 
-    - name: Run linter
+    - name: Run pylint
       shell: bash
       run: |
         . devtools/github-actions/initialize_conda.sh
         conda activate test
         pylint $PACKAGE/
+
+    # TODO: Remove --exclude pymbar/old_mbar.py after deprecation
+    - name: Run black check
+      shell: bash
+      run: |
+        . devtools/github-actions/initialize_conda.sh
+        conda activate test
+        black --check -l 99 $PACKAGE/ --exclude pymbar/old_mbar.py

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -107,6 +107,7 @@ jobs:
     # TODO: Remove --exclude pymbar/old_mbar.py after deprecation
     - name: Run black check
       shell: bash
+      if: always()
       run: |
         . devtools/github-actions/initialize_conda.sh
         conda activate test

--- a/pymbar/__init__.py
+++ b/pymbar/__init__.py
@@ -40,9 +40,20 @@ try:
 except ImportError:
     # Fill in information manually.
     # TODO: See if we can at least get the git revision info in here.
-    version = 'dev'
-    full_version = 'dev'
-    git_revision = 'dev'
+    version = "dev"
+    full_version = "dev"
+    git_revision = "dev"
     isrelease = False
 
-__all__ = ['EXP', 'EXPGauss', 'BAR', 'BARzero', 'MBAR', 'timeseries', 'testsystems', 'confidenceintervals', 'utils', 'PMF']
+__all__ = [
+    "EXP",
+    "EXPGauss",
+    "BAR",
+    "BARzero",
+    "MBAR",
+    "timeseries",
+    "testsystems",
+    "confidenceintervals",
+    "utils",
+    "PMF",
+]

--- a/pymbar/bar.py
+++ b/pymbar/bar.py
@@ -30,22 +30,22 @@ This module contains implementations of
 
 """
 
-#=============================================================================================
+# =============================================================================================
 # TODO
 # * Fix computeBAR and computeEXP to be BAR() and EXP() to make them easier to find.
 # * Make functions that don't need to be exported (like logsum) private by prefixing an underscore.
 # * Make asymptotic covariance matrix computation more robust to over/underflow.
 # * Double-check correspondence of comments to equation numbers once manuscript has been finalized.
 # * Change self.nonzero_N_k_indices to self.states_with_samples
-#=============================================================================================
+# =============================================================================================
 
 
 __authors__ = "Michael R. Shirts and John D. Chodera."
 __license__ = "MIT"
 
-#=============================================================================================
+# =============================================================================================
 # IMPORTS
-#=============================================================================================
+# =============================================================================================
 import logging
 import numpy as np
 from pymbar.utils import ParameterError, ConvergenceError, BoundsError, logsumexp
@@ -94,7 +94,7 @@ def BARzero(w_F, w_R, DeltaF):
 
     """
 
-    np.seterr(over='raise')  # raise exceptions to overflows
+    np.seterr(over="raise")  # raise exceptions to overflows
     w_F = np.array(w_F, np.float64)
     w_R = np.array(w_R, np.float64)
     DeltaF = float(DeltaF)
@@ -117,11 +117,11 @@ def BARzero(w_F, w_R, DeltaF):
     #          = - maxarg - log(exp[-maxarg] + exp[(M + W - DeltaF) - maxarg])
     # where maxarg = max((M + W - DeltaF), 0)
 
-    exp_arg_F = (M + w_F - DeltaF)
+    exp_arg_F = M + w_F - DeltaF
     # use boolean logic to zero out the ones that are less than 0, but not if greater than zero.
     max_arg_F = np.choose(np.less(0.0, exp_arg_F), (0.0, exp_arg_F))
     try:
-        log_f_F = - max_arg_F - np.log(np.exp(-max_arg_F) + np.exp(exp_arg_F - max_arg_F))
+        log_f_F = -max_arg_F - np.log(np.exp(-max_arg_F) + np.exp(exp_arg_F - max_arg_F))
     except ParameterError():
         # give up; if there's overflow, return zero
         logger.warning("The input data results in overflow in BAR")
@@ -138,7 +138,7 @@ def BARzero(w_F, w_R, DeltaF):
     # use boolean logic to zero out the ones that are less than 0, but not if greater than zero.
     max_arg_R = np.choose(np.less(0.0, exp_arg_R), (0.0, exp_arg_R))
     try:
-        log_f_R = - max_arg_R - np.log(np.exp(-max_arg_R) + np.exp(exp_arg_R - max_arg_R))
+        log_f_R = -max_arg_R - np.log(np.exp(-max_arg_R) + np.exp(exp_arg_R - max_arg_R))
     except ParameterError:
         logger.info("The input data results in overflow in BAR")
         return np.nan
@@ -147,11 +147,24 @@ def BARzero(w_F, w_R, DeltaF):
     # This function must be zeroed to find a root
     fzero = log_numer - log_denom
 
-    np.seterr(over='warn')  # return options to standard settings so we don't disturb other functionality.
+    np.seterr(
+        over="warn"
+    )  # return options to standard settings so we don't disturb other functionality.
     return fzero
 
 
-def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR',maximum_iterations=500, relative_tolerance=1.0e-12, verbose=False, method='false-position', iterated_solution=True):
+def BAR(
+    w_F,
+    w_R,
+    DeltaF=0.0,
+    compute_uncertainty=True,
+    uncertainty_method="BAR",
+    maximum_iterations=500,
+    relative_tolerance=1.0e-12,
+    verbose=False,
+    method="false-position",
+    iterated_solution=True,
+):
     """Compute free energy difference using the Bennett acceptance ratio (BAR) method.
 
     Parameters
@@ -225,44 +238,48 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
 
     if not iterated_solution:
         maximum_iterations = 1
-        method = 'self-consistent-iteration'
+        method = "self-consistent-iteration"
         DeltaF_initial = DeltaF
 
-    if method not in ['self-consistent-iteration','false-position','bisection']:
-        raise ParameterError('method {:d} is not defined for BAR'.format(method))
+    if method not in ["self-consistent-iteration", "false-position", "bisection"]:
+        raise ParameterError("method {:d} is not defined for BAR".format(method))
 
-    if uncertainty_method not in ['BAR','MBAR']:
-        raise ParameterError('uncertainty_method {:d} is not defined for BAR'.format(uncertainty_method))        
+    if uncertainty_method not in ["BAR", "MBAR"]:
+        raise ParameterError(
+            "uncertainty_method {:d} is not defined for BAR".format(uncertainty_method)
+        )
 
-    if method == 'self-consistent-iteration':
+    if method == "self-consistent-iteration":
         nfunc = 0
 
-    if method == 'bisection' or method == 'false-position':
-        UpperB = EXP(w_F)['Delta_f']
-        LowerB = -EXP(w_R)['Delta_f']
+    if method == "bisection" or method == "false-position":
+        UpperB = EXP(w_F)["Delta_f"]
+        LowerB = -EXP(w_R)["Delta_f"]
 
         FUpperB = BARzero(w_F, w_R, UpperB)
         FLowerB = BARzero(w_F, w_R, LowerB)
         nfunc = 2
 
-        if (np.isnan(FUpperB) or np.isnan(FLowerB)):
+        if np.isnan(FUpperB) or np.isnan(FLowerB):
             # this data set is returning NAN -- will likely not work.  Return 0, print a warning:
             # consider returning more information about failure
-            logger.warning("BAR is likely to be inaccurate because of poor overlap. Improve the sampling, or decrease the spacing betweeen states.  For now, guessing that the free energy difference is 0 with no uncertainty.")
+            logger.warning(
+                "BAR is likely to be inaccurate because of poor overlap. Improve the sampling, or decrease the spacing betweeen states.  For now, guessing that the free energy difference is 0 with no uncertainty."
+            )
             if compute_uncertainty:
-                result_vals['Delta_f'] = 0.0 
-                result_vals['dDelta_f'] = 0.0
+                result_vals["Delta_f"] = 0.0
+                result_vals["dDelta_f"] = 0.0
                 return result_vals
 
             else:
-                result_vals['Delta_f'] = 0.0
+                result_vals["Delta_f"] = 0.0
                 return result_vals
-            
+
         while FUpperB * FLowerB > 0:
             # if they have the same sign, they do not bracket.  Widen the bracket until they have opposite signs.
             # There may be a better way to do this, and the above bracket should rarely fail.
             if verbose:
-                logger.info('Initial brackets did not actually bracket, widening them')
+                logger.info("Initial brackets did not actually bracket, widening them")
             FAve = (UpperB + LowerB) / 2
             UpperB = UpperB - max(abs(UpperB - FAve), 0.1)
             LowerB = LowerB + max(abs(LowerB - FAve), 0.1)
@@ -276,7 +293,7 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
 
         DeltaF_old = DeltaF
 
-        if method == 'false-position':
+        if method == "false-position":
             # Predict the new value
             if (LowerB == 0.0) and (UpperB == 0.0):
                 DeltaF = 0.0
@@ -289,25 +306,25 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
             if FNew == 0:
                 # Convergence is achieved.
                 if verbose:
-                    logger.info('Convergence achieved.')
+                    logger.info("Convergence achieved.")
                 relative_change = 10 ** (-15)
                 break
 
-        if method == 'bisection':
+        if method == "bisection":
             # Predict the new value
             DeltaF = (UpperB + LowerB) / 2
             FNew = BARzero(w_F, w_R, DeltaF)
             nfunc += 1
 
-        if method == 'self-consistent-iteration':
+        if method == "self-consistent-iteration":
             DeltaF = -BARzero(w_F, w_R, DeltaF) + DeltaF
             nfunc += 1
 
         # Check for convergence.
-        if (DeltaF == 0.0):
+        if DeltaF == 0.0:
             # The free energy difference appears to be zero -- return.
             if verbose:
-                logger.info('The free energy difference appears to be zero.')
+                logger.info("The free energy difference appears to be zero.")
             break
 
         if iterated_solution:
@@ -315,13 +332,13 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
             if verbose:
                 logger.info("relative_change = {:12.3f}".format(relative_change))
 
-            if ((iteration > 0) and (relative_change < relative_tolerance)):
+            if (iteration > 0) and (relative_change < relative_tolerance):
                 # Convergence is achieved.
                 if verbose:
                     logger.info("Convergence achieved.")
                 break
 
-        if method == 'false-position' or method == 'bisection':
+        if method == "false-position" or method == "bisection":
             if FUpperB * FNew < 0:
                 # these two now bracket the root
                 LowerB = DeltaF
@@ -331,7 +348,7 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
                 UpperB = DeltaF
                 FUpperB = FNew
             else:
-                message = 'WARNING: Cannot determine bound on free energy'
+                message = "WARNING: Cannot determine bound on free energy"
                 raise BoundsError(message)
 
         if verbose:
@@ -341,9 +358,15 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
     if iterated_solution:
         if iteration < maximum_iterations:
             if verbose:
-                logger.info('Converged to tolerance of {:e} in {:d} iterations ({:d} function evaluations)'.format(relative_change, iteration, nfunc))
+                logger.info(
+                    "Converged to tolerance of {:e} in {:d} iterations ({:d} function evaluations)".format(
+                        relative_change, iteration, nfunc
+                    )
+                )
         else:
-            message = 'WARNING: Did not converge to within specified tolerance. max_delta = {:f}, TOLERANCE = {:f}, MAX_ITS = {:d}'.format(relative_change, relative_tolerance, maximum_iterations)
+            message = "WARNING: Did not converge to within specified tolerance. max_delta = {:f}, TOLERANCE = {:f}, MAX_ITS = {:d}".format(
+                relative_change, relative_tolerance, maximum_iterations
+            )
             raise ConvergenceError(message)
 
     if compute_uncertainty:
@@ -468,42 +491,43 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
         # In theory, overflow handling should not be needed now, because we use numlogexp or a custom routine?
 
         # fF = 1 / (1 + np.exp(w_F + C)), but we need to handle overflows
-        exp_arg_F = (w_F + C)
-        max_arg_F  = np.max(exp_arg_F)
-        log_fF = - np.log(np.exp(-max_arg_F) + np.exp(exp_arg_F - max_arg_F))
-        afF  = np.exp(logsumexp(log_fF)-max_arg_F)/T_F
+        exp_arg_F = w_F + C
+        max_arg_F = np.max(exp_arg_F)
+        log_fF = -np.log(np.exp(-max_arg_F) + np.exp(exp_arg_F - max_arg_F))
+        afF = np.exp(logsumexp(log_fF) - max_arg_F) / T_F
 
         # fR = 1 / (1 + np.exp(w_R - C)), but we need to handle overflows
-        exp_arg_R = (w_R - C)
-        max_arg_R  = np.max(exp_arg_R)
-        log_fR = - np.log(np.exp(-max_arg_R) + np.exp(exp_arg_R - max_arg_R))
-        afR = np.exp(logsumexp(log_fR)-max_arg_R)/T_R
+        exp_arg_R = w_R - C
+        max_arg_R = np.max(exp_arg_R)
+        log_fR = -np.log(np.exp(-max_arg_R) + np.exp(exp_arg_R - max_arg_R))
+        afR = np.exp(logsumexp(log_fR) - max_arg_R) / T_R
 
-        afF2 = np.exp(logsumexp(2*log_fF)-2*max_arg_F)/T_F
-        afR2 = np.exp(logsumexp(2*log_fR)-2*max_arg_R)/T_R
+        afF2 = np.exp(logsumexp(2 * log_fF) - 2 * max_arg_F) / T_F
+        afR2 = np.exp(logsumexp(2 * log_fR) - 2 * max_arg_R) / T_R
 
-        nrat = (T_F + T_R)/(T_F * T_R)   # same for both methods
+        nrat = (T_F + T_R) / (T_F * T_R)  # same for both methods
 
-        if uncertainty_method == 'BAR':
-            variance = (afF2/afF**2)/T_F + (afR2/afR**2)/T_R - nrat
+        if uncertainty_method == "BAR":
+            variance = (afF2 / afF ** 2) / T_F + (afR2 / afR ** 2) / T_R - nrat
             dDeltaF = np.sqrt(variance)
-        elif uncertainty_method == 'MBAR':
+        elif uncertainty_method == "MBAR":
             # OR equivalently
-            vartemp = ((afF - afF2)*T_F + (afR - afR2)*T_R)
-            dDeltaF = np.sqrt(1.0/vartemp - nrat)
+            vartemp = (afF - afF2) * T_F + (afR - afR2) * T_R
+            dDeltaF = np.sqrt(1.0 / vartemp - nrat)
         else:
-            message = 'ERROR: BAR uncertainty method {:s} is not defined'.format(uncertainty_method)
+            message = "ERROR: BAR uncertainty method {:s} is not defined".format(
+                uncertainty_method
+            )
             raise ParameterError(message)
 
         if verbose:
             logger.info("DeltaF = {:8.3f} +- {:8.3f}".format(DeltaF, dDeltaF))
-        result_vals['Delta_f'] = DeltaF
-        result_vals['dDelta_f'] = dDeltaF
+        result_vals["Delta_f"] = DeltaF
+        result_vals["dDelta_f"] = dDeltaF
         return result_vals
 
     else:
         if verbose:
             logger.info("DeltaF = {:8.3f}".format(DeltaF))
-        result_vals['Delta_f'] = DeltaF
+        result_vals["Delta_f"] = DeltaF
         return result_vals
-

--- a/pymbar/exp.py
+++ b/pymbar/exp.py
@@ -30,26 +30,27 @@ This module contains implementations of
 * EXP - unidirectional estimator for free energy differences based on Zwanzig relation / exponential averaging
 """
 
-#=============================================================================================
+# =============================================================================================
 # * Fix computeBAR and computeEXP to be BAR() and EXP() to make them easier to find.
 # * Make functions that don't need to be exported (like logsum) private by prefixing an underscore.
 # * Make asymptotic covariance matrix computation more robust to over/underflow.
 # * Double-check correspondence of comments to equation numbers once manuscript has been finalized.
 # * Change self.nonzero_N_k_indices to self.states_with_samples
-#=============================================================================================
+# =============================================================================================
 
 __authors__ = "Michael R. Shirts and John D. Chodera."
 __license__ = "MIT"
 
-#=============================================================================================
+# =============================================================================================
 # IMPORTS
-#=============================================================================================
+# =============================================================================================
 import numpy as np
 from pymbar.utils import logsumexp
 
-#=============================================================================================
+# =============================================================================================
 # One-sided exponential averaging (EXP).
-#=============================================================================================
+# =============================================================================================
+
 
 def EXP(w_F, compute_uncertainty=True, is_timeseries=False):
     """Estimate free energy difference using one-sided (unidirectional) exponential averaging (EXP).
@@ -97,7 +98,7 @@ def EXP(w_F, compute_uncertainty=True, is_timeseries=False):
     T = float(np.size(w_F))  # number of work measurements
 
     # Estimate free energy difference by exponential averaging using DeltaF = - log < exp(-w_F) >
-    DeltaF = - (logsumexp(- w_F) - np.log(T))
+    DeltaF = -(logsumexp(-w_F) - np.log(T))
 
     if compute_uncertainty:
         # Compute x_i = np.exp(-w_F_i - max_arg)
@@ -112,25 +113,28 @@ def EXP(w_F, compute_uncertainty=True, is_timeseries=False):
         if is_timeseries:
             # Estimate statistical inefficiency of x timeseries.
             import timeseries
+
             g = timeseries.statisticalInefficiency(x, x)
 
         # Estimate standard error of E[x].
         dx = np.std(x) / np.sqrt(T / g)
 
         # dDeltaF = <x>^-1 dx
-        dDeltaF = (dx / Ex)
+        dDeltaF = dx / Ex
 
         # Return estimate of free energy difference and uncertainty.
-        result_vals['Delta_f'] = DeltaF
-        result_vals['dDelta_f'] = dDeltaF
+        result_vals["Delta_f"] = DeltaF
+        result_vals["dDelta_f"] = dDeltaF
     else:
-        result_vals['Delta_f'] = DeltaF
+        result_vals["Delta_f"] = DeltaF
 
     return result_vals
 
-#=============================================================================================
+
+# =============================================================================================
 # Gaussian approximation to exponential averaging (Gauss).
-#=============================================================================================
+# =============================================================================================
+
 
 def EXPGauss(w_F, compute_uncertainty=True, is_timeseries=False):
     """Estimate free energy difference using gaussian approximation to one-sided (unidirectional) exponential averaging.
@@ -188,6 +192,7 @@ def EXPGauss(w_F, compute_uncertainty=True, is_timeseries=False):
         if is_timeseries:
             # Estimate statistical inefficiency of x timeseries.
             import timeseries
+
             g = timeseries.statisticalInefficiency(w_F, w_F)
 
             T_eff = T / g
@@ -196,9 +201,8 @@ def EXPGauss(w_F, compute_uncertainty=True, is_timeseries=False):
         dDeltaF = np.sqrt(dx2)
 
         # Return estimate of free energy difference and uncertainty.
-        result_vals['Delta_f'] = DeltaF
-        result_vals['dDelta_f'] = dDeltaF
+        result_vals["Delta_f"] = DeltaF
+        result_vals["dDelta_f"] = dDeltaF
     else:
-        result_vals['Delta_f'] = DeltaF
+        result_vals["Delta_f"] = DeltaF
     return result_vals
-

--- a/pymbar/mbar.py
+++ b/pymbar/mbar.py
@@ -42,7 +42,14 @@ import logging
 import numpy as np
 import numpy.linalg as linalg
 from pymbar import mbar_solvers
-from pymbar.utils import kln_to_kn, kn_to_n, ParameterError, DataError, logsumexp, check_w_normalized
+from pymbar.utils import (
+    kln_to_kn,
+    kn_to_n,
+    ParameterError,
+    DataError,
+    logsumexp,
+    check_w_normalized,
+)
 
 logger = logging.getLogger(__name__)
 DEFAULT_SOLVER_PROTOCOL = mbar_solvers.DEFAULT_SOLVER_PROTOCOL
@@ -70,10 +77,21 @@ class MBAR:
     J. Chem. Phys. 129:124105, 2008
     http://dx.doi.org/10.1063/1.2978177
     """
+
     # =========================================================================
 
-    def __init__(self, u_kn, N_k, maximum_iterations=10000, relative_tolerance=1.0e-7, verbose=False, initial_f_k=None,
-                 solver_protocol=None, initialize='zeros', x_kindices=None):
+    def __init__(
+        self,
+        u_kn,
+        N_k,
+        maximum_iterations=10000,
+        relative_tolerance=1.0e-7,
+        verbose=False,
+        initial_f_k=None,
+        solver_protocol=None,
+        initialize="zeros",
+        x_kindices=None,
+    ):
         """Initialize multistate Bennett acceptance ratio (MBAR) on a set of simulation data.
 
         Upon initialization, the dimensionless free energies for all states are computed.
@@ -203,7 +221,8 @@ class MBAR:
 
         if np.sum(self.N_k) != N:
             raise ParameterError(
-                'The sum of all N_k must equal the total number of samples (length of second dimension of u_kn.')
+                "The sum of all N_k must equal the total number of samples (length of second dimension of u_kn."
+            )
 
         # Store local copies of other data
         self.K = K  # number of thermodynamic states energies are evaluated at
@@ -217,7 +236,7 @@ class MBAR:
             self.x_kindices = np.arange(N, dtype=np.int64)
             Nsum = 0
             for k in range(K):
-                self.x_kindices[Nsum:Nsum+self.N_k[k]] = k
+                self.x_kindices[Nsum : Nsum + self.N_k[k]] = k
                 Nsum += self.N_k[k]
 
         # verbosity level -- if True, will print extra debug information
@@ -246,14 +265,14 @@ class MBAR:
             # but not clear if needed.
 
             # pick random indices
-            indices = np.random.choice(np.arange(self.N),maxpoint)
+            indices = np.random.choice(np.arange(self.N), maxpoint)
 
             for k in range(K):
                 for l in range(k):
                     diffsum = 0
                     uzero = u_kn[k, indices] - u_kn[l, indices]
                     diffsum += np.dot(uzero, uzero)
-                    if (diffsum < relative_tolerance):
+                    if diffsum < relative_tolerance:
                         self.samestates.append([k, l])
                         self.samestates.append([l, k])
                         msg = """
@@ -261,7 +280,9 @@ class MBAR:
                         They are therefore likely to to be the same thermodynamic state. This can occasionally cause
                         numerical problems with computing the covariance of their energy difference, which must be
                         identically zero in any case. Consider combining them into a single state.
-                        """.format(l, k)
+                        """.format(
+                            l, k
+                        )
                         logger.warning(dedent(msg[1:]))
 
         # Print number of samples from each state.
@@ -293,7 +314,8 @@ class MBAR:
             # Check shape
             if initial_f_k.shape != self.f_k.shape:
                 raise ParameterError(
-                    "initial_f_k must be a {:d}-dimensional np array.".format(self.K))
+                    "initial_f_k must be a {:d}-dimensional np array.".format(self.K)
+                )
             # Initialize f_k with provided guess.
             self.f_k = initial_f_k
             if self.verbose:
@@ -305,21 +327,25 @@ class MBAR:
             self._initializeFreeEnergies(verbose, method=initialize)
 
             if self.verbose:
-                logger.info("Initial dimensionless free energies with method {:s}".format(initialize))
+                logger.info(
+                    "Initial dimensionless free energies with method {:s}".format(initialize)
+                )
                 logger.info("f_k = ")
                 logger.info(self.f_k)
 
         if solver_protocol is None:
-            solver_protocol = ({'method': None},)
+            solver_protocol = ({"method": None},)
         for solver in solver_protocol:
-            if 'options' not in solver:
-                solver['options'] = dict()
-            if 'verbose' not in solver['options']:
+            if "options" not in solver:
+                solver["options"] = dict()
+            if "verbose" not in solver["options"]:
                 # should add in other ways to get information out of the scipy solvers, not just adaptive,
                 # which might involve passing in different combinations of options, and passing out other strings.
-                solver['options']['verbose'] = self.verbose
+                solver["options"]["verbose"] = self.verbose
 
-        self.f_k = mbar_solvers.solve_mbar_for_all_states(self.u_kn, self.N_k, self.f_k, solver_protocol)
+        self.f_k = mbar_solvers.solve_mbar_for_all_states(
+            self.u_kn, self.N_k, self.f_k, solver_protocol
+        )
         self.Log_W_nk = mbar_solvers.mbar_log_W_nk(self.u_kn, self.N_k, self.f_k)
 
         # Print final dimensionless free energies.
@@ -361,7 +387,7 @@ class MBAR:
         return self.W_nk
 
     # =========================================================================
-    def computeEffectiveSampleNumber(self, verbose = False):
+    def computeEffectiveSampleNumber(self, verbose=False):
         """
         Compute the effective sample number of each state;
         essentially, an estimate of how many samples are contributing to the average
@@ -413,11 +439,17 @@ class MBAR:
 
         N_eff = np.zeros(self.K)
         for k in range(self.K):
-            w = np.exp(self.Log_W_nk[:,k])
-            N_eff[k] = 1/np.sum(w**2)
+            w = np.exp(self.Log_W_nk[:, k])
+            N_eff[k] = 1 / np.sum(w ** 2)
             if verbose:
-                logger.info("Effective number of sample in state {:d} is {:10.3f}".format(k,N_eff[k]))
-                logger.info("Efficiency for state {:d} is {:6f}/{:d} = {:10.4f}".format(k,N_eff[k],len(w),N_eff[k]/len(w)))
+                logger.info(
+                    "Effective number of sample in state {:d} is {:10.3f}".format(k, N_eff[k])
+                )
+                logger.info(
+                    "Efficiency for state {:d} is {:6f}/{:d} = {:10.4f}".format(
+                        k, N_eff[k], len(w), N_eff[k] / len(w)
+                    )
+                )
 
         return N_eff
 
@@ -472,14 +504,20 @@ class MBAR:
         overlap_scalar = 1 - eigenvals[1]  # 1 minus the second largest eigenvalue
 
         results_vals = dict()
-        results_vals['scalar'] = overlap_scalar
-        results_vals['eigenvalues'] = eigenvals
-        results_vals['matrix'] = O
+        results_vals["scalar"] = overlap_scalar
+        results_vals["eigenvalues"] = eigenvals
+        results_vals["matrix"] = O
 
         return results_vals
 
-    #=========================================================================
-    def getFreeEnergyDifferences(self, compute_uncertainty=True, uncertainty_method=None, warning_cutoff=1.0e-10, return_theta=False):
+    # =========================================================================
+    def getFreeEnergyDifferences(
+        self,
+        compute_uncertainty=True,
+        uncertainty_method=None,
+        warning_cutoff=1.0e-10,
+        return_theta=False,
+    ):
         """Get the dimensionless free energy differences and uncertainties among all thermodynamic states.
 
 
@@ -530,7 +568,11 @@ class MBAR:
         >>> results = mbar.getFreeEnergyDifferences()
 
         """
-        Deltaf_ij, dDeltaf_ij, Theta_ij = None, None, None  # By default, returns None for dDelta and Theta
+        Deltaf_ij, dDeltaf_ij, Theta_ij = (
+            None,
+            None,
+            None,
+        )  # By default, returns None for dDelta and Theta
 
         # Compute free energy differences.
         Deltaf_ij = self.f_k - np.vstack(self.f_k)
@@ -540,12 +582,13 @@ class MBAR:
 
         result_vals = dict()
 
-        result_vals['Delta_f'] = Deltaf_ij
+        result_vals["Delta_f"] = Deltaf_ij
 
         if compute_uncertainty or return_theta:
             # Compute asymptotic covariance matrix.
             Theta_ij = self._computeAsymptoticCovarianceMatrix(
-                np.exp(self.Log_W_nk), self.N_k, method=uncertainty_method)
+                np.exp(self.Log_W_nk), self.N_k, method=uncertainty_method
+            )
 
         if compute_uncertainty:
             dDeltaf_ij = self._ErrorOfDifferences(Theta_ij, warning_cutoff=warning_cutoff)
@@ -553,18 +596,23 @@ class MBAR:
             self._zerosamestates(dDeltaf_ij)
             # Return matrix of free energy differences and uncertainties.
             dDeltaf_ij = np.array(dDeltaf_ij)
-            result_vals['dDelta_f'] = dDeltaf_ij
+            result_vals["dDelta_f"] = dDeltaf_ij
 
         if return_theta:
-            result_vals['Theta'] = Theta_ij
+            result_vals["Theta"] = Theta_ij
 
         return result_vals
 
     # =========================================================================
-    def computeExpectationsInner(self, A_n, u_ln, state_map,
-                                 uncertainty_method=None,
-                                 warning_cutoff=1.0e-10,
-                                 return_theta=False):
+    def computeExpectationsInner(
+        self,
+        A_n,
+        u_ln,
+        state_map,
+        uncertainty_method=None,
+        warning_cutoff=1.0e-10,
+        return_theta=False,
+    ):
         """
         Compute the expectations of multiple observables of phase space functions in multiple states.
 
@@ -647,29 +695,29 @@ class MBAR:
         """
 
         # Retrieve N and K for convenience.
-        mapshape = np.shape(state_map) # number of computed expectations we desire
-                                               # need to convert to matrix to be able to pick up D=1
+        mapshape = np.shape(state_map)  # number of computed expectations we desire
+        # need to convert to matrix to be able to pick up D=1
         if len(mapshape) < 2:
             # if 1D, it's just a list of states
             state_list = state_map.copy()
-            state_map = np.zeros([0,0],np.float64)
+            state_map = np.zeros([0, 0], np.float64)
             S = 0
         else:  # if 2D, then it's a list of observables and corresponding states
-            state_list = state_map[0,:]
+            state_list = state_map[0, :]
             S = mapshape[1]
 
         # reshape arrays explicitly into 2d (even if only one state) to make it easy to manipulate
         shapeu = np.shape(u_ln)
         if len(shapeu) == 1:
-            u_ln = np.reshape(u_ln,[1,shapeu[0]])
+            u_ln = np.reshape(u_ln, [1, shapeu[0]])
 
         shapeA = np.shape(A_n)
         if len(shapeA) == 1:
-            A_n = np.reshape(A_n,[1,shapeA[0]])
+            A_n = np.reshape(A_n, [1, shapeA[0]])
 
         K = self.K
         N = self.N  # N is total number of samples
-        result_vals = dict() # dictionary we will store uncertainties in
+        result_vals = dict()  # dictionary we will store uncertainties in
 
         # make observables all positive, allowing us to take the logarithm, which is
         # required to prevent overflow in some examples.
@@ -678,24 +726,26 @@ class MBAR:
         # This could lead to roundoff problems (check with Levi N.)
 
         L_list = np.unique(state_list)
-        NL = len(L_list) # number of states we need to examine
+        NL = len(L_list)  # number of states we need to examine
         if S > 0:
-            A_list = np.unique(state_map[1,:])  # what are the unique observables
+            A_list = np.unique(state_map[1, :])  # what are the unique observables
             A_min = np.zeros([len(A_list)], dtype=np.float64)
         else:
-            A_list = np.zeros(0,dtype=int)
+            A_list = np.zeros(0, dtype=int)
 
         for i in A_list:
-            A_min[i] = np.min(A_n[i, :]) #find the minimum
-            A_n[i, :] = A_n[i,:] - (A_min[i] - 1)  #all values now positive so that we can work in logarithmic scale
+            A_min[i] = np.min(A_n[i, :])  # find the minimum
+            A_n[i, :] = A_n[i, :] - (
+                A_min[i] - 1
+            )  # all values now positive so that we can work in logarithmic scale
 
         # Augment W_nk, N_k, and c_k for q_A(x) for the observables, with one
         # row for the specified state and I rows for the observable at that
         # state.
         # log weight matrix
-        msize = K + NL + S # augmented size; all of the states needed to calculate
-                           # the observables, and the observables themselves.
-        Log_W_nk = np.zeros([N, msize], np.float64) # log weight matrix
+        msize = K + NL + S  # augmented size; all of the states needed to calculate
+        # the observables, and the observables themselves.
+        Log_W_nk = np.zeros([N, msize], np.float64)  # log weight matrix
         N_k = np.zeros([msize], np.int64)  # counts
         f_k = np.zeros([msize], np.float64)  # free energies
 
@@ -706,12 +756,16 @@ class MBAR:
         f_k[0:K] = self.f_k
 
         # Pre-calculate the log denominator: Eqns 13, 14 in MBAR paper
-        states_with_samples = (self.N_k > 0)
-        log_denominator_n = logsumexp(self.f_k[states_with_samples] - self.u_kn[states_with_samples].T, b=self.N_k[states_with_samples], axis=1)
+        states_with_samples = self.N_k > 0
+        log_denominator_n = logsumexp(
+            self.f_k[states_with_samples] - self.u_kn[states_with_samples].T,
+            b=self.N_k[states_with_samples],
+            axis=1,
+        )
         # Compute row of W_nk matrix for the extra states corresponding to u_ln
         # that the state list specifies
         for l in L_list:
-            la = K+l  #l, augmented
+            la = K + l  # l, augmented
             # Calculate log normalizing constants and log weights via Eqns 13, 14
             log_C_a = -logsumexp(-u_ln[l] - log_denominator_n)
             Log_W_nk[:, la] = log_C_a - u_ln[l] - log_denominator_n
@@ -720,12 +774,12 @@ class MBAR:
         # Compute the remaining rows/columns of W_nk, and calculate
         # their normalizing constants c_k
         for s in range(S):
-            sa = K+NL+s  # augmented s
-            l = K + state_map[0,s]
-            i = state_map[1,s]
+            sa = K + NL + s  # augmented s
+            l = K + state_map[0, s]
+            i = state_map[1, s]
             Log_W_nk[:, sa] = np.log(A_n[i, :]) + Log_W_nk[:, l]
             f_k[sa] = -logsumexp(Log_W_nk[:, sa])
-            Log_W_nk[:, sa] += f_k[sa]    # normalize this row
+            Log_W_nk[:, sa] += f_k[sa]  # normalize this row
 
         # Compute estimates of A_i[s]
         A_i = np.zeros([S], np.float64)
@@ -735,19 +789,20 @@ class MBAR:
         # Now that covariances are computed, add the constants back to A_i that
         # were required to enforce positivity
         for s in range(S):
-            A_i[s] += (A_min[state_map[1,s]] - 1)
+            A_i[s] += A_min[state_map[1, s]] - 1
 
         # these values may be used outside the routine, so copy back.
         for i in A_list:
-            A_n[i, :] = A_n[i,:] + (A_min[i] - 1)
+            A_n[i, :] = A_n[i, :] + (A_min[i] - 1)
 
         # expectations of the observables at these states
         if S > 0:
-            result_vals['observables'] = A_i
+            result_vals["observables"] = A_i
 
         if return_theta:
             Theta_ij = self._computeAsymptoticCovarianceMatrix(
-                np.exp(Log_W_nk), N_k, method=uncertainty_method)
+                np.exp(Log_W_nk), N_k, method=uncertainty_method
+            )
 
             # Note: these variances will be the same whether or not we
             # subtract a different constant from each A_i
@@ -757,20 +812,20 @@ class MBAR:
             #          K*NL  NL*S NL*NL
 
             # first the observables (S of them), then the free energies (also S of them)
-            if S>0:
-                si = K+NL+np.arange(S)
+            if S > 0:
+                si = K + NL + np.arange(S)
             else:
-                si = np.zeros(0,dtype=int)
-            li = K+state_list
-            i = np.concatenate((si,li))
+                si = np.zeros(0, dtype=int)
+            li = K + state_list
+            i = np.concatenate((si, li))
             Theta = Theta_ij[np.ix_(i, i)]
-            result_vals['Theta'] = Theta
+            result_vals["Theta"] = Theta
             if S > 0:
                 # we need to return the minimum A as well
-                result_vals['Amin'] = (A_min[state_map[1,np.arange(S)]] - 1)
+                result_vals["Amin"] = A_min[state_map[1, np.arange(S)]] - 1
 
         # free energies at these new states
-        result_vals['f'] =  f_k[K+state_list]
+        result_vals["f"] = f_k[K + state_list]
 
         # Return expectations and uncertainties.
         return result_vals
@@ -804,7 +859,7 @@ class MBAR:
         #   =  A^2 (Theta(c_A,c_A) + (A^2+2A+1)Theta(c_a,c_a) -(2A^2+2A)Theta(c_A,c_a)
         #
 
-    #=========================================================================
+    # =========================================================================
     def computeCovarianceOfSums(self, d_ij, K, a):
 
         """
@@ -876,21 +931,38 @@ class MBAR:
 
         # todo: vectorize this.
         var_ij = np.square(d_ij)
-        d2 = np.zeros([K,K],float)
+        d2 = np.zeros([K, K], float)
         n = len(a)
         for i in range(K):
             for j in range(K):
                 for k in range(n):
-                    d2[i,j] +=  a[k]**2 * var_ij[i+k*K,j+k*K]
+                    d2[i, j] += a[k] ** 2 * var_ij[i + k * K, j + k * K]
                     for l in range(n):
-                        d2[i,j] +=  a[k] * a[l] * (-var_ij[i+k*K,i+l*K] + var_ij[i+k*K,j+l*K] + var_ij[j+k*K,i+l*K] - var_ij[j+k*K,j+l*K])
+                        d2[i, j] += (
+                            a[k]
+                            * a[l]
+                            * (
+                                -var_ij[i + k * K, i + l * K]
+                                + var_ij[i + k * K, j + l * K]
+                                + var_ij[j + k * K, i + l * K]
+                                - var_ij[j + k * K, j + l * K]
+                            )
+                        )
 
         return np.sqrt(d2)
 
-    #=========================================================================
-    def computeExpectations(self, A_n, u_kn=None, output='averages', state_dependent=False,
-                            compute_uncertainty=True, uncertainty_method=None,
-                            warning_cutoff=1.0e-10, return_theta=False):
+    # =========================================================================
+    def computeExpectations(
+        self,
+        A_n,
+        u_kn=None,
+        output="averages",
+        state_dependent=False,
+        compute_uncertainty=True,
+        uncertainty_method=None,
+        warning_cutoff=1.0e-10,
+        return_theta=False,
+    ):
         """Compute the expectation of an observable of a phase space function.
 
         Compute the expectation of an observable of a single phase space
@@ -958,10 +1030,12 @@ class MBAR:
         dims = len(np.shape(A_n))
 
         if dims > 2:
-            logger.warning("dim=3 for (state_dependent==True) matrices for observables and dim=2 for (state_dependent==False) observables are deprecated; we suggest you convert to NxK form instead of NxKxK form.")
+            logger.warning(
+                "dim=3 for (state_dependent==True) matrices for observables and dim=2 for (state_dependent==False) observables are deprecated; we suggest you convert to NxK form instead of NxKxK form."
+            )
 
         if not state_dependent:
-            if dims==2:
+            if dims == 2:
                 A_n = kn_to_n(A_n, N_k=self.N_k)
                 if u_kn is not None:
                     if len(np.shape(u_kn)) == 3:
@@ -969,7 +1043,7 @@ class MBAR:
                     elif len(np.shape(u_kn)) == 2:
                         u_kn = kn_to_n(u_kn, N_k=self.N_k)
         else:
-            if dims==3:
+            if dims == 3:
                 A_n = kln_to_kn(A_n, N_k=self.N_k)
                 if u_kn is not None:
                     if len(np.shape(u_kn)) == 3:
@@ -986,57 +1060,76 @@ class MBAR:
         if len(ushape) == 1:
             K = 1
         else:
-            K = np.shape(u_kn)[0] # number of potentials provided.
+            K = np.shape(u_kn)[0]  # number of potentials provided.
 
-        state_map = np.zeros([2,K],int)
+        state_map = np.zeros([2, K], int)
         if state_dependent:
             for k in range(K):
                 # first property at the first state, 2nd property at the 2nd state
-                state_map[0,k] = k
-                state_map[1,k] = k
+                state_map[0, k] = k
+                state_map[1, k] = k
         else:
             # only one property, evaluate at K different states.
             for k in range(K):
-                state_map[0,k] = k
-                state_map[1,k] = 0
+                state_map[0, k] = k
+                state_map[1, k] = 0
 
-        inner_results = self.computeExpectationsInner(A_n,u_kn,state_map,
-                                                      return_theta=compute_uncertainty,
-                                                      uncertainty_method=uncertainty_method,
-                                                      warning_cutoff=warning_cutoff)
+        inner_results = self.computeExpectationsInner(
+            A_n,
+            u_kn,
+            state_map,
+            return_theta=compute_uncertainty,
+            uncertainty_method=uncertainty_method,
+            warning_cutoff=warning_cutoff,
+        )
 
         result_vals = dict()
         if compute_uncertainty or return_theta:
             # we want the theta matrix for the exponentials of the
             # observables, which means we need to make the
             # transformation.
-            Adiag = np.zeros([2*K,2*K],dtype=np.float64)
-            diag = np.ones(2*K,dtype=np.float64)
-            diag[0:K] = diag[K:2*K] = inner_results['observables']-inner_results['Amin']
-            np.fill_diagonal(Adiag,diag)
-            Theta = Adiag*inner_results['Theta']*Adiag
-            covA_ij = np.array(Theta[0:K,0:K]+Theta[K:2*K,K:2*K]-Theta[0:K,K:2*K]-Theta[K:2*K,0:K])
+            Adiag = np.zeros([2 * K, 2 * K], dtype=np.float64)
+            diag = np.ones(2 * K, dtype=np.float64)
+            diag[0:K] = diag[K : 2 * K] = inner_results["observables"] - inner_results["Amin"]
+            np.fill_diagonal(Adiag, diag)
+            Theta = Adiag * inner_results["Theta"] * Adiag
+            covA_ij = np.array(
+                Theta[0:K, 0:K]
+                + Theta[K : 2 * K, K : 2 * K]
+                - Theta[0:K, K : 2 * K]
+                - Theta[K : 2 * K, 0:K]
+            )
 
-        if output == 'averages':
-            result_vals['mu'] = inner_results['observables']
+        if output == "averages":
+            result_vals["mu"] = inner_results["observables"]
             if compute_uncertainty:
-                result_vals['sigma'] = np.sqrt(covA_ij[0:K,0:K].diagonal())
+                result_vals["sigma"] = np.sqrt(covA_ij[0:K, 0:K].diagonal())
 
-        if output == 'differences':
-            A_im = inner_results['observables']
-            result_vals['mu'] = A_im - np.vstack(A_im)  # Cast to A_ij
+        if output == "differences":
+            A_im = inner_results["observables"]
+            result_vals["mu"] = A_im - np.vstack(A_im)  # Cast to A_ij
 
             if compute_uncertainty:
-                result_vals['sigma'] = self._ErrorOfDifferences(covA_ij,warning_cutoff=warning_cutoff)
+                result_vals["sigma"] = self._ErrorOfDifferences(
+                    covA_ij, warning_cutoff=warning_cutoff
+                )
 
         if return_theta:
-            result_vals['Theta'] = Theta
+            result_vals["Theta"] = Theta
 
         return result_vals
 
-    #=========================================================================
-    def computeMultipleExpectations(self, A_in, u_n, compute_uncertainty=True, compute_covariance=False,
-                                    uncertainty_method=None, warning_cutoff=1.0e-10, return_theta=False):
+    # =========================================================================
+    def computeMultipleExpectations(
+        self,
+        A_in,
+        u_n,
+        compute_uncertainty=True,
+        compute_covariance=False,
+        uncertainty_method=None,
+        warning_cutoff=1.0e-10,
+        return_theta=False,
+    ):
         """Compute the expectations of multiple observables of phase space functions.
 
         Compute the expectations of multiple observables of phase
@@ -1099,44 +1192,55 @@ class MBAR:
             A_in_old = A_in.copy()  # convert to k by n format
             A_in = np.zeros([I, N], np.float64)
             for i in range(I):
-                A_in[i,:] = kn_to_n(A_in_old[i, :, :], N_k=self.N_k)
+                A_in[i, :] = kn_to_n(A_in_old[i, :, :], N_k=self.N_k)
 
         if len(np.shape(u_n)) == 2:
-            u_n = kn_to_n(u_n, N_k = self.N_k)
+            u_n = kn_to_n(u_n, N_k=self.N_k)
 
-        state_map = np.zeros([2,I],int)
-        state_map[1,:] = np.arange(I)  # same (first) state for all variables.
+        state_map = np.zeros([2, I], int)
+        state_map[1, :] = np.arange(I)  # same (first) state for all variables.
 
-        inner_results = self.computeExpectationsInner(A_in,u_n,state_map,
-                                                      return_theta=(compute_uncertainty or compute_covariance),
-                                                      uncertainty_method=uncertainty_method,
-                                                      warning_cutoff=warning_cutoff)
+        inner_results = self.computeExpectationsInner(
+            A_in,
+            u_n,
+            state_map,
+            return_theta=(compute_uncertainty or compute_covariance),
+            uncertainty_method=uncertainty_method,
+            warning_cutoff=warning_cutoff,
+        )
         result_vals = dict()
         expectations, uncertainties, covariances = None, None, None
-        result_vals['mu'] = inner_results['observables']
+        result_vals["mu"] = inner_results["observables"]
 
         if compute_uncertainty or compute_covariance or return_theta:
-            Adiag = np.zeros([2*I,2*I],dtype=np.float64)
-            diag = np.ones(2*I,dtype=np.float64)
-            diag[0:I] = diag[I:2*I] = inner_results['observables']-inner_results['Amin']
-            np.fill_diagonal(Adiag,diag)
-            Theta = Adiag*inner_results['Theta']*Adiag
+            Adiag = np.zeros([2 * I, 2 * I], dtype=np.float64)
+            diag = np.ones(2 * I, dtype=np.float64)
+            diag[0:I] = diag[I : 2 * I] = inner_results["observables"] - inner_results["Amin"]
+            np.fill_diagonal(Adiag, diag)
+            Theta = Adiag * inner_results["Theta"] * Adiag
 
             if compute_uncertainty:
-                covA_ij = np.array(Theta[0:I,0:I]+Theta[I:2*I,I:2*I]-Theta[0:I,I:2*I]-Theta[I:2*I,0:I])
-                result_vals['sigma'] = np.sqrt(covA_ij[0:I,0:I].diagonal())
+                covA_ij = np.array(
+                    Theta[0:I, 0:I]
+                    + Theta[I : 2 * I, I : 2 * I]
+                    - Theta[0:I, I : 2 * I]
+                    - Theta[I : 2 * I, 0:I]
+                )
+                result_vals["sigma"] = np.sqrt(covA_ij[0:I, 0:I].diagonal())
 
             if compute_covariance:
                 # compute estimate of statistical covariance of the observables
-                result_vals['covariances'] = inner_results['Theta'][0:I,0:I]
+                result_vals["covariances"] = inner_results["Theta"][0:I, 0:I]
 
             if return_theta:
-                result_vals['Theta'] = Theta
+                result_vals["Theta"] = Theta
 
         return result_vals
 
-    #=========================================================================
-    def computePerturbedFreeEnergies(self, u_ln, compute_uncertainty=True, uncertainty_method=None, warning_cutoff=1.0e-10):
+    # =========================================================================
+    def computePerturbedFreeEnergies(
+        self, u_ln, compute_uncertainty=True, uncertainty_method=None, warning_cutoff=1.0e-10
+    ):
         """Compute the free energies for a new set of states.
 
         Here, we desire the free energy differences among a set of new states, as well as the uncertainty estimates in these differences.
@@ -1179,31 +1283,41 @@ class MBAR:
         [L, N] = u_ln.shape
 
         # Check dimensions.
-        if (N < self.N):
-            raise DataError("There seems to be too few samples in u_kn. You must evaluate at the new potential with all of the samples used originally.")
+        if N < self.N:
+            raise DataError(
+                "There seems to be too few samples in u_kn. You must evaluate at the new potential with all of the samples used originally."
+            )
 
-        state_list = np.arange(L)   # need to get it into the correct shape
+        state_list = np.arange(L)  # need to get it into the correct shape
         A_in = np.array([0])
-        inner_results = self.computeExpectationsInner(A_in, u_ln, state_list,
-                                                      return_theta=compute_uncertainty,
-                                                      uncertainty_method=uncertainty_method,
-                                                      warning_cutoff=warning_cutoff)
+        inner_results = self.computeExpectationsInner(
+            A_in,
+            u_ln,
+            state_list,
+            return_theta=compute_uncertainty,
+            uncertainty_method=uncertainty_method,
+            warning_cutoff=warning_cutoff,
+        )
 
         Deltaf_ij, dDeltaf_ij = None, None
 
-        f_k = inner_results['f']
+        f_k = inner_results["f"]
 
         result_vals = dict()
-        result_vals['Delta_f'] = f_k - np.vstack(f_k)
+        result_vals["Delta_f"] = f_k - np.vstack(f_k)
 
-        if (compute_uncertainty):
-            result_vals['dDelta_f'] = self._ErrorOfDifferences(inner_results['Theta'],warning_cutoff=warning_cutoff)
+        if compute_uncertainty:
+            result_vals["dDelta_f"] = self._ErrorOfDifferences(
+                inner_results["Theta"], warning_cutoff=warning_cutoff
+            )
 
         return result_vals
 
-    #=====================================================================
+    # =====================================================================
 
-    def computeEntropyAndEnthalpy(self, u_kn=None, uncertainty_method=None, verbose=False, warning_cutoff=1.0e-10):
+    def computeEntropyAndEnthalpy(
+        self, u_kn=None, uncertainty_method=None, verbose=False, warning_cutoff=1.0e-10
+    ):
         """Decompose free energy differences into enthalpy and entropy differences.
 
         Compute the decomposition of the free energy difference between
@@ -1250,57 +1364,66 @@ class MBAR:
             logger.info("Computing average energy and entropy by MBAR.")
 
         dims = len(np.shape(u_kn))
-        if dims==3:
+        if dims == 3:
             u_kn = kln_to_kn(u_kn, N_k=self.N_k)
 
         if u_kn is None:
             u_kn = self.u_kn
 
         # Retrieve N and K for convenience.
-        [K,N] = np.shape(u_kn)
+        [K, N] = np.shape(u_kn)
         A_in = u_kn.copy()
-        state_map = np.zeros([2,K],int)
+        state_map = np.zeros([2, K], int)
         for k in range(K):
-            state_map[0,k] = k
-            state_map[1,k] = k
+            state_map[0, k] = k
+            state_map[1, k] = k
 
-        inner_results = self.computeExpectationsInner(A_in, u_kn, state_map,
-                                                      return_theta=True,
-                                                      uncertainty_method=uncertainty_method,
-                                                      warning_cutoff=warning_cutoff)
+        inner_results = self.computeExpectationsInner(
+            A_in,
+            u_kn,
+            state_map,
+            return_theta=True,
+            uncertainty_method=uncertainty_method,
+            warning_cutoff=warning_cutoff,
+        )
 
         # construct the covariance matrix of exp(ln c_Ua - ln c_a) - ln c_ca
 
-        Theta = np.zeros([3*K,3*K],dtype=np.float64)
-        Theta[0:2*K,0:2*K] = inner_results['Theta']
-        Theta[2*K:3*K,:] = Theta[K:2*K,:]
-        Theta[:,2*K:3*K] = Theta[:,K:2*K]
-        diag = np.ones(3*K,dtype=np.float64)
-        diag[0:K] = diag[K:2*K] = inner_results['observables']-inner_results['Amin']
-        Adiag = np.zeros([3*K, 3*K], dtype=np.float64)
+        Theta = np.zeros([3 * K, 3 * K], dtype=np.float64)
+        Theta[0 : 2 * K, 0 : 2 * K] = inner_results["Theta"]
+        Theta[2 * K : 3 * K, :] = Theta[K : 2 * K, :]
+        Theta[:, 2 * K : 3 * K] = Theta[:, K : 2 * K]
+        diag = np.ones(3 * K, dtype=np.float64)
+        diag[0:K] = diag[K : 2 * K] = inner_results["observables"] - inner_results["Amin"]
+        Adiag = np.zeros([3 * K, 3 * K], dtype=np.float64)
         np.fill_diagonal(Adiag, diag)
         Theta = Adiag @ Theta @ Adiag
 
         # Compute reduced free energy difference.
-        f_k = inner_results['f']
+        f_k = inner_results["f"]
         Delta_f_ij = f_k - np.vstack(f_k)
         # compute uncertainty matrix in free energies:
-        covf = Theta[2*K:3*K, 2*K:3*K]
+        covf = Theta[2 * K : 3 * K, 2 * K : 3 * K]
         dDelta_f_ij = self._ErrorOfDifferences(covf, warning_cutoff=warning_cutoff)
 
         # Compute reduced enthalpy difference.
-        u_k = inner_results['observables']
+        u_k = inner_results["observables"]
         Delta_u_ij = u_k - np.vstack(u_k)
         # compute uncertainty matrix in energies:
-        covu = Theta[0:K,0:K] + Theta[K:2*K, K:2*K] - Theta[0:K, K:2*K] - Theta[K:2*K, 0:K]
+        covu = (
+            Theta[0:K, 0:K]
+            + Theta[K : 2 * K, K : 2 * K]
+            - Theta[0:K, K : 2 * K]
+            - Theta[K : 2 * K, 0:K]
+        )
         dDelta_u_ij = self._ErrorOfDifferences(covu, warning_cutoff=warning_cutoff)
 
         # Compute reduced entropy difference
         s_k = u_k - f_k
         Delta_s_ij = s_k - np.vstack(s_k)
         # compute uncertainty matrix in entropies
-        #s_i = u_i - f_i
-        #cov(s_i) =   cov(u_i - f_i)
+        # s_i = u_i - f_i
+        # cov(s_i) =   cov(u_i - f_i)
         #         =   cov(exp(ln C_a - ln c_a) + ln c_a)
         #         =   cov(exp(ln C_a - ln c_a), exp(ln C_a - ln c_a)) + cov(ln c_a, ln c_a)
         #           + cov(exp(ln C_a - ln c_a), ln c_a) + cov(ln c_a, exp(ln C_a - ln c_a))
@@ -1310,23 +1433,30 @@ class MBAR:
         #             + A cov(ln C_a, ln c_a) - A cov(ln c_a, ln c_a) + A cov(ln c_a, ln C_a) - A cov(ln c_a, ln c_a)
         #         = cov(u,u) + cov(f,f) + A cov(ln C_a,ln c_a) + A cov(ln c_a, ln C_a) - 2A cov(ln_ca,ln_ca)
         #
-        covs = covu + covf + Theta[0:K,2*K:3*K] + Theta[2*K:3*K,0:K] - Theta[K:2*K,2*K:3*K] - Theta[2*K:3*K,K:2*K]
+        covs = (
+            covu
+            + covf
+            + Theta[0:K, 2 * K : 3 * K]
+            + Theta[2 * K : 3 * K, 0:K]
+            - Theta[K : 2 * K, 2 * K : 3 * K]
+            - Theta[2 * K : 3 * K, K : 2 * K]
+        )
         # note: not clear that Theta[K:2*K,2*K:3*K] and Theta[K:2*K,2*K:3*K] are symmetric?
-        dDelta_s_ij = self._ErrorOfDifferences(covs,warning_cutoff=warning_cutoff)
+        dDelta_s_ij = self._ErrorOfDifferences(covs, warning_cutoff=warning_cutoff)
 
         result_vals = dict()
-        result_vals['Delta_f'] = Delta_f_ij
-        result_vals['dDelta_f'] = dDelta_f_ij
-        result_vals['Delta_u'] = Delta_u_ij
-        result_vals['dDelta_u'] = dDelta_u_ij
-        result_vals['Delta_s'] = Delta_s_ij
-        result_vals['dDelta_s'] = dDelta_s_ij
+        result_vals["Delta_f"] = Delta_f_ij
+        result_vals["dDelta_f"] = dDelta_f_ij
+        result_vals["Delta_u"] = Delta_u_ij
+        result_vals["dDelta_u"] = dDelta_u_ij
+        result_vals["Delta_s"] = Delta_s_ij
+        result_vals["dDelta_s"] = dDelta_s_ij
 
         return result_vals
 
-    #=========================================================================
+    # =========================================================================
     # PRIVATE METHODS - INTERFACES ARE NOT EXPORTED
-    #=========================================================================
+    # =========================================================================
 
     def _ErrorOfDifferences(self, cov, warning_cutoff=1.0e-10):
         """
@@ -1345,8 +1475,11 @@ class MBAR:
         # check for any numbers below zero.
         if np.any(d2 < 0.0):
             if np.any(d2 < cutoff):
-                logger.warning("A squared uncertainty is negative. Largest Magnitude = {0:f}".format(
-                    abs(np.min(d2[d2 < cutoff]))))
+                logger.warning(
+                    "A squared uncertainty is negative. Largest Magnitude = {0:f}".format(
+                        abs(np.min(d2[d2 < cutoff]))
+                    )
+                )
             else:
                 d2[np.logical_and(0 > d2, d2 > cutoff)] = 0.0
         return np.sqrt(np.array(d2))
@@ -1371,7 +1504,7 @@ class MBAR:
 
         return np.linalg.pinv(A, rcond=tol)
 
-    #=========================================================================
+    # =========================================================================
 
     def _zerosamestates(self, A):
         """
@@ -1387,7 +1520,7 @@ class MBAR:
             A[pair[0], pair[1]] = 0
             A[pair[1], pair[0]] = 0
 
-    #=========================================================================
+    # =========================================================================
     def _computeAsymptoticCovarianceMatrix(self, W, N_k, method=None):
         """Compute estimate of the asymptotic covariance matrix.
 
@@ -1423,29 +1556,28 @@ class MBAR:
 
         # Set 'svd-ew' as default if uncertainty method specified as None.
         if method == None:
-            method = 'svd-ew'
+            method = "svd-ew"
 
         # Get dimensions of weight matrix.
         [N, K] = W.shape
 
         # Check dimensions
-        if(K != N_k.size):
-            raise ParameterError(
-                'W must be NxK, where N_k is a K-dimensional array.')
-        if(np.sum(N_k) != N):
-            raise ParameterError('W must be NxK, where N = sum_k N_k.')
+        if K != N_k.size:
+            raise ParameterError("W must be NxK, where N_k is a K-dimensional array.")
+        if np.sum(N_k) != N:
+            raise ParameterError("W must be NxK, where N = sum_k N_k.")
 
         check_w_normalized(W, N_k)
 
         # Compute estimate of asymptotic covariance matrix using specified method.
-        if method == 'approximate':
+        if method == "approximate":
             # Use fast approximate expression from Kong et al. -- this underestimates the true covariance, but may be a good approximation in some cases and requires no matrix inversions
             # Theta = P'P
 
             # Compute covariance
             Theta = W.T @ W
 
-        elif method == 'svd':
+        elif method == "svd":
             # Use singular value decomposition based approach given in supplementary material to efficiently compute uncertainty
             # See Appendix D.1, Eq. D4 in [1].
 
@@ -1454,15 +1586,18 @@ class MBAR:
             I = np.identity(K, dtype=np.float64)
 
             # Compute SVD of W
-            [U, S, Vt] = linalg.svd(W, full_matrices=False)  # False Avoids O(N^2) memory allocation by only calculting the active subspace of U.
+            [U, S, Vt] = linalg.svd(
+                W, full_matrices=False
+            )  # False Avoids O(N^2) memory allocation by only calculting the active subspace of U.
             Sigma = np.diag(S)
             V = Vt.T
 
             # Compute covariance
-            Theta = V @ Sigma @ self._pseudoinverse(
-                I - Sigma @ V.T @ Ndiag @ V @ Sigma) @ Sigma @ V.T
+            Theta = (
+                V @ Sigma @ self._pseudoinverse(I - Sigma @ V.T @ Ndiag @ V @ Sigma) @ Sigma @ V.T
+            )
 
-        elif method == 'svd-ew':
+        elif method == "svd-ew":
             # Use singular value decomposition based approach given in supplementary material to efficiently compute uncertainty
             # The eigenvalue decomposition of W'W is used to forego computing the SVD.
             # See Appendix D.1, Eqs. D4 and D5 of [1].
@@ -1481,18 +1616,19 @@ class MBAR:
             Sigma = np.diag(np.sqrt(S2))
 
             # Compute covariance
-            Theta = V @ Sigma @ self._pseudoinverse(
-                I - Sigma @ V.T @ Ndiag @ V @ Sigma) @ Sigma @ V.T
+            Theta = (
+                V @ Sigma @ self._pseudoinverse(I - Sigma @ V.T @ Ndiag @ V @ Sigma) @ Sigma @ V.T
+            )
 
         else:
             # Raise an exception.
-            raise ParameterError('Method ' + method + ' unrecognized.')
+            raise ParameterError("Method " + method + " unrecognized.")
 
         return Theta
 
-    #=========================================================================
+    # =========================================================================
 
-    def _initializeFreeEnergies(self, verbose=False, method='zeros'):
+    def _initializeFreeEnergies(self, verbose=False, method="zeros"):
         """
         Compute an initial guess at the relative free energies.
 
@@ -1504,23 +1640,27 @@ class MBAR:
 
         """
 
-        if (method == 'zeros'):
+        if method == "zeros":
             # Use zeros for initial free energies.
             if verbose:
                 logger.info("Initializing free energies to zero.")
             self.f_k[:] = 0.0
-        elif (method == 'mean-reduced-potential'):
+        elif method == "mean-reduced-potential":
             # Compute initial guess at free energies from the mean reduced
             # potential from each state
             if verbose:
-                logger.info("Initializing free energies with mean reduced potential for each state.")
+                logger.info(
+                    "Initializing free energies with mean reduced potential for each state."
+                )
             means = np.zeros([self.K], float)
             for k in self.states_with_samples:
-                means[k] = self.u_kn[k, 0:self.N_k[k]].mean()
-            if (np.max(np.abs(means)) < 0.000001):
-                logger.warning("Warning: All mean reduced potentials are close to zero. If you are using energy differences in the u_kln matrix, then the mean reduced potentials will be zero, and this is expected behavoir.")
+                means[k] = self.u_kn[k, 0 : self.N_k[k]].mean()
+            if np.max(np.abs(means)) < 0.000001:
+                logger.warning(
+                    "Warning: All mean reduced potentials are close to zero. If you are using energy differences in the u_kln matrix, then the mean reduced potentials will be zero, and this is expected behavoir."
+                )
             self.f_k = means
-        elif (method == 'BAR'):
+        elif method == "BAR":
             # For now, make a simple list of those states with samples.
             initialization_order = np.where(self.N_k > 0)[0]
             # Initialize all f_k to zero.
@@ -1531,20 +1671,27 @@ class MBAR:
                 l = initialization_order[index + 1]
                 # forward work
                 # here, we actually need to distinguish which states are which
-                w_F = (
-                    self.u_kn[l,self.x_kindices==k] - self.u_kn[k,self.x_kindices==k])
-                    #self.u_kln[k, l, 0:self.N_k[k]] - self.u_kln[k, k, 0:self.N_k[k]])
-                    # reverse work
-                w_R = (
-                    self.u_kn[k,self.x_kindices==l] - self.u_kn[l,self.x_kindices==l])
-                    #self.u_kln[l, k, 0:self.N_k[l]] - self.u_kln[l, l, 0:self.N_k[l]])
+                w_F = self.u_kn[l, self.x_kindices == k] - self.u_kn[k, self.x_kindices == k]
+                # self.u_kln[k, l, 0:self.N_k[k]] - self.u_kln[k, k, 0:self.N_k[k]])
+                # reverse work
+                w_R = self.u_kn[k, self.x_kindices == l] - self.u_kn[l, self.x_kindices == l]
+                # self.u_kln[l, k, 0:self.N_k[l]] - self.u_kln[l, l, 0:self.N_k[l]])
 
-                if (len(w_F) > 0 and len(w_R) > 0):
+                if len(w_F) > 0 and len(w_R) > 0:
                     # BAR solution doesn't need to be incredibly accurate to
                     # kickstart NR.
                     import pymbar.bar
-                    self.f_k[l] = self.f_k[k] + pymbar.bar.BAR(
-                        w_F, w_R, relative_tolerance=0.000001, verbose=False, compute_uncertainty=False)['Delta_f']
+
+                    self.f_k[l] = (
+                        self.f_k[k]
+                        + pymbar.bar.BAR(
+                            w_F,
+                            w_R,
+                            relative_tolerance=0.000001,
+                            verbose=False,
+                            compute_uncertainty=False,
+                        )["Delta_f"]
+                    )
                 else:
                     # no states observed, so we don't need to initialize this free energy anyway, as
                     # the solution is noniterative.
@@ -1552,7 +1699,7 @@ class MBAR:
 
         else:
             # The specified method is not implemented.
-            raise ParameterError('Method ' + method + ' unrecognized.')
+            raise ParameterError("Method " + method + " unrecognized.")
 
         # Shift all free energies such that f_0 = 0.
         self.f_k[:] = self.f_k[:] - self.f_k[0]
@@ -1574,4 +1721,4 @@ class MBAR:
         REFERENCE
           'log weights' here refers to \\log [ \\sum_{k=1}^K N_k exp[f_k - (u_k(x_n) - u(x_n)] ]
         """
-        return -1. * logsumexp(self.f_k + u_n[:, np.newaxis] - self.u_kn.T, b=self.N_k, axis=1)
+        return -1.0 * logsumexp(self.f_k + u_n[:, np.newaxis] - self.u_kn.T, b=self.N_k, axis=1)

--- a/pymbar/mbar_solvers.py
+++ b/pymbar/mbar_solvers.py
@@ -10,8 +10,8 @@ logger = logging.getLogger(__name__)
 
 # Below are the recommended default protocols (ordered sequence of minimization algorithms / NLE solvers) for solving the MBAR equations.
 # Note: we use tuples instead of lists to avoid accidental mutability.
-#DEFAULT_SUBSAMPLING_PROTOCOL = (dict(method="L-BFGS-B"), )  # First use BFGS on subsampled data.
-#DEFAULT_SOLVER_PROTOCOL = (dict(method="hybr"), )  # Then do fmin hybrid on full dataset.
+# DEFAULT_SUBSAMPLING_PROTOCOL = (dict(method="L-BFGS-B"), )  # First use BFGS on subsampled data.
+# DEFAULT_SOLVER_PROTOCOL = (dict(method="hybr"), )  # Then do fmin hybrid on full dataset.
 # Use Adpative solver as first attempt
 DEFAULT_SOLVER_METHOD = "adaptive"
 DEFAULT_SOLVER_PROTOCOL = (dict(method=DEFAULT_SOLVER_METHOD,),)
@@ -40,9 +40,11 @@ def validate_inputs(u_kn, N_k, f_k):
     """
     n_states, n_samples = u_kn.shape
 
-    u_kn = ensure_type(u_kn, 'float', 2, "u_kn or Q_kn", shape=(n_states, n_samples))
-    N_k = ensure_type(N_k, 'float', 1, "N_k", shape=(n_states,), warn_on_cast=False)  # Autocast to float because will be eventually used in float calculations.
-    f_k = ensure_type(f_k, 'float', 1, "f_k", shape=(n_states,))
+    u_kn = ensure_type(u_kn, "float", 2, "u_kn or Q_kn", shape=(n_states, n_samples))
+    N_k = ensure_type(
+        N_k, "float", 1, "N_k", shape=(n_states,), warn_on_cast=False
+    )  # Autocast to float because will be eventually used in float calculations.
+    f_k = ensure_type(f_k, "float", 1, "f_k", shape=(n_states,))
 
     return u_kn, N_k, f_k
 
@@ -70,14 +72,16 @@ def self_consistent_update(u_kn, N_k, f_k):
     """
 
     u_kn, N_k, f_k = validate_inputs(u_kn, N_k, f_k)
-    
-    states_with_samples = (N_k > 0)
+
+    states_with_samples = N_k > 0
 
     # Only the states with samples can contribute to the denominator term.
-    log_denominator_n = logsumexp(f_k[states_with_samples] - u_kn[states_with_samples].T, b=N_k[states_with_samples], axis=1)
-    
+    log_denominator_n = logsumexp(
+        f_k[states_with_samples] - u_kn[states_with_samples].T, b=N_k[states_with_samples], axis=1
+    )
+
     # All states can contribute to the numerator term.
-    return -1. * logsumexp(-log_denominator_n - u_kn, axis=1)
+    return -1.0 * logsumexp(-log_denominator_n - u_kn, axis=1)
 
 
 def mbar_gradient(u_kn, N_k, f_k):
@@ -237,7 +241,7 @@ def mbar_W_nk(u_kn, N_k, f_k):
     return np.exp(mbar_log_W_nk(u_kn, N_k, f_k))
 
 
-def adaptive(u_kn, N_k, f_k, tol = 1.0e-12, options = None):
+def adaptive(u_kn, N_k, f_k, tol=1.0e-12, options=None):
 
     """
     Determine dimensionless free energies by a combination of Newton-Raphson iteration and self-consistent iteration.
@@ -270,15 +274,17 @@ def adaptive(u_kn, N_k, f_k, tol = 1.0e-12, options = None):
 
     """
     # put the defaults here in case we get passed an 'options' dictionary that is only partial
-    options.setdefault('verbose',False)
-    options.setdefault('maximum_iterations',250)
-    options.setdefault('print_warning',False)
-    options.setdefault('gamma',1.0)
+    options.setdefault("verbose", False)
+    options.setdefault("maximum_iterations", 250)
+    options.setdefault("print_warning", False)
+    options.setdefault("gamma", 1.0)
 
-    gamma = options['gamma']
+    gamma = options["gamma"]
     doneIterating = False
-    if options['verbose'] == True:
-        logger.info("Determining dimensionless free energies by Newton-Raphson / self-consistent iteration.")
+    if options["verbose"] == True:
+        logger.info(
+            "Determining dimensionless free energies by Newton-Raphson / self-consistent iteration."
+        )
 
     if tol < 1.5e-15:
         logger.info("Tolerance may be too close to machine precision to converge.")
@@ -295,7 +301,7 @@ def adaptive(u_kn, N_k, f_k, tol = 1.0e-12, options = None):
     # to calculate the first time.
     g = mbar_gradient(u_kn, N_k, f_k)  # Objective function gradient.
 
-    for iteration in range(0, options['maximum_iterations']):
+    for iteration in range(0, options["maximum_iterations"]):
 
         H = mbar_hessian(u_kn, N_k, f_k)  # Objective function hessian
         Hinvg = np.linalg.lstsq(H, g, rcond=-1)[0]
@@ -304,7 +310,7 @@ def adaptive(u_kn, N_k, f_k, tol = 1.0e-12, options = None):
 
         # self-consistent iteration gradient norm and saved log sums.
         f_sci = self_consistent_update(u_kn, N_k, f_k)
-        f_sci = f_sci -  f_sci[0]   # zero out the minimum
+        f_sci = f_sci - f_sci[0]  # zero out the minimum
         g_sci = mbar_gradient(u_kn, N_k, f_sci)
         gnorm_sci = np.dot(g_sci, g_sci)
 
@@ -315,47 +321,71 @@ def adaptive(u_kn, N_k, f_k, tol = 1.0e-12, options = None):
         # we could save the gradient, for the next round, but it's not too expensive to
         # compute since we are doing the Hessian anyway.
 
-        if options['verbose']:
-            logger.info("self consistent iteration gradient norm is %10.5g, Newton-Raphson gradient norm is %10.5g" % (gnorm_sci, gnorm_nr))
+        if options["verbose"]:
+            logger.info(
+                "self consistent iteration gradient norm is %10.5g, Newton-Raphson gradient norm is %10.5g"
+                % (gnorm_sci, gnorm_nr)
+            )
         # decide which directon to go depending on size of gradient norm
         f_old = f_k
-        if (gnorm_sci < gnorm_nr or sci_iter < 2):
+        if gnorm_sci < gnorm_nr or sci_iter < 2:
             f_k = f_sci
             g = g_sci
             sci_iter += 1
-            if options['verbose']:
+            if options["verbose"]:
                 if sci_iter < 2:
                     logger.info("Choosing self-consistent iteration on iteration %d" % iteration)
                 else:
-                    logger.info("Choosing self-consistent iteration for lower gradient on iteration %d" % iteration)
+                    logger.info(
+                        "Choosing self-consistent iteration for lower gradient on iteration %d"
+                        % iteration
+                    )
         else:
             f_k = f_nr
             g = g_nr
             nr_iter += 1
-            if options['verbose']:
+            if options["verbose"]:
                 logger.info("Newton-Raphson used on iteration %d" % iteration)
 
-        div = np.abs(f_k[1:]) # what we will divide by to get relative difference
-        zeroed = np.abs(f_k[1:])< np.min([10**-8,tol]) # check which values are near enough to zero, hard coded max for now.
+        div = np.abs(f_k[1:])  # what we will divide by to get relative difference
+        zeroed = np.abs(f_k[1:]) < np.min(
+            [10 ** -8, tol]
+        )  # check which values are near enough to zero, hard coded max for now.
         div[zeroed] = 1.0  # for these values, use absolute values.
-        max_delta = np.max(np.abs(f_k[1:]-f_old[1:])/div)
+        max_delta = np.max(np.abs(f_k[1:] - f_old[1:]) / div)
         if np.isnan(max_delta) or (max_delta < tol):
             doneIterating = True
             break
 
     if doneIterating:
-        if options['verbose']:
-            logger.info('Converged to tolerance of {:e} in {:d} iterations.'.format(max_delta, iteration + 1))
-            logger.info('Of {:d} iterations, {:d} were Newton-Raphson iterations and {:d} were self-consistent iterations'.format(iteration + 1, nr_iter, sci_iter))
+        if options["verbose"]:
+            logger.info(
+                "Converged to tolerance of {:e} in {:d} iterations.".format(
+                    max_delta, iteration + 1
+                )
+            )
+            logger.info(
+                "Of {:d} iterations, {:d} were Newton-Raphson iterations and {:d} were self-consistent iterations".format(
+                    iteration + 1, nr_iter, sci_iter
+                )
+            )
             if np.all(f_k == 0.0):
                 # all f_k appear to be zero
-                logger.info('WARNING: All f_k appear to be zero.')
+                logger.info("WARNING: All f_k appear to be zero.")
     else:
-        logger.warning('WARNING: Did not converge to within specified tolerance.')
-        if options['maximum_iterations'] <= 0:
-            logger.warning("No iterations ran be cause maximum_iterations was <= 0 ({:s})!".format(options['maximum_iterations']))
+        logger.warning("WARNING: Did not converge to within specified tolerance.")
+        if options["maximum_iterations"] <= 0:
+            logger.warning(
+                "No iterations ran be cause maximum_iterations was <= 0 ({:s})!".format(
+                    options["maximum_iterations"]
+                )
+            )
         else:
-            logger.warning('max_delta = {:e}, tol = {:e}, maximum_iterations = {:d}, iterations completed = {:d}'.format(max_delta,tol, options['maximum_iterations'], iteration))
+            logger.warning(
+                "max_delta = {:e}, tol = {:e}, maximum_iterations = {:d}, iterations completed = {:d}".format(
+                    max_delta, tol, options["maximum_iterations"], iteration
+                )
+            )
     return f_k
 
 
@@ -390,7 +420,9 @@ def precondition_u_kn(u_kn, N_k, f_k):
     return u_kn
 
 
-def solve_mbar_once(u_kn_nonzero, N_k_nonzero, f_k_nonzero, method="hybr", tol=1E-12, options=None):
+def solve_mbar_once(
+    u_kn_nonzero, N_k_nonzero, f_k_nonzero, method="hybr", tol=1e-12, options=None
+):
     """Solve MBAR self-consistent equations using some form of equation solver.
 
     Parameters
@@ -432,29 +464,63 @@ def solve_mbar_once(u_kn_nonzero, N_k_nonzero, f_k_nonzero, method="hybr", tol=1
     For fast but precise convergence, we recommend calling this function
     multiple times to polish the result.  `solve_mbar()` facilitates this.
     """
-    u_kn_nonzero, N_k_nonzero, f_k_nonzero = validate_inputs(u_kn_nonzero, N_k_nonzero, f_k_nonzero)
+    u_kn_nonzero, N_k_nonzero, f_k_nonzero = validate_inputs(
+        u_kn_nonzero, N_k_nonzero, f_k_nonzero
+    )
     f_k_nonzero = f_k_nonzero - f_k_nonzero[0]  # Work with reduced dimensions with f_k[0] := 0
     u_kn_nonzero = precondition_u_kn(u_kn_nonzero, N_k_nonzero, f_k_nonzero)
 
-    pad = lambda x: np.pad(x, (1, 0), mode='constant')  # Helper function inserts zero before first element
-    unpad_second_arg = lambda obj, grad: (obj, grad[1:])  # Helper function drops first element of gradient
+    pad = lambda x: np.pad(
+        x, (1, 0), mode="constant"
+    )  # Helper function inserts zero before first element
+    unpad_second_arg = lambda obj, grad: (
+        obj,
+        grad[1:],
+    )  # Helper function drops first element of gradient
 
     # Create objective functions / nonlinear equations to send to scipy.optimize, fixing f_0 = 0
-    grad = lambda x: mbar_gradient(u_kn_nonzero, N_k_nonzero, pad(x))[1:]  # Objective function gradient
-    grad_and_obj = lambda x: unpad_second_arg(*mbar_objective_and_gradient(u_kn_nonzero, N_k_nonzero, pad(x)))  # Objective function gradient and objective function
-    hess = lambda x: mbar_hessian(u_kn_nonzero, N_k_nonzero, pad(x))[1:][:, 1:]  # Hessian of objective function
+    grad = lambda x: mbar_gradient(u_kn_nonzero, N_k_nonzero, pad(x))[
+        1:
+    ]  # Objective function gradient
+    grad_and_obj = lambda x: unpad_second_arg(
+        *mbar_objective_and_gradient(u_kn_nonzero, N_k_nonzero, pad(x))
+    )  # Objective function gradient and objective function
+    hess = lambda x: mbar_hessian(u_kn_nonzero, N_k_nonzero, pad(x))[1:][
+        :, 1:
+    ]  # Hessian of objective function
 
     with warnings.catch_warnings(record=True) as w:
-        if method in ["L-BFGS-B", "dogleg", "CG", "BFGS", "Newton-CG", "TNC", "trust-ncg", "SLSQP"]:
+        if method in [
+            "L-BFGS-B",
+            "dogleg",
+            "CG",
+            "BFGS",
+            "Newton-CG",
+            "TNC",
+            "trust-ncg",
+            "SLSQP",
+        ]:
             if method in ["L-BFGS-B", "CG"]:
                 hess = None  # To suppress warning from passing a hessian function.
-            results = scipy.optimize.minimize(grad_and_obj, f_k_nonzero[1:], jac=True, hess=hess, method=method, tol=tol, options=options)
+            results = scipy.optimize.minimize(
+                grad_and_obj,
+                f_k_nonzero[1:],
+                jac=True,
+                hess=hess,
+                method=method,
+                tol=tol,
+                options=options,
+            )
             f_k_nonzero = pad(results["x"])
-        elif method == 'adaptive':
+        elif method == "adaptive":
             results = adaptive(u_kn_nonzero, N_k_nonzero, f_k_nonzero, tol=tol, options=options)
-            f_k_nonzero = results # they are the same for adaptive, until we decide to return more.
+            f_k_nonzero = (
+                results  # they are the same for adaptive, until we decide to return more.
+            )
         else:
-            results = scipy.optimize.root(grad, f_k_nonzero[1:], jac=hess, method=method, tol=tol, options=options)
+            results = scipy.optimize.root(
+                grad, f_k_nonzero[1:], jac=hess, method=method, tol=tol, options=options
+            )
             f_k_nonzero = pad(results["x"])
 
     # If there were runtime warnings, show the messages
@@ -463,14 +529,22 @@ def solve_mbar_once(u_kn_nonzero, N_k_nonzero, f_k_nonzero, method="hybr", tol=1
         for warn_msg in w:
             if "Unknown solver options" in str(warn_msg.message):
                 continue
-            warnings.showwarning(warn_msg.message, warn_msg.category,
-                                 warn_msg.filename, warn_msg.lineno, warn_msg.file, "")
+            warnings.showwarning(
+                warn_msg.message,
+                warn_msg.category,
+                warn_msg.filename,
+                warn_msg.lineno,
+                warn_msg.file,
+                "",
+            )
             can_ignore = False  # If any warning is not just unknown options, can ]not skip check
         if not can_ignore:
             # Ensure MBAR solved correctly
             w_nk_check = mbar_W_nk(u_kn_nonzero, N_k_nonzero, f_k_nonzero)
             check_w_normalized(w_nk_check, N_k_nonzero)
-            logger.warning("MBAR weights converged within tolerance, despite the SciPy Warnings. Please validate your results.")
+            logger.warning(
+                "MBAR weights converged within tolerance, despite the SciPy Warnings. Please validate your results."
+            )
 
     return f_k_nonzero, results
 
@@ -517,14 +591,19 @@ def solve_mbar(u_kn_nonzero, N_k_nonzero, f_k_nonzero, solver_protocol=None):
     if solver_protocol is None:
         solver_protocol = DEFAULT_SOLVER_PROTOCOL
     for protocol in solver_protocol:
-        if protocol['method'] is None:
-            protocol['method'] = DEFAULT_SOLVER_METHOD
+        if protocol["method"] is None:
+            protocol["method"] = DEFAULT_SOLVER_METHOD
 
     all_results = []
     for k, options in enumerate(solver_protocol):
         f_k_nonzero, results = solve_mbar_once(u_kn_nonzero, N_k_nonzero, f_k_nonzero, **options)
         all_results.append(results)
-        all_results.append(("Final gradient norm: %.3g" % np.linalg.norm(mbar_gradient(u_kn_nonzero, N_k_nonzero, f_k_nonzero))))
+        all_results.append(
+            (
+                "Final gradient norm: %.3g"
+                % np.linalg.norm(mbar_gradient(u_kn_nonzero, N_k_nonzero, f_k_nonzero))
+            )
+        )
     return f_k_nonzero, all_results
 
 
@@ -554,8 +633,12 @@ def solve_mbar_for_all_states(u_kn, N_k, f_k, solver_protocol):
     if len(states_with_samples) == 1:
         f_k_nonzero = np.array([0.0])
     else:
-        f_k_nonzero, all_results = solve_mbar(u_kn[states_with_samples], N_k[states_with_samples],
-                                              f_k[states_with_samples], solver_protocol=solver_protocol)
+        f_k_nonzero, all_results = solve_mbar(
+            u_kn[states_with_samples],
+            N_k[states_with_samples],
+            f_k[states_with_samples],
+            solver_protocol=solver_protocol,
+        )
 
     f_k[states_with_samples] = f_k_nonzero
 

--- a/pymbar/pmf.py
+++ b/pymbar/pmf.py
@@ -33,6 +33,7 @@ from pymbar import timeseries
 
 # bunch of imports needed for doing newton optimization of B-splines
 from scipy.interpolate import BSpline, make_lsq_spline
+
 # imports needed for scipy minimizations
 from scipy.integrate import quad
 from scipy.optimize import minimize
@@ -50,7 +51,7 @@ DEFAULT_SOLVER_PROTOCOL = mbar_solvers.DEFAULT_SOLVER_PROTOCOL
 class PMF:
     """
 
-    Methods for generating potentials of mean force with statistical uncertainties. 
+    Methods for generating potentials of mean force with statistical uncertainties.
 
     Notes
     -----
@@ -67,20 +68,14 @@ class PMF:
 
     [2] Shirts MR and Ferguson AF. Statistically optimal continuous
     potentials of mean force from umbrella sampling and multistate
-    reweighting 
+    reweighting
     https://arxiv.org/abs/2001.01170
 
     """
+
     # =========================================================================
 
-    def __init__(
-            self,
-            u_kn,
-            N_k,
-            verbose=False,
-            mbar_options=None,
-            timings=True,
-            **kwargs):
+    def __init__(self, u_kn, N_k, verbose=False, mbar_options=None, timings=True, **kwargs):
         """Initialize a potential of mean force calculation by performing
         multistate Bennett acceptance ratio (MBAR) on a set of
         simulation data from umbrella sampling at K states.
@@ -101,7 +96,7 @@ class PMF:
            getPMF: given coordinates, generate the PMF at each coordinate (and uncertainty)
 
            getMBAR: return the underlying mbar object.
-           
+
            getKDE: return the underlying kde object.
 
            sampleParameterDistribution: Only works for pmf_type =
@@ -148,7 +143,9 @@ class PMF:
 
         """
         for key, val in kwargs.items():
-            logging.warning("Warning: parameter {:s}={:s} is unrecognized and unused.".format(key, val))
+            logging.warning(
+                "Warning: parameter {:s}={:s} is unrecognized and unused.".format(key, val)
+            )
 
         # Store local copies of necessary data.
         # N_k[k] is the number of samples from state k, some of which might be
@@ -172,7 +169,8 @@ class PMF:
 
         if np.sum(self.N_k) != N:
             raise ParameterError(
-                'The sum of all N_k must equal the total number of samples (length of second dimension of u_kn.')
+                "The sum of all N_k must equal the total number of samples (length of second dimension of u_kn."
+            )
 
         # Store local copies of other data
         self.K = K  # number of thermodynamic states energies are evaluated at
@@ -190,35 +188,37 @@ class PMF:
         else:
             # if the dictionary does not define the option, add it in
             required_mbar_options = (
-                'maximum_iterations',
-                'relative_tolerance',
-                'verbose',
-                'initial_f_k',
-                'solver_protocol',
-                'initialize',
-                'x_kindices')
+                "maximum_iterations",
+                "relative_tolerance",
+                "verbose",
+                "initial_f_k",
+                "solver_protocol",
+                "initialize",
+                "x_kindices",
+            )
             for o in required_mbar_options:
                 if o not in mbar_options:
                     mbar_options[o] = None
 
             # reset the options that might be none to the default value
-            if mbar_options['maximum_iterations'] is None:
-                mbar_options['maximum_iterations'] = 10000
-            if mbar_options['relative_tolerance'] is None:
-                mbar_options['relative_tolerance'] = 1.0e-7
-            if mbar_options['initialize'] is None:
-                mbar_options['initialize'] = 'zeros'
+            if mbar_options["maximum_iterations"] is None:
+                mbar_options["maximum_iterations"] = 10000
+            if mbar_options["relative_tolerance"] is None:
+                mbar_options["relative_tolerance"] = 1.0e-7
+            if mbar_options["initialize"] is None:
+                mbar_options["initialize"] = "zeros"
 
             pmf_mbar = pymbar.MBAR(
                 u_kn,
                 N_k,
-                maximum_iterations=mbar_options['maximum_iterations'],
-                relative_tolerance=mbar_options['relative_tolerance'],
-                verbose=mbar_options['verbose'],
-                initial_f_k=mbar_options['initial_f_k'],
-                solver_protocol=mbar_options['solver_protocol'],
-                initialize=mbar_options['initialize'],
-                x_kindices=mbar_options['x_kindices'])
+                maximum_iterations=mbar_options["maximum_iterations"],
+                relative_tolerance=mbar_options["relative_tolerance"],
+                verbose=mbar_options["verbose"],
+                initial_f_k=mbar_options["initial_f_k"],
+                solver_protocol=mbar_options["solver_protocol"],
+                initialize=mbar_options["initialize"],
+                x_kindices=mbar_options["x_kindices"],
+            )
 
         self.mbar = pmf_mbar
 
@@ -237,16 +237,16 @@ class PMF:
         self._seed = None
 
     def generatePMF(
-            self,
-            u_n,
-            x_n,
-            pmf_type='histogram',
-            histogram_parameters=None,
-            kde_parameters=None,
-            spline_parameters=None,
-            nbootstraps=0,
-            seed=-1,
-            ):
+        self,
+        u_n,
+        x_n,
+        pmf_type="histogram",
+        histogram_parameters=None,
+        kde_parameters=None,
+        spline_parameters=None,
+        nbootstraps=0,
+        seed=-1,
+    ):
         """
         Given an intialized MBAR object, a set of points,
         the desired energies at that point, and a method, generate
@@ -282,7 +282,7 @@ class PMF:
 
         spline_parameters:
             - 'fit_type': which type of fit to use:
-                -- 'biasedstates' - sum of log likelihood over all weighted states 
+                -- 'biasedstates' - sum of log likelihood over all weighted states
                 -- 'unbiasedstate' - log likelihood of the single unbiased state
                 -- 'simplesum': sum of log likelihoods from the biased simulation. Essentially equivalent to vFEP (York et al.)
             - 'optimization_algorithm':
@@ -366,7 +366,9 @@ class PMF:
 
         # we need to save this for calculating uncertainties.
         if not np.issubdtype(type(nbootstraps), np.integer) or nbootstraps == 1:
-            raise ValueError(f"nbootstraps must be an integer of 0 or >=2, it was set to {nbootstraps}")
+            raise ValueError(
+                f"nbootstraps must be an integer of 0 or >=2, it was set to {nbootstraps}"
+            )
         self.nbootstraps = nbootstraps
 
         if self.timings:
@@ -382,15 +384,16 @@ class PMF:
 
         self.mc_data = None  # we have not sampled MC data yet.
 
-        if self.pmf_type == 'histogram':
+        if self.pmf_type == "histogram":
 
             self.histogram_datas = list()
 
-            if 'bin_edges' not in histogram_parameters:
+            if "bin_edges" not in histogram_parameters:
                 raise ParameterError(
-                    'histogram_parameters[\'bin_edges\'] cannot be undefined with pmf_type = histogram')
+                    "histogram_parameters['bin_edges'] cannot be undefined with pmf_type = histogram"
+                )
 
-            bins = histogram_parameters['bin_edges']
+            bins = histogram_parameters["bin_edges"]
 
             # First, determine the number of dimensions of the histogram. This can be determined
             # by the shape of bin_edges
@@ -398,14 +401,16 @@ class PMF:
             self.dims = dims  # store the dimensionality for checking later.
             self.histogram_parameters = histogram_parameters
 
-        elif pmf_type == 'kde':
+        elif pmf_type == "kde":
 
             self.kdes = list()
 
             try:
                 from sklearn.neighbors import KernelDensity
             except ImportError:
-                raise ImportError("Cannot use 'kde' type PMF without the scikit-learn module. Could not import sklearn")
+                raise ImportError(
+                    "Cannot use 'kde' type PMF without the scikit-learn module. Could not import sklearn"
+                )
             kde = KernelDensity()
             # get the default params to set them.
             kde_defaults = kde.get_params()
@@ -418,109 +423,120 @@ class PMF:
             for k in kde_parameters:
                 if k not in kde_defaults:
                     raise ParameterError(
-                        "Warning: {:s} is not a parameter in KernelDensity".format(k))
+                        "Warning: {:s} is not a parameter in KernelDensity".format(k)
+                    )
             kde.set_params(**kde_defaults)
 
-        elif pmf_type == 'spline':
+        elif pmf_type == "spline":
 
             # zero this out so we know if we haven't called it yet.
             self.bspline = None
             self.pmf_functions = list()
 
-            self.spline_parameters = spline_parameters # save these for later references.
+            self.spline_parameters = spline_parameters  # save these for later references.
 
-            if 'objective' not in spline_parameters:
-                spline_parameters['objective'] = 'ml' # default
+            if "objective" not in spline_parameters:
+                spline_parameters["objective"] = "ml"  # default
 
-            objective = spline_parameters['objective']
+            objective = spline_parameters["objective"]
 
-            if objective not in ['ml','map']:
+            if objective not in ["ml", "map"]:
                 raise ParameterError(
-                    "objective may only be \'ml\' or \'map\': you have selected {:s}".format(objective))
+                    "objective may only be 'ml' or 'map': you have selected {:s}".format(objective)
+                )
 
-            if objective == 'ml': # we are doing maximum likelihood minimization
+            if objective == "ml":  # we are doing maximum likelihood minimization
                 logprior = None
                 dlogprior = None
                 ddlogprior = None
 
-            elif objective == 'map':
-                if 'map_data' not in spline_parameters:
+            elif objective == "map":
+                if "map_data" not in spline_parameters:
                     raise ParameterError(
-                        "if 'objective' is \'map\' you must include 'map_data' structure")
-                elif spline_parameters['map_data'] == None:
-                    raise ParameterError(
-                        "MAP data must be defined if objective is MAP")
+                        "if 'objective' is 'map' you must include 'map_data' structure"
+                    )
+                elif spline_parameters["map_data"] == None:
+                    raise ParameterError("MAP data must be defined if objective is MAP")
                 else:
-                    map_data = spline_parameters['map_data']
-                    if map_data['logprior'] == None:
-                        raise ParameterError(
-                            "log prior must be included if objective is MAP")
+                    map_data = spline_parameters["map_data"]
+                    if map_data["logprior"] == None:
+                        raise ParameterError("log prior must be included if objective is MAP")
                     else:
-                        logprior = map_data['logprior']
-                    if map_data['dlogprior'] == None:
-                        raise ParameterError(
-                            "d(log prior) must be included if objective is MAP")
+                        logprior = map_data["logprior"]
+                    if map_data["dlogprior"] == None:
+                        raise ParameterError("d(log prior) must be included if objective is MAP")
                     else:
-                        dlogprior = map_data['dlogprior']
-                    if map_data['ddlogprior'] == None:
-                        raise ParameterError(
-                            "d^2(log prior) must be included if objective is MAP")
+                        dlogprior = map_data["dlogprior"]
+                    if map_data["ddlogprior"] == None:
+                        raise ParameterError("d^2(log prior) must be included if objective is MAP")
                     else:
-                        ddlogprior = map_data['ddlogprior']
+                        ddlogprior = map_data["ddlogprior"]
 
-            spline_weights = spline_parameters['spline_weights']
+            spline_weights = spline_parameters["spline_weights"]
 
             # need the x-range for all methods, since we need to
-            xrange = spline_parameters['xrange']
+            xrange = spline_parameters["xrange"]
             # numerically integrate over this range
-            nspline = spline_parameters['nspline']  # number of spline points.
-            kdegree = spline_parameters['kdegree']  # degree of the spline
+            nspline = spline_parameters["nspline"]  # number of spline points.
+            kdegree = spline_parameters["kdegree"]  # degree of the spline
 
             # we need to intialize our function starting point
 
-            if spline_parameters['optimization_algorithm'] != 'Custom-NR':
+            if spline_parameters["optimization_algorithm"] != "Custom-NR":
                 # we are passing it on to scipy
 
-                if 'optimize_options' not in spline_parameters:
-                    spline_parameters['optimize_options'] = {
-                        'disp': True, 'ftol': 10**(-7), 'xtol': 10**(-7)}
+                if "optimize_options" not in spline_parameters:
+                    spline_parameters["optimize_options"] = {
+                        "disp": True,
+                        "ftol": 10 ** (-7),
+                        "xtol": 10 ** (-7),
+                    }
 
-                if 'tol' in spline_parameters['optimize_options']:
+                if "tol" in spline_parameters["optimize_options"]:
                     # scipy doesn't like 'tol' within options
-                    scipy_tol = spline_parameters['optimize_options']['tol']
-                    spline_parameters['optimize_options'].pop('tol', None)
+                    scipy_tol = spline_parameters["optimize_options"]["tol"]
+                    spline_parameters["optimize_options"].pop("tol", None)
                 else:
-                    scipy_tol = None # this is just the default anyway.
-                if spline_parameters['optimization_algorithm'] not in [
-                        'Newton-CG', 'CG', 'BFGS', 'L-BFGS-B', 'TNC', 'SLSQP']:
+                    scipy_tol = None  # this is just the default anyway.
+                if spline_parameters["optimization_algorithm"] not in [
+                    "Newton-CG",
+                    "CG",
+                    "BFGS",
+                    "L-BFGS-B",
+                    "TNC",
+                    "SLSQP",
+                ]:
                     raise ParameterError(
-                        'Optimization method {:s} is not supported'.format(
-                            spline_parameters['optimization_algorithm']))
+                        "Optimization method {:s} is not supported".format(
+                            spline_parameters["optimization_algorithm"]
+                        )
+                    )
             else:
-                if 'optimize_options' not in spline_parameters:
-                    spline_parameters['optimize_options'] = dict()
-                if 'gtol' not in spline_parameters['optimize_options']:
-                    spline_parameters['optimize_options']['tol'] = 10**(-7)
+                if "optimize_options" not in spline_parameters:
+                    spline_parameters["optimize_options"] = dict()
+                if "gtol" not in spline_parameters["optimize_options"]:
+                    spline_parameters["optimize_options"]["tol"] = 10 ** (-7)
 
-            if spline_parameters['spline_initialize'] == 'bias_free_energies':
+            if spline_parameters["spline_initialize"] == "bias_free_energies":
 
                 initivals = self.mbar.f_k
                 # initialize to the bias free energies
-                if 'bias_centers' in spline_parameters:  # if we are provided bias center, use them
-                    bias_centers = spline_parameters['bias_centers']
+                if "bias_centers" in spline_parameters:  # if we are provided bias center, use them
+                    bias_centers = spline_parameters["bias_centers"]
                     sort_indices = np.argsort(bias_centers)
                     K = self.mbar.K
                     if K < 2 * nspline:
                         noverfit = int(np.round(K / 2))
                         tinit = np.zeros(noverfit + kdegree + 1)
                         tinit[0:kdegree] = xrange[0]
-                        tinit[kdegree:noverfit + 1] = np.linspace(
-                            xrange[0], xrange[1], num=noverfit + 1 - kdegree, endpoint=True)
-                        tinit[noverfit + 1:noverfit + kdegree + 1] = xrange[1]
+                        tinit[kdegree : noverfit + 1] = np.linspace(
+                            xrange[0], xrange[1], num=noverfit + 1 - kdegree, endpoint=True
+                        )
+                        tinit[noverfit + 1 : noverfit + kdegree + 1] = xrange[1]
                         # problem: bin centers might not actually be sorted.
                         binit = make_lsq_spline(
-                            bias_centers[sort_indices], initivals[sort_indices],
-                            tinit, k=kdegree)
+                            bias_centers[sort_indices], initivals[sort_indices], tinit, k=kdegree
+                        )
                         xinit = np.linspace(xrange[0], xrange[1], num=2 * nspline)
                         yinit = binit(xinit)
                     else:
@@ -528,23 +544,24 @@ class PMF:
                         yinit = initivals[sort_indices]
                 else:
                     # assume equally spaced bias scenters
-                    xinit = np.linspace(
-                        xrange[0], xrange[1], self.mbar.K + 1)[1:-1]
+                    xinit = np.linspace(xrange[0], xrange[1], self.mbar.K + 1)[1:-1]
                     yinit = initivals
 
-            elif spline_parameters['spline_initialize'] == 'explicit':
-                if 'xinit' in spline_parameters:
-                    xinit = spline_parameters['xinit']
+            elif spline_parameters["spline_initialize"] == "explicit":
+                if "xinit" in spline_parameters:
+                    xinit = spline_parameters["xinit"]
                 else:
                     raise ParameterError(
-                        'spline_initialize set as explicit, but no xinit array specified')
-                if 'yinit' in spline_parameters:
-                    yinit = spline_parameters['yinit']
+                        "spline_initialize set as explicit, but no xinit array specified"
+                    )
+                if "yinit" in spline_parameters:
+                    yinit = spline_parameters["yinit"]
                 else:
                     raise ParameterError(
-                        'spline_initialize set as explicit, but no yinit array specified')
+                        "spline_initialize set as explicit, but no yinit array specified"
+                    )
 
-            elif spline_parameters['spline_initialize'] == 'zeros':  # initialize to zero
+            elif spline_parameters["spline_initialize"] == "zeros":  # initialize to zero
                 xinit = np.linspace(xrange[0], xrange[1], nspline + kdegree)
                 yinit = np.zeros(len(xinit))
 
@@ -555,19 +572,16 @@ class PMF:
             # t has to be of size nsplines + kdegree + 1
             t = np.zeros(nspline + kdegree + 1)
             t[0:kdegree] = xrange[0]
-            t[kdegree:nspline + 1] = np.linspace(
-                xrange[0], xrange[1], num=nspline + 1 - kdegree, endpoint=True)
-            t[nspline + 1:nspline + kdegree + 1] = xrange[1]
+            t[kdegree : nspline + 1] = np.linspace(
+                xrange[0], xrange[1], num=nspline + 1 - kdegree, endpoint=True
+            )
+            t[nspline + 1 : nspline + kdegree + 1] = xrange[1]
 
             # initial fit function
             # problem: bin centers might not actually be sorted. Should data
             # getting to here be already sorted?
             sort_indices = np.argsort(xinit)
-            b = make_lsq_spline(
-                xinit[sort_indices],
-                yinit[sort_indices],
-                t,
-                k=kdegree)
+            b = make_lsq_spline(xinit[sort_indices], yinit[sort_indices], t, k=kdegree)
             # one, since the PMF is only determined up to a constant.
             b.c = b.c - b.c[0]  # We zero out the first
             # the bspline coefficients are the variables we care about.
@@ -591,7 +605,7 @@ class PMF:
             # same for the next execution. Not sure if best time to save it.
             self.bspline_derivatives = db_c
             self.bspline = b
-            self.fkbias = spline_parameters['fkbias']
+            self.fkbias = spline_parameters["fkbias"]
 
             # We also construct integration ranges for the derivatives, since no point in integrating when
             # the function is zero.
@@ -609,8 +623,7 @@ class PMF:
                     xrangeij[i, j, 1] = np.min([xrangei[i, 1], xrangei[j, 1]])
 
         else:
-            raise ParameterError(
-                'pmf_type {:s} is not defined!'.format(pmf_type))
+            raise ParameterError("pmf_type {:s} is not defined!".format(pmf_type))
 
         for b in range(nbootstraps + 1):  # generate bootstrap samples.
             # we bootstrap from each simulation separately.
@@ -621,25 +634,27 @@ class PMF:
             else:
                 index = 0
                 for k in range(K):
-                    bootstrap_indices[index:index + N_k[k]] = index + self._random.randint(0, N_k[k], size=N_k[k])
+                    bootstrap_indices[index : index + N_k[k]] = index + self._random.randint(
+                        0, N_k[k], size=N_k[k]
+                    )
                     index += N_k[k]
                     # recompute MBAR.
                     mbar = pymbar.MBAR(
-                        self.u_kn[:, bootstrap_indices], self.N_k, initial_f_k=self.mbar.f_k)
+                        self.u_kn[:, bootstrap_indices], self.N_k, initial_f_k=self.mbar.f_k
+                    )
                     x_nb = x_n[bootstrap_indices]
 
             # Compute unnormalized log weights for the given reduced potential
             # u_n, needed for all methods.
-            log_w_n = mbar._computeUnnormalizedLogWeights(
-                self.u_n[bootstrap_indices])
+            log_w_n = mbar._computeUnnormalizedLogWeights(self.u_n[bootstrap_indices])
             # calculate a few other things used for multiple methods
-            max_log_w_n = np.max(log_w_n) # we need to solve underflow.
-            self.w_n = np.exp(log_w_n-max_log_w_n)
+            max_log_w_n = np.max(log_w_n)  # we need to solve underflow.
+            self.w_n = np.exp(log_w_n - max_log_w_n)
             self.w_n = self.w_n / np.sum(self.w_n)  # nomalize the weights
             # normalized weights for all states.
             self.w_kn = np.exp(mbar.Log_W_nk)
 
-            if self.pmf_type == 'histogram':
+            if self.pmf_type == "histogram":
 
                 # store the data that will be regenerated each time.
                 # We will not try to regenerate the bin locations each time,
@@ -647,8 +662,8 @@ class PMF:
                 # We will just recalculate the populations.
                 histogram_data = dict()
 
-                histogram_data['bins'] = bins # save for other functions.  
-                                              # Does not actually vary between bootstraps
+                histogram_data["bins"] = bins  # save for other functions.
+                # Does not actually vary between bootstraps
 
                 # create the bins from the data.
                 # it's a 1D array, instead of a Nx1 array.  Reshape.
@@ -661,7 +676,7 @@ class PMF:
                     # bins returns 0 as out of bin.  We want to use -1 as out
                     # of bin
                     bin_n[:, d] = np.digitize(x_nb[:, d], bins[d]) - 1
-                histogram_data['bin_n'] = bin_n  # bin counts
+                histogram_data["bin_n"] = bin_n  # bin counts
 
                 # now we need to loop over the bin_n and identify and label the
                 # nonzero bins.
@@ -684,32 +699,35 @@ class PMF:
                         # this bin has a sample.  Add it to the list
                         nonzero_bins.append(ind2)
                     nonzero_bins_index[n] = nonzero_bins.index(
-                        ind2)  # the index of the nonzero bins
+                        ind2
+                    )  # the index of the nonzero bins
 
-                histogram_data['nbins'] = np.int(
-                    np.max(nonzero_bins_index)) + 1  # the total number of nonzero bins
-                histogram_data['bin_n'] = nonzero_bins_index
+                histogram_data["nbins"] = (
+                    np.int(np.max(nonzero_bins_index)) + 1
+                )  # the total number of nonzero bins
+                histogram_data["bin_n"] = nonzero_bins_index
 
                 # Compute the free energies for these histogram states with
                 # samples
-                f_i = np.zeros([histogram_data['nbins']], np.float64)
-                df_i = np.zeros([histogram_data['nbins']], np.float64)
+                f_i = np.zeros([histogram_data["nbins"]], np.float64)
+                df_i = np.zeros([histogram_data["nbins"]], np.float64)
 
-                for i in range(histogram_data['nbins']):
+                for i in range(histogram_data["nbins"]):
                     # Get linear n-indices of samples that fall in this bin.
-                    indices = np.where(histogram_data['bin_n'] == i)
+                    indices = np.where(histogram_data["bin_n"] == i)
 
                     # Sanity check.
-                    if (len(indices) == 0):
+                    if len(indices) == 0:
                         raise DataError(
-                            "WARNING: bin %d has no samples -- all bins must have at least one sample." %
-                            i)
+                            "WARNING: bin %d has no samples -- all bins must have at least one sample."
+                            % i
+                        )
 
                     # Compute dimensionless free energy of occupying state i.
-                    f_i[i] = - logsumexp(log_w_n[indices])
+                    f_i[i] = -logsumexp(log_w_n[indices])
 
                 # store the free energies for this bin
-                histogram_data['f'] = f_i
+                histogram_data["f"] = f_i
 
                 # now assign back the free energy from the sample_only bins to
                 # all of the bins.
@@ -735,13 +753,13 @@ class PMF:
                         # points.
                         fbin_index[g] = -1
 
-                histogram_data['fbin_index'] = fbin_index
+                histogram_data["fbin_index"] = fbin_index
                 if b == 0:
                     self.histogram_data = histogram_data
                 else:
                     self.histogram_datas.append(histogram_data)
 
-            elif pmf_type == 'kde':
+            elif pmf_type == "kde":
 
                 # reshape data if needed.
                 # it's a 1D array, instead of a Nx1 array.  Reshape.
@@ -760,33 +778,46 @@ class PMF:
                 else:
                     self.kdes.append(kde)
 
-            elif pmf_type == 'spline':
+            elif pmf_type == "spline":
 
                 w_n = self.w_n
                 if b > 0:
                     xi = savexi
-                if spline_parameters['optimization_algorithm'] != 'Custom-NR':
-                    if spline_parameters['optimization_algorithm'] == 'Newton-CG':
+                if spline_parameters["optimization_algorithm"] != "Custom-NR":
+                    if spline_parameters["optimization_algorithm"] == "Newton-CG":
                         hess = self._bspline_calculate_h
                     else:
                         hess = None
                     results = minimize(
                         self._bspline_calculate_f,
                         xi,
-                        args=(w_n,x_nb,nspline,kdegree,spline_weights,xrange,xrangei,xrangeij,logprior,dlogprior,ddlogprior),
-                        method=spline_parameters['optimization_algorithm'],
+                        args=(
+                            w_n,
+                            x_nb,
+                            nspline,
+                            kdegree,
+                            spline_weights,
+                            xrange,
+                            xrangei,
+                            xrangeij,
+                            logprior,
+                            dlogprior,
+                            ddlogprior,
+                        ),
+                        method=spline_parameters["optimization_algorithm"],
                         jac=self._bspline_calculate_g,
-                        tol = scipy_tol,
+                        tol=scipy_tol,
                         hess=hess,
-                        options=spline_parameters['optimize_options'])
-                    self.bspline = self._val_to_spline(results['x'], form ='log')
-                    savexi = results['x']
-                    f = results['fun']
+                        options=spline_parameters["optimize_options"],
+                    )
+                    self.bspline = self._val_to_spline(results["x"], form="log")
+                    savexi = results["x"]
+                    f = results["fun"]
                 else:
-                    if 'gtol' in spline_parameters['optimize_options']:
-                        tol = spline_parameters['optimize_options']['gtol']
-                    elif 'tol' in spline_parameters['optimize_options']:
-                        tol = spline_parameters['optimize_options']['tol']
+                    if "gtol" in spline_parameters["optimize_options"]:
+                        tol = spline_parameters["optimize_options"]["gtol"]
+                    elif "tol" in spline_parameters["optimize_options"]:
+                        tol = spline_parameters["optimize_options"]["tol"]
 
                     # should come up with better way to make sure it passes the first time.
                     dg = tol * 1e10
@@ -795,8 +826,19 @@ class PMF:
                     while dg > tol:  # until we reach the tolerance.
 
                         f = self._bspline_calculate_f(
-                            xi, w_n, x_n, nspline, kdegree, spline_weights, 
-                            xrange, xrangei, xrangeij, logprior, dlogprior, ddlogprior)
+                            xi,
+                            w_n,
+                            x_n,
+                            nspline,
+                            kdegree,
+                            spline_weights,
+                            xrange,
+                            xrangei,
+                            xrangeij,
+                            logprior,
+                            dlogprior,
+                            ddlogprior,
+                        )
 
                         # we need some error handling: if we stepped too far, we should go back
                         # still not great error handling.  Requires something
@@ -805,16 +847,26 @@ class PMF:
                         if not firsttime:
                             count = 0
                             # we went too far!  Pull back.
-                            while ((f >= fold * (1.1)
-                                    and count < 5) or (np.isinf(f))):
+                            while (f >= fold * (1.1) and count < 5) or (np.isinf(f)):
                                 f = fold
                                 # let's not step as far:
                                 dx = 0.9 * dx
                                 xi = xold - dx  # step back 90% of dx
                                 xold = xi.copy()
                                 f = self._bspline_calculate_f(
-                                    xi, w_n, x_n, nspline, kdegree, spline_weights, 
-                                    xrange, xrangei, xrangeij, logprior, dlogprior, ddlogprior)
+                                    xi,
+                                    w_n,
+                                    x_n,
+                                    nspline,
+                                    kdegree,
+                                    spline_weights,
+                                    xrange,
+                                    xrangei,
+                                    xrangeij,
+                                    logprior,
+                                    dlogprior,
+                                    ddlogprior,
+                                )
                                 count += 1
                         else:
                             firsttime = False
@@ -822,11 +874,33 @@ class PMF:
                         xold = xi.copy()
 
                         g = self._bspline_calculate_g(
-                            xi, w_n, x_n, nspline, kdegree, spline_weights, 
-                            xrange, xrangei, xrangeij, logprior, dlogprior, ddlogprior)
+                            xi,
+                            w_n,
+                            x_n,
+                            nspline,
+                            kdegree,
+                            spline_weights,
+                            xrange,
+                            xrangei,
+                            xrangeij,
+                            logprior,
+                            dlogprior,
+                            ddlogprior,
+                        )
                         h = self._bspline_calculate_h(
-                            xi, w_n, x_n, nspline, kdegree, spline_weights, 
-                            xrange, xrangei, xrangeij, logprior, dlogprior, ddlogprior)
+                            xi,
+                            w_n,
+                            x_n,
+                            nspline,
+                            kdegree,
+                            spline_weights,
+                            xrange,
+                            xrangei,
+                            xrangeij,
+                            logprior,
+                            dlogprior,
+                            ddlogprior,
+                        )
 
                         # now find the new point.
                         # x_n+1 = x_n - f''(x_n)^-1 f'(x_n)
@@ -837,35 +911,46 @@ class PMF:
 
                         dx = np.linalg.lstsq(h, g, rcond=None)[0]
                         xi = xold - dx
-                        if spline_parameters['optimize_options']['disp']:
+                        if spline_parameters["optimize_options"]["disp"]:
                             dg = np.sqrt(np.dot(g, g))
                             logger.info(
-                                "f = {:.10f}. gradient norm = {:.10f}".format(
-                                    f, np.sqrt(dg)))
-                    self.bspline = self._val_to_spline(xi, form = 'log')
+                                "f = {:.10f}. gradient norm = {:.10f}".format(f, np.sqrt(dg))
+                            )
+                    self.bspline = self._val_to_spline(xi, form="log")
 
                 if b == 0:
                     self.pmf_function = self.bspline
                     savexi = xi
 
                     minusloglikelihood = self._bspline_calculate_f(
-                        savexi, w_n, x_n, nspline, kdegree, spline_weights, 
-                        xrange, xrangei, xrangeij, logprior, dlogprior, ddlogprior)
+                        savexi,
+                        w_n,
+                        x_n,
+                        nspline,
+                        kdegree,
+                        spline_weights,
+                        xrange,
+                        xrangei,
+                        xrangeij,
+                        logprior,
+                        dlogprior,
+                        ddlogprior,
+                    )
 
                     nparameters = len(savexi)
 
                     # calculate the AIC
                     # formula is: 2(number of parameters) - 2 * loglikelihood
 
-                    self.aic = 2*nparameters + 2*minusloglikelihood  
+                    self.aic = 2 * nparameters + 2 * minusloglikelihood
 
                     # calculate the BIC
                     # formula is: ln(number of data points) * (number of parameters) - 2 ln (likelihood at maximum)
 
-                    self.bic = 2*np.log(self.N) * len(xi) + 2*minusloglikelihood
+                    self.bic = 2 * np.log(self.N) * len(xi) + 2 * minusloglikelihood
 
-                    # potential problems: we don't compute the full log likelihood currently since we 
-                    # exclude the potential energy part - will have to see what this is in reference to. 
+                    # potential problems: we don't compute the full log likelihood currently since we
+                    # exclude the potential energy part - will have to see what this is in reference to.
                     # this shouldn't be too much of a problem, since we are interested in choosing BETWEEN models.
 
                 else:
@@ -875,11 +960,11 @@ class PMF:
         # low.
         if self.timings:
             end = timer()
-            result_vals['timing'] = end - start
+            result_vals["timing"] = end - start
 
         return result_vals  # should we returrn results under some other conditions?
 
-    def getInformationCriteria(self,type='akaike'):
+    def getInformationCriteria(self, type="akaike"):
 
         """
         returns the Akaike Informatiton Criteria for the model if it exists.
@@ -892,21 +977,23 @@ class PMF:
         Output:
         =======
 
-        information criteria 
+        information criteria
         """
 
-        if self.pmf_type != 'spline':
+        if self.pmf_type != "spline":
             raise ParameterError(
-                "Information criteria currently only defined for spline approaches, you are currently using {:s}".format(type))
-        if type in ['akaike','Akaike','AIC','aic']:
+                "Information criteria currently only defined for spline approaches, you are currently using {:s}".format(
+                    type
+                )
+            )
+        if type in ["akaike", "Akaike", "AIC", "aic"]:
             return self.aic
-        elif type in ['bayesian','Bayesian','BIC','bic']:
+        elif type in ["bayesian", "Bayesian", "BIC", "bic"]:
             return self.bic
         else:
-            raise ParameterError(
-                "Information criteria of type \'{:s}\' not defined".format(type))
+            raise ParameterError("Information criteria of type '{:s}' not defined".format(type))
 
-    def getPMF(self, x, uncertainties='from-lowest', pmf_reference=None):
+    def getPMF(self, x, uncertainties="from-lowest", pmf_reference=None):
         """
         Returns values of the PMF at the specified x points.
 
@@ -943,29 +1030,29 @@ class PMF:
         else:
             coorddim = np.shape(x)[1]
 
-        if self.pmf_type == 'histogram':
+        if self.pmf_type == "histogram":
             if self.dims != coorddim:
                 # later, need to put coordinate check on other methods.
-                raise DataError(
-                    'coordinates have inconsistent dimension with the PMF.')
+                raise DataError("coordinates have inconsistent dimension with the PMF.")
 
-        if uncertainties == 'from-specified' and pmf_reference is None:
+        if uncertainties == "from-specified" and pmf_reference is None:
             raise ParameterError(
-                "No reference state specified for PMF using uncertainties = from-specified")
+                "No reference state specified for PMF using uncertainties = from-specified"
+            )
 
         if self.pmf_type is None:
-            raise ParameterError('pmf_type has not been set!')
+            raise ParameterError("pmf_type has not been set!")
 
         K = self.mbar.K  # number of states
 
         # create dictionary to return results
         result_vals = dict()
 
-        if self.pmf_type == 'histogram':
+        if self.pmf_type == "histogram":
 
             # figure out which bins the values are in.
-            nbins = self.histogram_data['nbins']
-            bins = self.histogram_data['bins']
+            nbins = self.histogram_data["nbins"]
+            bins = self.histogram_data["bins"]
             dims = len(bins)
 
             if dims == 1:
@@ -986,27 +1073,34 @@ class PMF:
                 pmf_ref_grid = np.zeros([dims], dtype=int)
                 for d in range(dims):
                     # -1 and nbins_per_dim are out of range
-                    pmf_ref_grid[d] = np.digitize(
-                        pmf_reference[d], bins[d]) - 1
-                    if pmf_ref_grid[d] == - 1 or pmf_ref_grid[d] == len(bins[d]):
+                    pmf_ref_grid[d] = np.digitize(pmf_reference[d], bins[d]) - 1
+                    if pmf_ref_grid[d] == -1 or pmf_ref_grid[d] == len(bins[d]):
                         raise ParameterError(
                             "Specified reference point coordinate {:f} in dim {:d} grid point is out of the defined free energy region [{:f},{:f}]".format(
-                                pmf_ref_grid[d], d, np.min(bins[d]), np.max(bins[d])))
+                                pmf_ref_grid[d], d, np.min(bins[d]), np.max(bins[d])
+                            )
+                        )
 
-            if uncertainties == 'from-lowest' or uncertainties == 'from-specified' or uncertainties == 'all-differences':
+            if (
+                uncertainties == "from-lowest"
+                or uncertainties == "from-specified"
+                or uncertainties == "all-differences"
+            ):
                 # Report uncertainties in free energy difference from a given
                 # point on PMF.
 
-                df_i = np.zeros(len(self.histogram_data['f']), np.float64)
-                
-                if uncertainties == 'from-lowest':
+                df_i = np.zeros(len(self.histogram_data["f"]), np.float64)
+
+                if uncertainties == "from-lowest":
                     # Determine bin index with lowest free energy.
-                    j = self.histogram_data['f'].argmin()
-                elif uncertainties == 'from-specified':
-                    j = self.histogram_data['fbin_index'][tuple(pmf_ref_grid)]
-                elif uncertainties == 'all-differences':
-                    raise ParameterError("Uncertainty method of 'all-differences' is not yet supported for histogram "
-                                         "PMF types (not implemented)")
+                    j = self.histogram_data["f"].argmin()
+                elif uncertainties == "from-specified":
+                    j = self.histogram_data["fbin_index"][tuple(pmf_ref_grid)]
+                elif uncertainties == "all-differences":
+                    raise ParameterError(
+                        "Uncertainty method of 'all-differences' is not yet supported for histogram "
+                        "PMF types (not implemented)"
+                    )
 
                 if self.nbootstraps == 0:
                     # Compute uncertainties in free energy at each gridpoint by
@@ -1016,16 +1110,16 @@ class PMF:
                     W_nk = np.zeros([self.N, self.K + nbins], np.float64)
                     W_nk[:, 0:K] = np.exp(self.mbar.Log_W_nk)
 
-                    log_w_n = self.mbar._computeUnnormalizedLogWeights(
-                        self.u_n)
+                    log_w_n = self.mbar._computeUnnormalizedLogWeights(self.u_n)
                     for i in range(nbins):  # loop over the nonzero bins, internal numbering
                         # Get indices of samples that fall in this bin.
-                        indices = np.where(self.histogram_data['bin_n'] == i)
+                        indices = np.where(self.histogram_data["bin_n"] == i)
 
                         # Compute normalized weights for this state.
-                        W_nk[indices,
-                             K + i] = np.exp(log_w_n[indices] + self.histogram_data['f'][i])
-                        
+                        W_nk[indices, K + i] = np.exp(
+                            log_w_n[indices] + self.histogram_data["f"][i]
+                        )
+
                     # Compute asymptotic covariance matrix using specified
                     # method.
                     Theta_ij = self.mbar._computeAsymptoticCovarianceMatrix(W_nk, N_k)
@@ -1034,23 +1128,26 @@ class PMF:
                     # from this state j.
                     for i in range(nbins):
                         df_i[i] = math.sqrt(
-                            Theta_ij[K + i, K + i] + Theta_ij[K + j, K + j] - 2.0 * Theta_ij[K + i, K + j])
+                            Theta_ij[K + i, K + i]
+                            + Theta_ij[K + j, K + j]
+                            - 2.0 * Theta_ij[K + i, K + j]
+                        )
 
                 else:
-                    fall = np.zeros(
-                        [len(self.histogram_data['f']), self.nbootstraps])
+                    fall = np.zeros([len(self.histogram_data["f"]), self.nbootstraps])
                     for b in range(self.nbootstraps):
-                        fall[:, b] = self.histogram_datas[b]['f'] - self.histogram_datas[b]['f'][j]
+                        fall[:, b] = self.histogram_datas[b]["f"] - self.histogram_datas[b]["f"][j]
 
                         df_i = np.std(fall, axis=1)
                     # Shift free energies so that state j has zero free energy.
-                f_i = self.histogram_data['f'] - self.histogram_data['f'][j]
+                f_i = self.histogram_data["f"] - self.histogram_data["f"][j]
 
-            elif (uncertainties == 'from-normalization'):
+            elif uncertainties == "from-normalization":
                 # Determine uncertainties from normalization that \sum_i p_i = 1.
                 # need to reimplement this . . . maybe.
                 raise ParameterError(
-                    'uncertainty method \'from-normalization\' is not currently supported for histograms')
+                    "uncertainty method 'from-normalization' is not currently supported for histograms"
+                )
 
                 # Currently unreachable code
 
@@ -1092,9 +1189,9 @@ class PMF:
                     continue
 
                 if dims == 1:
-                    findex = self.histogram_data['fbin_index'][l]
+                    findex = self.histogram_data["fbin_index"][l]
                 else:
-                    findex = self.histogram_data['fbin_index'][tuple(l)]
+                    findex = self.histogram_data["fbin_index"][tuple(l)]
                 if findex >= 0:
                     fx_vals[i] = f_i[findex]
                     dfx_vals[i] = df_i[findex]
@@ -1103,17 +1200,16 @@ class PMF:
                     dfx_vals[i] = np.nan
 
                 # Return dimensionless free energy and uncertainty.
-                result_vals['f_i'] = fx_vals
-                result_vals['df_i'] = dfx_vals
+                result_vals["f_i"] = fx_vals
+                result_vals["df_i"] = dfx_vals
 
-            if uncertainties == 'all-differences':
+            if uncertainties == "all-differences":
                 if self.nbootstraps == 0:
                     # Report uncertainties in all free energy differences as
                     # well.
                     diag = Theta_ij.diagonal()
                     dii = diag[K, K + nbins]  # appears broken?  Not used?
-                    d2f_ij = dii + dii.transpose() - 2 * \
-                        Theta_ij[K:K + nbins, K:K + nbins]
+                    d2f_ij = dii + dii.transpose() - 2 * Theta_ij[K : K + nbins, K : K + nbins]
 
                     # unsquare uncertainties
                     df_ij = np.sqrt(d2f_ij)
@@ -1123,10 +1219,9 @@ class PMF:
                     findexs = list()
                     for i, l in enumerate(loc_indices):
                         if dims == 1:
-                            findex = self.histogram_data['fbin_index'][l]
+                            findex = self.histogram_data["fbin_index"][l]
                         else:
-                            findex = self.histogram_data['fbin_index'][tuple(
-                                l)]
+                            findex = self.histogram_data["fbin_index"][tuple(l)]
                         findexs.append(findex)
 
                     for i, vi in enumerate(findexs):
@@ -1137,18 +1232,25 @@ class PMF:
                                 dfxij_vals[i, j] = np.nan
                 else:
                     dfxij_vals = np.zeros(
-                        [len(self.histogram_data['f']), len(self.histogram_data['f'])])
-                    fall = np.zeros([len(self.histogram_data['f']), len(
-                        self.histogram_data['f']), self.nbootstraps])
+                        [len(self.histogram_data["f"]), len(self.histogram_data["f"])]
+                    )
+                    fall = np.zeros(
+                        [
+                            len(self.histogram_data["f"]),
+                            len(self.histogram_data["f"]),
+                            self.nbootstraps,
+                        ]
+                    )
                     for b in range(self.nbootstraps):
-                        fall[:, b] = self.histogram_datas[b]['f'] - \
-                            self.histogram_data[b]['f'].transpose()
+                        fall[:, b] = (
+                            self.histogram_datas[b]["f"] - self.histogram_data[b]["f"].transpose()
+                        )
                     dfxij_vals = np.std(fall, axis=2)
 
                 # Return dimensionless free energy and uncertainty.
-                result_vals['df_ij'] = dfxij_vals
+                result_vals["df_ij"] = dfxij_vals
 
-        elif self.pmf_type == 'kde':
+        elif self.pmf_type == "kde":
 
             # if it's not an array, make it one.
             x = np.array(x)
@@ -1158,13 +1260,12 @@ class PMF:
                 x = x.reshape(-1, 1)
             f_i = -self.kde.score_samples(x)  # gives the LOG density, which is what we want.
 
-            if uncertainties == 'from-lowest':
+            if uncertainties == "from-lowest":
                 fmin = np.min(f_i)
                 f_i = f_i - fmin
 
-            elif uncertainties == 'from-specified':
-                fmin = - \
-                    self.kde.score_samples(np.array(pmf_reference).reshape(1, -1))
+            elif uncertainties == "from-specified":
+                fmin = -self.kde.score_samples(np.array(pmf_reference).reshape(1, -1))
                 f_i = f_i - fmin
             else:
                 raise ParameterError(f"Uncertainty method {uncertainties} for kde is unavailable")
@@ -1179,20 +1280,19 @@ class PMF:
 
             # uncertainites "from normalization" reference is applied, since
             # the density is normalized.
-            result_vals['f_i'] = f_i
-            result_vals['df_i'] = df_i
+            result_vals["f_i"] = f_i
+            result_vals["df_i"] = df_i
 
-        elif self.pmf_type == 'spline':
+        elif self.pmf_type == "spline":
 
             f_i = self.pmf_function(x)
 
-            if uncertainties == 'from-lowest':
+            if uncertainties == "from-lowest":
                 fmin = np.min(f_i)
                 f_i = f_i - fmin
 
-            elif uncertainties == 'from-specified':
-                fmin = - \
-                    self.pmf_function(np.array(pmf_reference).reshape(1, -1))
+            elif uncertainties == "from-specified":
+                fmin = -self.pmf_function(np.array(pmf_reference).reshape(1, -1))
                 f_i = f_i - fmin
             if self.nbootstraps == 0:
                 df_i = None
@@ -1205,8 +1305,8 @@ class PMF:
 
             # uncertainites "from normalization" reference is applied, since
             # the density is normalized.
-            result_vals['f_i'] = f_i
-            result_vals['df_i'] = df_i
+            result_vals["f_i"] = f_i
+            result_vals["df_i"] = df_i
             # no error method yet. Maybe write a bootstrap class?
 
         return result_vals
@@ -1221,8 +1321,7 @@ class PMF:
         if self.mbar is not None:
             return self.mbar
         else:
-            raise DataError(
-                'MBAR in the PMF object is not initialized, cannot return it.')
+            raise DataError("MBAR in the PMF object is not initialized, cannot return it.")
 
     def getKDE(self):
         """ return the KernelDensity object if it exists.
@@ -1232,23 +1331,19 @@ class PMF:
             Returns: sklearn KernelDensity object
         """
 
-        if self.pmf_type == 'kde':
+        if self.pmf_type == "kde":
             if self.kde != None:
                 return self.kde
             else:
                 raise ParameterError(
-                    'Can\'t return the KernelDensity object because kde not yet defined')                
+                    "Can't return the KernelDensity object because kde not yet defined"
+                )
         else:
-            raise ParameterError(
-                'Can\'t return the KernelDensity object because pmf_type != kde')
+            raise ParameterError("Can't return the KernelDensity object because pmf_type != kde")
 
     def sampleParameterDistribution(
-            self,
-            x_n,
-            mc_parameters = None,
-            decorrelate = True,
-            verbose = True,
-            ):
+        self, x_n, mc_parameters=None, decorrelate=True, verbose=True,
+    ):
 
         # determine the range of the bspline at the start of the
         # process: changes are made as fractions of this
@@ -1257,62 +1352,62 @@ class PMF:
 
         pmf_type = self.pmf_type
 
-        if pmf_type != 'spline':
-            ParameterError("Keyword \'pmf_type\' must be spline")
+        if pmf_type != "spline":
+            ParameterError("Keyword 'pmf_type' must be spline")
 
         K = self.mbar.K
-        spline_weights = spline_parameters['spline_weights']
+        spline_weights = spline_parameters["spline_weights"]
 
         if spline_parameters is None:
-            ParameterError(
-                "Must specify spline_parameters to sample the distributions")
+            ParameterError("Must specify spline_parameters to sample the distributions")
 
-        spline_weights = spline_parameters['spline_weights']
+        spline_weights = spline_parameters["spline_weights"]
 
         w_n = self.w_n
 
         # need the x-range for all methods, since we need to
-        xrange = spline_parameters['xrange']
+        xrange = spline_parameters["xrange"]
         # numerically integrate over this range
 
-        if pmf_type != 'spline':
-            ParameterError(
-                "Sampling of posterior is only supported for spline type")
+        if pmf_type != "spline":
+            ParameterError("Sampling of posterior is only supported for spline type")
 
         if self.bspline is None:
             ParameterError(
-                "Need to generate a splined PMF using GeneratePMF before performing MCMC sampling")
+                "Need to generate a splined PMF using GeneratePMF before performing MCMC sampling"
+            )
 
         if mc_parameters is None:
-            logger.info('Using default MC parameters')
+            logger.info("Using default MC parameters")
             mc_parameters = dict()
 
-        if 'niterations' not in mc_parameters:
-            mc_parameters['niterations'] = 5000
-        if 'fraction_change' not in mc_parameters:
-            mc_parameters['fraction_change'] = 0.01
-        if 'sample_every' not in mc_parameters:
-            mc_parameters['sample_every'] = 50
-        if 'print_every' not in mc_parameters:
-            mc_parameters['print_every'] = 1000
-        if 'logprior' not in mc_parameters:
-            mc_parameters['logprior'] = lambda x: 0
+        if "niterations" not in mc_parameters:
+            mc_parameters["niterations"] = 5000
+        if "fraction_change" not in mc_parameters:
+            mc_parameters["fraction_change"] = 0.01
+        if "sample_every" not in mc_parameters:
+            mc_parameters["sample_every"] = 50
+        if "print_every" not in mc_parameters:
+            mc_parameters["print_every"] = 1000
+        if "logprior" not in mc_parameters:
+            mc_parameters["logprior"] = lambda x: 0
 
-        niterations = mc_parameters['niterations']
-        fraction_change = mc_parameters['fraction_change']
-        sample_every = mc_parameters['sample_every']
-        print_every = mc_parameters['print_every']
-        logprior = mc_parameters['logprior']
+        niterations = mc_parameters["niterations"]
+        fraction_change = mc_parameters["fraction_change"]
+        sample_every = mc_parameters["sample_every"]
+        print_every = mc_parameters["print_every"]
+        logprior = mc_parameters["logprior"]
 
         # ensure normalization of spline
-        def prob(x): return np.exp(-self.bspline(x))
-        norm = self._integrate(spline_parameters['spline_weights'], prob, xrange[0], xrange[1])
+        def prob(x):
+            return np.exp(-self.bspline(x))
+
+        norm = self._integrate(spline_parameters["spline_weights"], prob, xrange[0], xrange[1])
         self.bspline.c = self.bspline.c + np.log(norm)
-            
+
         self.mc_data = dict()
         # make a copy of the original spline to preserve it.
-        self.mc_data['original_spline'] = BSpline(
-            self.bspline.t, self.bspline.c, self.bspline.k)
+        self.mc_data["original_spline"] = BSpline(self.bspline.t, self.bspline.c, self.bspline.k)
 
         # this might not work as well for probability
         c = self.bspline.c
@@ -1328,10 +1423,14 @@ class PMF:
         for n in range(niterations):
             results = self._MCStep(x_n, w_n, dc, xrange, spline_weights, logprior)
             if n % sample_every == 0:
-                csamples[:, n // sample_every] = results['c']
-                logposteriors[n // sample_every] = results['logposterior']
+                csamples[:, n // sample_every] = results["c"]
+                logposteriors[n // sample_every] = results["logposterior"]
             if n % print_every == 0 and verbose:
-                print("MC Step {:d} of {:d}".format(n, niterations),str(results['logposterior']),str(self.bspline.c))
+                print(
+                    "MC Step {:d} of {:d}".format(n, niterations),
+                    str(results["logposterior"]),
+                    str(self.bspline.c),
+                )
 
         # We now have a distribution of samples of parameters sampled according
         # to the posterior.
@@ -1345,37 +1444,39 @@ class PMF:
 
         if decorrelate:
             t_mc, g_mc, Neff = timeseries.detectEquilibration(logposteriors)
-            logger.info("First equilibration sample is {:d} of {:d}".format(t_mc,len(logposteriors)))
+            logger.info(
+                "First equilibration sample is {:d} of {:d}".format(t_mc, len(logposteriors))
+            )
             equil_logp = logposteriors[t_mc:]
             g_mc = timeseries.statisticalInefficiency(equil_logp)
             if verbose:
                 logger.info("Statistical inefficiency of log posterior is {:.3g}".format(g_mc))
             g_c = np.zeros(len(c))
             for nc in range(len(c)):
-                g_c[nc] = timeseries.statisticalInefficiency(csamples[nc,t_mc:])
+                g_c[nc] = timeseries.statisticalInefficiency(csamples[nc, t_mc:])
             if verbose:
-                logger.info("Time series for spline parameters are: {:s}".format(str(g_c))) 
+                logger.info("Time series for spline parameters are: {:s}".format(str(g_c)))
             maxgc = np.max(g_c)
             meangc = np.mean(g_c)
             guse = g_mc  # doesn't affect the distribution that much
             indices = timeseries.subsampleCorrelatedData(equil_logp, g=guse)
             logposteriors = equil_logp[indices]
-            csamples = (csamples[:,t_mc:])[:,indices]
+            csamples = (csamples[:, t_mc:])[:, indices]
             if verbose:
                 logger.info("samples after decorrelation: {:d}".format(np.shape(csamples)[1]))
 
-        self.mc_data['samples'] = csamples
-        self.mc_data['logposteriors'] = logposteriors
-        self.mc_data['mc_parameters'] = mc_parameters
-        self.mc_data['acceptance ratio'] = self.naccept / niterations
+        self.mc_data["samples"] = csamples
+        self.mc_data["logposteriors"] = logposteriors
+        self.mc_data["mc_parameters"] = mc_parameters
+        self.mc_data["acceptance ratio"] = self.naccept / niterations
         if verbose:
-            logger.info("Acceptance rate: {:5.3f}".format(self.mc_data['acceptance ratio']))
-        self.mc_data['nequil'] = t_mc # the start of the "equilibrated" data set
-        self.mc_data['g_logposterior'] = g_mc # statistical efficiency of the log posterior
-        self.mc_data['g_parameters'] = g_c # statistical efficiency of the parametere
-        self.mc_data['g'] = guse # statistical efficiency used for subsampling 
+            logger.info("Acceptance rate: {:5.3f}".format(self.mc_data["acceptance ratio"]))
+        self.mc_data["nequil"] = t_mc  # the start of the "equilibrated" data set
+        self.mc_data["g_logposterior"] = g_mc  # statistical efficiency of the log posterior
+        self.mc_data["g_parameters"] = g_c  # statistical efficiency of the parametere
+        self.mc_data["g"] = guse  # statistical efficiency used for subsampling
 
-    def getConfidenceIntervals(self, xplot, plow, phigh, reference='zero'):
+    def getConfidenceIntervals(self, xplot, plow, phigh, reference="zero"):
         """
         xplot is the data points we want to plot at
         plow is the lowest percentile
@@ -1383,16 +1484,15 @@ class PMF:
         """
 
         if self.mc_data is None:
-            raise DataError(
-                "No MC sampling has been done, cannot construct confidence intervals")
+            raise DataError("No MC sampling has been done, cannot construct confidence intervals")
 
         # determine confidence intervals
-        nplot = len(xplot) # number of data points to plot.
-        nsamples = len(self.mc_data['logposteriors'])
+        nplot = len(xplot)  # number of data points to plot.
+        nsamples = len(self.mc_data["logposteriors"])
         samplevals = np.zeros([nplot, nsamples])
 
-        csamples = self.mc_data['samples']
-        base_spline = self.mc_data['original_spline']
+        csamples = self.mc_data["samples"]
+        base_spline = self.mc_data["original_spline"]
 
         yvals = base_spline(xplot)
 
@@ -1413,23 +1513,23 @@ class PMF:
 
         return_vals = dict()
 
-        if reference == 'zero':
+        if reference == "zero":
             ref = np.min(yvals)
         elif reference == None:
             ref = 0
         else:
-            raise ParameterError("{:s} is not a valid value for \'reference\'") 
+            raise ParameterError("{:s} is not a valid value for 'reference'")
 
-        return_vals['plow'] = ylows - ref
-        return_vals['phigh'] = yhighs - ref
-        return_vals['median'] = ymedians - ref
-        return_vals['values'] = yvals - ref
+        return_vals["plow"] = ylows - ref
+        return_vals["phigh"] = yhighs - ref
+        return_vals["median"] = ymedians - ref
+        return_vals["values"] = yvals - ref
 
         return return_vals
 
     def getMCData(self):
 
-        """ convenience function to get MC data 
+        """ convenience function to get MC data
 
         Parameters:
         ===========
@@ -1443,57 +1543,54 @@ class PMF:
 
         mc_data['samples']: samples of the parameters with size [# parameters x # points]
         mc_data['logposteriors']: log posteriors (which might be defined with respect to some reference) as a time series size [# points]
-        self.mc_data['mc_parameters']: dictionary of parameters that were run with 
+        self.mc_data['mc_parameters']: dictionary of parameters that were run with
         self.mc_data['acceptance ratio']: acceptance ratio overall of the MC chain
         self.mc_data['nequil']: the start of the "equilibrated" data set (i.e. nequil-1 is the number that werer thrown out)
         self.mc_data['g_logposterior']: statistical efficiency of the log posterior
         self.mc_data['g_parameters']: statistical efficiency of the parametere
-        self.mc_data['g']: statistical efficiency used for subsampling   
+        self.mc_data['g']: statistical efficiency used for subsampling
 
         """
 
         if self.mc_data is None:
-            raise DataError(
-                "No MC sampling has been done, cannot construct confidence intervals")
+            raise DataError("No MC sampling has been done, cannot construct confidence intervals")
         else:
             return self.mc_data
-
 
     def _get_MC_loglikelihood(self, x_n, w_n, spline_weights, spline, xrange):
 
         N = self.N
         K = self.K
 
-        if spline_weights in ['simplesum', 'biasedstates']:
+        if spline_weights in ["simplesum", "biasedstates"]:
             loglikelihood = 0
 
             for k in range(self.K):
                 x_kn = x_n[self.mbar.x_kindices == k]
-                def splinek(x, kf=k): return spline(x) + self.fkbias[kf](x)
-                def expk(x, kf=k): return np.exp(-splinek(x, kf))
+
+                def splinek(x, kf=k):
+                    return spline(x) + self.fkbias[kf](x)
+
+                def expk(x, kf=k):
+                    return np.exp(-splinek(x, kf))
+
                 normalize = np.log(
-                    self._integrate(
-                        spline_weights, expk, xrange[0], xrange[1],args=(k)))
-                if spline_weights == 'simplesum':
+                    self._integrate(spline_weights, expk, xrange[0], xrange[1], args=(k))
+                )
+                if spline_weights == "simplesum":
                     loglikelihood += (N / K) * np.mean(splinek(x_kn))
                     loglikelihood += (N / K) * normalize
-                elif spline_weights == 'biasedstates':
+                elif spline_weights == "biasedstates":
                     loglikelihood += np.sum(splinek(x_kn))
                     loglikelihood += self.N_k[k] * normalize
 
-        elif spline_weights == 'unbiasedstate':
+        elif spline_weights == "unbiasedstate":
             loglikelihood = N * np.dot(w_n, spline(x_n))
             # no need to add normalization, should be normalized.
 
         return loglikelihood
 
-    def _MCStep(self, 
-                x_n, 
-                w_n, 
-                stepsize, 
-                xrange, 
-                spline_weights, 
-                logprior):
+    def _MCStep(self, x_n, w_n, stepsize, xrange, spline_weights, logprior):
 
         """ sample over the posterior space of the PMF as splined.
 
@@ -1504,7 +1601,7 @@ class PMF:
         w_n: weights of each sample.
         stepsize: sigma of the normal distribution used to propose steps
         xrange: Range the probility distribution is defined o er.
-        spline_weights: Type of weighting used for maximum likelihood for splines.  See class 
+        spline_weights: Type of weighting used for maximum likelihood for splines.  See class
                         definition for description of types.
         logprior: function describing the prior of the parameters. Default is uniform.
 
@@ -1512,7 +1609,7 @@ class PMF:
         ========
 
         results dict(), containing:
-            * 'c' the value of the spline constants (len nsplines - we always assume normalized 
+            * 'c' the value of the spline constants (len nsplines - we always assume normalized
             * 'logposterior': the current value of the logoposterior.
 
         NOTE: modifies several saved variables saved in the structure.x
@@ -1522,12 +1619,12 @@ class PMF:
         if self.first_step:
             c = self.bspline.c
             self.previous_logposterior = self._get_MC_loglikelihood(
-                x_n, w_n, spline_weights, self.bspline, xrange) - logprior(c)
+                x_n, w_n, spline_weights, self.bspline, xrange
+            ) - logprior(c)
             cold = self.bspline.c
             self.first_step = True
             # create an extra one we can carry around
-            self.newspline = BSpline(
-                self.bspline.t, self.bspline.c, self.bspline.k)
+            self.newspline = BSpline(self.bspline.t, self.bspline.c, self.bspline.k)
 
         self.cold = self.bspline.c
         psize = len(self.cold)
@@ -1538,7 +1635,9 @@ class PMF:
         self.newspline.c = cnew
 
         # determine the change in the integral
-        def prob(x): return np.exp(-self.newspline(x))
+        def prob(x):
+            return np.exp(-self.newspline(x))
+
         new_integral = self._integrate(spline_weights, prob, xrange[0], xrange[1])
 
         cnew = cnew + np.log(new_integral)
@@ -1547,7 +1646,8 @@ class PMF:
 
         # now calculate the change in log likelihood
         loglikelihood = self._get_MC_loglikelihood(
-            x_n, w_n, spline_weights, self.newspline, xrange)
+            x_n, w_n, spline_weights, self.newspline, xrange
+        )
 
         newlogposterior = loglikelihood - logprior(cnew)
         dlogposterior = newlogposterior - (self.previous_logposterior)
@@ -1564,25 +1664,25 @@ class PMF:
             self.previous_logposterior = newlogposterior
             self.naccept = self.naccept + 1
         results = dict()
-        results['c'] = self.bspline.c
-        results['logposterior'] = self.previous_logposterior
+        results["c"] = self.bspline.c
+        results["logposterior"] = self.previous_logposterior
         return results
 
     def _bspline_calculate_f(
-            self,
-            xi,
-            w_n,
-            x_n,
-            nspline,
-            kdegree,
-            spline_weights,
-            xrange,
-            xrangei,
-            xrangeij,
-            logprior,
-            dlogprior,
-            ddlogprior
-):
+        self,
+        xi,
+        w_n,
+        x_n,
+        nspline,
+        kdegree,
+        spline_weights,
+        xrange,
+        xrangei,
+        xrangeij,
+        logprior,
+        dlogprior,
+        ddlogprior,
+    ):
 
         """ Calculate the maximum likelihood / KL divergence of the PMF represented using B-splines.
 
@@ -1604,7 +1704,7 @@ class PMF:
 
         Output:
         =======
-        
+
         function value: scalar float
 
         """
@@ -1615,20 +1715,19 @@ class PMF:
 
         bloc = self._val_to_spline(xi)
 
-        if spline_weights in ['simplesum', 'biasedstates']:
+        if spline_weights in ["simplesum", "biasedstates"]:
             pF = np.zeros(K)
-            if spline_weights == 'simplesum':
+            if spline_weights == "simplesum":
                 f = 0
                 for k in range(K):
-                    f += (N / K) * \
-                        np.mean(bloc(x_n[self.mbar.x_kindices == k]))
-            elif spline_weights == 'biasedstates':
+                    f += (N / K) * np.mean(bloc(x_n[self.mbar.x_kindices == k]))
+            elif spline_weights == "biasedstates":
                 # multiply by K to get it in the same order of magnitude
                 f = np.sum(bloc(x_n))
 
-            if spline_weights == 'simplesum':
+            if spline_weights == "simplesum":
                 integral_scaling = (N / K) * np.ones(K)
-            elif spline_weights == 'biasedstates':
+            elif spline_weights == "biasedstates":
                 integral_scaling = N_k
 
             expf = list()
@@ -1637,16 +1736,21 @@ class PMF:
                 # define the biasing function
                 # define the exponential of f based on the current parameters
                 # t.
-                def expfk(x, kf=k): return np.exp(-bloc(x) - self.fkbias[kf](x))
+                def expfk(x, kf=k):
+                    return np.exp(-bloc(x) - self.fkbias[kf](x))
+
                 # compute the partition function
                 pF[k] = self._integrate(spline_weights, expfk, xrange[0], xrange[1], args=(k))
                 expf.append(expfk)
             # subtract the free energy (add log partition function)
             f += np.dot(integral_scaling, np.log(pF))
 
-        elif spline_weights == 'unbiasedstate':  # just KL divergence of the unbiased potential
+        elif spline_weights == "unbiasedstate":  # just KL divergence of the unbiased potential
             f = N * np.dot(w_n, bloc(x_n))
-            def expf(x): return np.exp(-bloc(x))
+
+            def expf(x):
+                return np.exp(-bloc(x))
+
             # setting limit to try to eliminate errors: hard time because it
             # goes so small.
             pF = self._integrate(spline_weights, expf, xrange[0], xrange[1])
@@ -1658,25 +1762,25 @@ class PMF:
 
         # need to add the zero explicitly to the front
         if logprior != None:
-            f -= logprior(np.concatenate([[0],xi],axis=None))
-        
+            f -= logprior(np.concatenate([[0], xi], axis=None))
+
         return f
 
     def _bspline_calculate_g(
-            self,
-            xi,
-            w_n,
-            x_n,
-            nspline,
-            kdegree,
-            spline_weights,
-            xrange,
-            xrangei,
-            xrangeij,
-            logprior,
-            dlogprior,
-            ddlogprior
-            ):
+        self,
+        xi,
+        w_n,
+        x_n,
+        nspline,
+        kdegree,
+        spline_weights,
+        xrange,
+        xrangei,
+        xrangeij,
+        logprior,
+        dlogprior,
+        ddlogprior,
+    ):
 
         """ Calculate the gradient of the maximum likelihood / KL divergence of the PMF represented using B-splines.
 
@@ -1691,17 +1795,17 @@ class PMF:
         spline_weights: type of spline weighting (i.e. choice of maximum likelihood)
         dlogprior: derivative of logprior with respect to the parameters, for use with MAP estimates
         xrange: range the PMF is defined over
-        xrangei: range the ith basis function of the spline is defined over   
-        xrangeij: range in x and y the 2d integration of basis functions i and j are defined over.  
-         
+        xrangei: range the ith basis function of the spline is defined over
+        xrangeij: range in x and y the 2d integration of basis functions i and j are defined over.
+
         xrangeij is not used, but used to keep consistent call arguments among f,g,h calls.
         logprior: log of the prior for MAP   Not needed here, but included for consistent arguments
-        dlogprior: d(log prior)/xi for MAP.  
+        dlogprior: d(log prior)/xi for MAP.
         ddlogprior: d^2(log prior)/xi for MAP.  Not needed here, but included for consistent arguments
 
         Output:
         =======
-        
+
         gradient: float, size (nspline-1)
 
         """
@@ -1719,48 +1823,54 @@ class PMF:
         bloc = self._val_to_spline(xi)
         pF = np.zeros(K)
 
-        if spline_weights == 'simplesum':
+        if spline_weights == "simplesum":
             integral_scaling = (N / K) * np.ones(K)
-        elif spline_weights == 'biasedstates':
+        elif spline_weights == "biasedstates":
             integral_scaling = N_k
 
         g = np.zeros(nspline - 1)
 
         for i in range(1, nspline):
-            if spline_weights == 'simplesum':
+            if spline_weights == "simplesum":
                 for k in range(K):
-                    g[i - 1] += (N / K) * np.mean(db_c[i]
-                                                  (x_n[self.mbar.x_kindices == k]))
-            elif spline_weights == 'biasedstates':
+                    g[i - 1] += (N / K) * np.mean(db_c[i](x_n[self.mbar.x_kindices == k]))
+            elif spline_weights == "biasedstates":
                 g[i - 1] = np.sum(db_c[i](x_n))
-            elif spline_weights == 'unbiasedstate':
+            elif spline_weights == "unbiasedstate":
                 g[i - 1] = N * np.dot(w_n, db_c[i](x_n))
 
         # now the second part of the gradient.
 
-        if spline_weights in ['biasedstates', 'simplesum']:
+        if spline_weights in ["biasedstates", "simplesum"]:
             gkquad = np.zeros([nspline - 1, K])
-            def expf(x, k): return np.exp(-bloc(x) - self.fkbias[k](x))
-            def dexpf(x, k): return db_c[i + 1](x) * expf(x, k)
+
+            def expf(x, k):
+                return np.exp(-bloc(x) - self.fkbias[k](x))
+
+            def dexpf(x, k):
+                return db_c[i + 1](x) * expf(x, k)
 
             for k in range(K):
                 # putting this in rather than saving the term so gradient and f
                 # can be called independently
-                pF[k] = self._integrate(spline_weights, expf, xrange[0], xrange[1],args=(k))
+                pF[k] = self._integrate(spline_weights, expf, xrange[0], xrange[1], args=(k))
 
                 for i in range(nspline - 1):
                     # Boltzmann weighted derivative with each biasing function
                     # now compute the expectation of each derivative
                     pE = self._integrate(
-                        spline_weights, dexpf, xrangei[i+1,0], xrangei[i+1,1], args=(k))
+                        spline_weights, dexpf, xrangei[i + 1, 0], xrangei[i + 1, 1], args=(k)
+                    )
 
                     # normalize the expectation
                     gkquad[i, k] = pE / pF[k]
             g -= np.dot(gkquad, integral_scaling)
 
-        elif spline_weights == 'unbiasedstate':
+        elif spline_weights == "unbiasedstate":
             gkquad = 0  # not used here, but saved for Hessian calls.
-            def expf(x): return np.exp(-bloc(x))
+
+            def expf(x):
+                return np.exp(-bloc(x))
 
             # 0 is the value of gkquad. Recomputed here to avoid problems
             pF = self._integrate(spline_weights, expf, xrange[0], xrange[1])
@@ -1769,37 +1879,40 @@ class PMF:
 
             for i in range(nspline - 1):
                 # Boltzmann weighted derivative
-                def dexpf(x): return db_c[i + 1](x) * expf(x)
+                def dexpf(x):
+                    return db_c[i + 1](x) * expf(x)
+
                 # now compute the expectation of each derivative
-                pE[i] = self._integrate(spline_weights, dexpf, xrangei[i+1,0], xrangei[i+1,1])
+                pE[i] = self._integrate(
+                    spline_weights, dexpf, xrangei[i + 1, 0], xrangei[i + 1, 1]
+                )
                 # normalize the expectation.
                 pE[i] /= pF
             g -= N * pE
 
-        # need to add the zero explicitly to the front    
+        # need to add the zero explicitly to the front
         if dlogprior != None:
-            g -= dlogprior(np.concatenate([[0],xi],axis=None))
+            g -= dlogprior(np.concatenate([[0], xi], axis=None))
 
         self.bspline_gkquad = gkquad
         self.bspline_pE = pE
         return g
 
     def _bspline_calculate_h(
-            self,
-            xi,
-            w_n,
-            x_n,
-            nspline,
-            kdegree,
-            spline_weights,
-            xrange,
-            xrangei,
-            xrangeij,
-            logprior, 
-            dlogprior,
-            ddlogprior
-            ):
-
+        self,
+        xi,
+        w_n,
+        x_n,
+        nspline,
+        kdegree,
+        spline_weights,
+        xrange,
+        xrangei,
+        xrangeij,
+        logprior,
+        dlogprior,
+        ddlogprior,
+    ):
 
         """ Calculate the Hessian of the maximum likelihood / KL divergence of the PMF represented using B-splines.
 
@@ -1815,13 +1928,13 @@ class PMF:
         xrange: range the PMF is defined over
         xrangei: range the ith basis function of the spline is defined over
         xrangeij: range in x and y the 2d integration of basis functions i and j are defined over.
-        logprior: log of the prior for MAP  Not needed here, but included for consistent arguments 
+        logprior: log of the prior for MAP  Not needed here, but included for consistent arguments
         dlogprior: d(log prior)/xi for MAP.  Not needed here, but included for consistent arguments
-        ddlogprior: d^2(log prior)/xi for MAP.  
+        ddlogprior: d^2(log prior)/xi for MAP.
 
         Output:
         =======
-        
+
         Hessian: nfloat, size (nspline-1) x (nspline - 1)
 
         CURRENTLY assumes that the gradient has already been called at
@@ -1839,65 +1952,78 @@ class PMF:
         pE = self.bspline_pE
         db_c = self.bspline_derivatives
 
-        if spline_weights == 'simplesum':
+        if spline_weights == "simplesum":
             integral_scaling = N / K * np.ones(K)
-        elif spline_weights == 'biasedstates':
+        elif spline_weights == "biasedstates":
             integral_scaling = N_k
 
         # now, compute the Hessian.  First, the first order components
         h = np.zeros([nspline - 1, nspline - 1])
 
-        if spline_weights in ['simplesum', 'biasedstates']:  
+        if spline_weights in ["simplesum", "biasedstates"]:
             for k in range(K):
-                h += -integral_scaling[k] * \
-                    np.outer(gkquad[:, k], gkquad[:, k])
-        elif spline_weights == 'unbiasedstate':
+                h += -integral_scaling[k] * np.outer(gkquad[:, k], gkquad[:, k])
+        elif spline_weights == "unbiasedstate":
             h = -N * np.outer(pE, pE)
 
-        if spline_weights in ['simplesum','biasedstates']:
+        if spline_weights in ["simplesum", "biasedstates"]:
             for i in range(nspline - 1):
                 for j in range(0, i + 1):
                     if np.abs(i - j) <= kdegree:
-                        def ddexpf(x, k): return db_c[i + 1](x) * db_c[j + 1](x) * expf[k](x)
+
+                        def ddexpf(x, k):
+                            return db_c[i + 1](x) * db_c[j + 1](x) * expf[k](x)
+
                         for k in range(K):
                             # now compute the expectation of each derivative
                             pE = integral_scaling[k] * self._integrate(
-                                spline_weights, ddexpf, xrangeij[i+1, j+1, 0], xrangeij[i+1, j+1, 1], args=(k))
+                                spline_weights,
+                                ddexpf,
+                                xrangeij[i + 1, j + 1, 0],
+                                xrangeij[i + 1, j + 1, 1],
+                                args=(k),
+                            )
                             h[i, j] += pE / pF[k]
 
-        elif spline_weights == 'unbiasedstate':
+        elif spline_weights == "unbiasedstate":
             for i in range(nspline - 1):
                 for j in range(0, i + 1):
                     if np.abs(i - j) <= kdegree:
-                        def ddexpf(x): return db_c[i + 1](x) * db_c[j + 1](x) * expf(x)
+
+                        def ddexpf(x):
+                            return db_c[i + 1](x) * db_c[j + 1](x) * expf(x)
+
                         # now compute the expectation of each derivative
                         pE = self._integrate(
-                            spline_weights, ddexpf, xrangeij[i+1, j+1, 0], xrangeij[i+1, j+1, 1])
+                            spline_weights,
+                            ddexpf,
+                            xrangeij[i + 1, j + 1, 0],
+                            xrangeij[i + 1, j + 1, 1],
+                        )
                         h[i, j] += N * pE / pF
 
         for i in range(nspline - 1):
             for j in range(i + 1, nspline - 1):
                 h[i, j] = h[j, i]
 
-        # need to add the zero explicitly to the front        
-        if ddlogprior != None: # add hessian of prior
-            h -= ddlogprior(np.concatenate([[0],xi],axis=None))
+        # need to add the zero explicitly to the front
+        if ddlogprior != None:  # add hessian of prior
+            h -= ddlogprior(np.concatenate([[0], xi], axis=None))
 
         return h
 
-    def _integrate(self, spline_parameters, func, xlow, xhigh, args = (), method = 'quad'):
-        """ 
+    def _integrate(self, spline_parameters, func, xlow, xhigh, args=(), method="quad"):
+        """
         wrapper for integration in case we decide to replace quad with something analytical
         """
-        if method == 'quad':
+        if method == "quad":
             # just use scipy quadrature
-            results = quad(func,xlow,xhigh,args)[0]
+            results = quad(func, xlow, xhigh, args)[0]
         else:
-            raise ParameterError(
-                "integration method {:s} not yet implemented".format(method))
+            raise ParameterError("integration method {:s} not yet implemented".format(method))
         return results
 
-    def _val_to_spline(self, x, form = None):
+    def _val_to_spline(self, x, form=None):
         """
         Convert a set of B-spline coefficients into a BSpline object
 
@@ -1915,28 +2041,29 @@ class PMF:
         xnew[0] = (self.bspline).c[0]
         xnew[1:] = x
         bspline = BSpline((self.bspline).t, xnew, (self.bspline).k)
-        if form == 'exp':
+        if form == "exp":
             return lambda x: -np.log(bspline(x))
-        elif form == 'log':
+        elif form == "log":
             return bspline
-        elif form is None: 
+        elif form is None:
             return bspline
+
 
 ########
 # Integration notes:
 #
-# If we wanted to integrate the function, can we do it analytically?  
+# If we wanted to integrate the function, can we do it analytically?
 # Let's focus on the likelihood integral, which is what is slowing down
 # the MC, which is the slow part.
 #
 # for k=0, then B_i,0:t = 1 if t_i < x < t_i+i, 0 otherwise
 # for k=1, It is a piecewise sum of 2 linear terms, so linear.
-# f(x) = \\int exp(ax+b)_{t_i}^{t_i+1) = (1/a) e^b (e^a*t2 - e^a t1) 
-# for k=2, it is piecewise sum of 3 quadratic terms, which is quadradic 
-# f(x) = \\int exp(-a(x-b)(x-c))_{t_i)+{t_i+1) = (exp^(1/4 a (b - c)^2) Sqrt[\\pi]] (Erf[1/2 Sqrt[a] (b + c - 2 t1)] - 
+# f(x) = \\int exp(ax+b)_{t_i}^{t_i+1) = (1/a) e^b (e^a*t2 - e^a t1)
+# for k=2, it is piecewise sum of 3 quadratic terms, which is quadradic
+# f(x) = \\int exp(-a(x-b)(x-c))_{t_i)+{t_i+1) = (exp^(1/4 a (b - c)^2) Sqrt[\\pi]] (Erf[1/2 Sqrt[a] (b + c - 2 t1)] -
 #    Erf[1/2 Sqrt[a] (b + c - 2 t2)]))/(2 Sqrt[a]), for a > 0, switch for a<0.
 #
-# for k=3, piecewise sum of cubic terms, which appears hard in general. 
+# for k=3, piecewise sum of cubic terms, which appears hard in general.
 #
 # Of course, even with linear, we need to be able to integrate with the
 # bias functions.  If it's a Gaussian bias, then linear and quadratic should integrate fine.

--- a/pymbar/tests/test_bar.py
+++ b/pymbar/tests/test_bar.py
@@ -4,7 +4,7 @@ for which the true free energy differences can be computed analytically.
 
 import numpy as np
 import pytest
-from pymbar import bar as pybar 
+from pymbar import bar as pybar
 from pymbar.testsystems import harmonic_oscillators, exponential_distributions
 from pymbar.utils_for_testing import assert_equal, assert_almost_equal
 
@@ -15,7 +15,7 @@ z_scale_factor = 12.0
 N_k = np.array([500, 800])
 
 
-def generate_ho(O_k = np.array([1.0, 2.0]), K_k = np.array([0.5, 2.0])):
+def generate_ho(O_k=np.array([1.0, 2.0]), K_k=np.array([0.5, 2.0])):
     return "Harmonic Oscillators", harmonic_oscillators.HarmonicOscillatorsTestCase(O_k, K_k)
 
 
@@ -29,21 +29,21 @@ system_generators = [generate_ho, generate_exp]
 @pytest.fixture(scope="module", params=system_generators)
 def bar_and_test(request):
     name, test = request.param()
-    w_F, w_R, N_k_output = test.sample(N_k, mode='wFwR')
+    w_F, w_R, N_k_output = test.sample(N_k, mode="wFwR")
     assert_equal(N_k, N_k_output)
     bars = dict()
     # can't return method, because BAR is just a function
-    bars['sci'] = pybar.BAR(w_F,w_R,method='self-consistent-iteration')
-    bars['bis'] = pybar.BAR(w_F,w_R,method='bisection')
-    bars['fp'] = pybar.BAR(w_F,w_R,method='false-position')
-    bars['dBAR'] = pybar.BAR(w_F,w_R,uncertainty_method='BAR')
-    bars['dMBAR'] = pybar.BAR(w_F,w_R,uncertainty_method='MBAR')
+    bars["sci"] = pybar.BAR(w_F, w_R, method="self-consistent-iteration")
+    bars["bis"] = pybar.BAR(w_F, w_R, method="bisection")
+    bars["fp"] = pybar.BAR(w_F, w_R, method="false-position")
+    bars["dBAR"] = pybar.BAR(w_F, w_R, uncertainty_method="BAR")
+    bars["dMBAR"] = pybar.BAR(w_F, w_R, uncertainty_method="MBAR")
 
     yield_bundle = {
-        'bars': bars,
-        'test': test,
-        'w_F': w_F,
-        'w_R': w_R,
+        "bars": bars,
+        "test": test,
+        "w_F": w_F,
+        "w_R": w_R,
     }
     yield yield_bundle
 
@@ -55,35 +55,36 @@ def test_sample(system_generator):
     name, test = system_generator()
     print(name)
 
-    w_F, w_R, N_k = test.sample([10,8], mode='wFwR')
-    w_F, w_R, N_k = test.sample([1,1], mode='wFwR')
-    w_F, w_R, N_k = test.sample([10,0], mode='wFwR')
-    w_F, w_R, N_k = test.sample([0,5], mode='wFwR')
+    w_F, w_R, N_k = test.sample([10, 8], mode="wFwR")
+    w_F, w_R, N_k = test.sample([1, 1], mode="wFwR")
+    w_F, w_R, N_k = test.sample([10, 0], mode="wFwR")
+    w_F, w_R, N_k = test.sample([0, 5], mode="wFwR")
+
 
 def test_bar_free_energies(bar_and_test):
 
     """Can BAR calculate moderately correct free energy differences?"""
 
-    bars, test = bar_and_test['bars'], bar_and_test['test']
+    bars, test = bar_and_test["bars"], bar_and_test["test"]
 
     fe0 = test.analytical_free_energies()
     fe0 = fe0[1:] - fe0[0]
 
-    results_fp = bars['fp']
-    fe_fp = results_fp['Delta_f']
-    dfe_fp = results_fp['dDelta_f']
+    results_fp = bars["fp"]
+    fe_fp = results_fp["Delta_f"]
+    dfe_fp = results_fp["dDelta_f"]
     z = (fe_fp - fe0) / dfe_fp
     assert_almost_equal(z / z_scale_factor, np.zeros(len(z)), decimal=0)
 
-    results_sci = bars['sci']
-    fe_sci = results_sci['Delta_f']
-    dfe_sci = results_sci['dDelta_f']
+    results_sci = bars["sci"]
+    fe_sci = results_sci["Delta_f"]
+    dfe_sci = results_sci["dDelta_f"]
     z = (fe_sci - fe0) / dfe_sci
     assert_almost_equal(z / z_scale_factor, np.zeros(len(z)), decimal=0)
 
-    results_bis = bars['bis']
-    fe_bis = results_bis['Delta_f']
-    dfe_bis = results_bis['dDelta_f']
+    results_bis = bars["bis"]
+    fe_bis = results_bis["Delta_f"]
+    dfe_bis = results_bis["dDelta_f"]
     z = (fe_bis - fe0) / dfe_bis
     assert_almost_equal(z / z_scale_factor, np.zeros(len(z)), decimal=0)
 
@@ -93,11 +94,10 @@ def test_bar_free_energies(bar_and_test):
     assert_almost_equal(fe_fp, fe_bis, decimal=8)
 
     # Test uncertainty methods
-    results_dBAR = bars['dBAR']
-    dfe_bar = results_dBAR['dDelta_f']
-    results_dMBAR = bars['dMBAR']
-    dfe_mbar = results_dMBAR['dDelta_f']
+    results_dBAR = bars["dBAR"]
+    dfe_bar = results_dBAR["dDelta_f"]
+    results_dMBAR = bars["dMBAR"]
+    dfe_mbar = results_dMBAR["dDelta_f"]
 
     # not sure exactly how close they need to be for sample problems?
-    assert_almost_equal(dfe_bar,dfe_mbar,decimal=3)
-
+    assert_almost_equal(dfe_bar, dfe_mbar, decimal=3)

--- a/pymbar/tests/test_covariance.py
+++ b/pymbar/tests/test_covariance.py
@@ -1,16 +1,18 @@
 import numpy as np
 import pytest
 import pymbar
-from pymbar.utils_for_testing import (suppress_derivative_warnings_for_tests, suppress_matrix_warnings_for_tests,
-                                      assert_almost_equal,
-                                      oscillators, exponentials)
+from pymbar.utils_for_testing import (
+    suppress_derivative_warnings_for_tests,
+    suppress_matrix_warnings_for_tests,
+    assert_almost_equal,
+    oscillators,
+    exponentials,
+)
 
 
 @pytest.mark.parametrize(
-    'statesa, statesb, test_system',
-    [(100, 100, oscillators),
-     (200, 50, oscillators),
-     (200, 50, exponentials)]
+    "statesa, statesb, test_system",
+    [(100, 100, oscillators), (200, 50, oscillators), (200, 50, exponentials)],
 )
 def _test(statesa, statesb, test_system):
     name, U, N_k, s_n = test_system(statesa, statesb)
@@ -18,15 +20,19 @@ def _test(statesa, statesb, test_system):
     mbar = pymbar.MBAR(U, N_k)
     results1 = mbar.getFreeEnergyDifferences(uncertainty_method="svd")
     results2 = mbar.getFreeEnergyDifferences(uncertainty_method="svd-ew")
-    fij1 = results1['Delta_f']
-    dfij1 = results1['dDelta_f']
-    fij2 = results2['Delta_f']
-    dfij2 = results2['dDelta_f']
+    fij1 = results1["Delta_f"]
+    dfij1 = results1["dDelta_f"]
+    fij2 = results2["Delta_f"]
+    dfij2 = results2["dDelta_f"]
 
-    assert_almost_equal(pymbar.mbar_solvers.mbar_gradient(U, N_k, mbar.f_k), np.zeros(N_k.shape), decimal=8)
+    assert_almost_equal(
+        pymbar.mbar_solvers.mbar_gradient(U, N_k, mbar.f_k), np.zeros(N_k.shape), decimal=8
+    )
     assert_almost_equal(np.exp(mbar.Log_W_nk).sum(0), np.ones(len(N_k)), decimal=10)
     assert_almost_equal(np.exp(mbar.Log_W_nk).dot(N_k), np.ones(U.shape[1]), decimal=10)
-    assert_almost_equal(pymbar.mbar_solvers.self_consistent_update(U, N_k, mbar.f_k), mbar.f_k, decimal=10)
+    assert_almost_equal(
+        pymbar.mbar_solvers.self_consistent_update(U, N_k, mbar.f_k), mbar.f_k, decimal=10
+    )
 
     # Test against old MBAR code.
     with suppress_derivative_warnings_for_tests():

--- a/pymbar/tests/test_exp.py
+++ b/pymbar/tests/test_exp.py
@@ -4,7 +4,7 @@ for which the true free energy differences can be computed analytically.
 
 import numpy as np
 import pytest
-from pymbar import exp as pyexp 
+from pymbar import exp as pyexp
 from pymbar.testsystems import harmonic_oscillators, exponential_distributions
 from pymbar.utils_for_testing import assert_equal, assert_almost_equal
 
@@ -15,32 +15,34 @@ z_scale_factor = 12.0
 N_k = np.array([50000, 100000])
 
 
-def generate_ho(O_k = np.array([1.0, 2.0]), K_k = np.array([0.5, 1.0])):
+def generate_ho(O_k=np.array([1.0, 2.0]), K_k=np.array([0.5, 1.0])):
     return "Harmonic Oscillators", harmonic_oscillators.HarmonicOscillatorsTestCase(O_k, K_k)
 
 
 def generate_exp(rates=np.array([1.0, 4.0])):  # Rates, e.g. Lambda
     return "Exponentials", exponential_distributions.ExponentialTestCase(rates)
 
+
 system_generators = [generate_ho, generate_exp]
+
 
 @pytest.fixture(scope="module", params=system_generators)
 def exp_and_test(request):
     name, test = request.param()
-    w_F, w_R, N_k_output = test.sample(N_k, mode='wFwR')
+    w_F, w_R, N_k_output = test.sample(N_k, mode="wFwR")
     assert_equal(N_k, N_k_output)
     exps = dict()
     # can't return method, because EXP is just a function
-    exps['F'] = pyexp.EXP(w_F)
-    exps['R'] = pyexp.EXP(w_R)
-    exps['gF'] = pyexp.EXPGauss(w_F)
-    exps['gR'] = pyexp.EXPGauss(w_R)
+    exps["F"] = pyexp.EXP(w_F)
+    exps["R"] = pyexp.EXP(w_R)
+    exps["gF"] = pyexp.EXPGauss(w_F)
+    exps["gR"] = pyexp.EXPGauss(w_R)
 
     yield_bundle = {
-        'exps': exps,
-        'test': test,
-        'w_F': w_F,
-        'w_R': w_R,
+        "exps": exps,
+        "test": test,
+        "w_F": w_F,
+        "w_R": w_R,
     }
     yield yield_bundle
 
@@ -52,46 +54,47 @@ def test_sample(system_generator):
     name, test = system_generator()
     print(name)
 
-    w_F, w_R, N_k = test.sample([10,8], mode='wFwR')
-    w_F, w_R, N_k = test.sample([1,1], mode='wFwR')
-    w_F, w_R, N_k = test.sample([10,0], mode='wFwR')
-    w_F, w_R, N_k = test.sample([0,5], mode='wFwR')
+    w_F, w_R, N_k = test.sample([10, 8], mode="wFwR")
+    w_F, w_R, N_k = test.sample([1, 1], mode="wFwR")
+    w_F, w_R, N_k = test.sample([10, 0], mode="wFwR")
+    w_F, w_R, N_k = test.sample([0, 5], mode="wFwR")
+
 
 def test_EXP_free_energies(exp_and_test):
 
     """Can EXP calculate moderately correct free energy differences?"""
 
-    exps, test = exp_and_test['exps'], exp_and_test['test']
+    exps, test = exp_and_test["exps"], exp_and_test["test"]
 
     fe0 = test.analytical_free_energies()
     fe0 = fe0[1:] - fe0[0]
 
-    results_F = exps['F']
-    fe_F = results_F['Delta_f']
-    dfe_F = results_F['dDelta_f']
+    results_F = exps["F"]
+    fe_F = results_F["Delta_f"]
+    dfe_F = results_F["dDelta_f"]
     z = (fe_F - fe0) / dfe_F
     assert_almost_equal(z / z_scale_factor, np.zeros(len(z)), decimal=0)
 
-    results_R = exps['R']
-    fe_R = -results_R['Delta_f']
-    dfe_R = results_R['dDelta_f']
+    results_R = exps["R"]
+    fe_R = -results_R["Delta_f"]
+    dfe_R = results_R["dDelta_f"]
     z = (fe_R - fe0) / dfe_R
     assert_almost_equal(z / z_scale_factor, np.zeros(len(z)), decimal=0)
 
-    # turning off Gaussian comparisons because it's not clear how accurate they should be!  
+    # turning off Gaussian comparisons because it's not clear how accurate they should be!
 
-    results_gF = exps['gF']
-    fe_gF = results_gF['Delta_f']
-    dfe_gF = results_gF['dDelta_f']
+    results_gF = exps["gF"]
+    fe_gF = results_gF["Delta_f"]
+    dfe_gF = results_gF["dDelta_f"]
     z = (fe_gF - fe0) / dfe_gF
-    #assert_almost_equal(z / z_scale_factor, np.zeros(len(z)), decimal=0)
+    # assert_almost_equal(z / z_scale_factor, np.zeros(len(z)), decimal=0)
 
-    results_gR = exps['gR']
-    fe_gR = -results_gR['Delta_f']
-    dfe_gR = results_gR['dDelta_f']
+    results_gR = exps["gR"]
+    fe_gR = -results_gR["Delta_f"]
+    dfe_gR = results_gR["dDelta_f"]
     z = (fe_gR - fe0) / dfe_gR
-    #assert_almost_equal(z / z_scale_factor, np.zeros(len(z)), decimal=0)
+    # assert_almost_equal(z / z_scale_factor, np.zeros(len(z)), decimal=0)
 
     # make sure the different methods are nearly equal for these systems (within uncertainty)
-    z = np.abs(fe_R - fe_F) / np.sqrt(dfe_R**2 + dfe_F**2)
+    z = np.abs(fe_R - fe_F) / np.sqrt(dfe_R ** 2 + dfe_F ** 2)
     assert_almost_equal(z / z_scale_factor, 0.0, decimal=0)

--- a/pymbar/tests/test_mbar.py
+++ b/pymbar/tests/test_mbar.py
@@ -16,7 +16,7 @@ z_scale_factor = 12.0
 N_k = np.array([1000, 500, 0, 800])
 
 
-def generate_ho(O_k = np.array([1.0, 2.0, 3.0, 4.0]), K_k = np.array([0.5, 1.0, 1.5, 2.0])):
+def generate_ho(O_k=np.array([1.0, 2.0, 3.0, 4.0]), K_k=np.array([0.5, 1.0, 1.5, 2.0])):
     return "Harmonic Oscillators", harmonic_oscillators.HarmonicOscillatorsTestCase(O_k, K_k)
 
 
@@ -32,25 +32,27 @@ def convert_to_differences(x_ij, dx_ij, xa):
         dx_ij[i, i] += 1
     z = (x_ij - xa_ij) / dx_ij
     for i in range(len(N_k)):
-        z[i, i] = x_ij[i, i]-xa_ij[i, i]  # these terms should be zero; so we only throw an error if they aren't
+        z[i, i] = (
+            x_ij[i, i] - xa_ij[i, i]
+        )  # these terms should be zero; so we only throw an error if they aren't
     return z
 
 
 system_generators = [generate_ho, generate_exp]
-observables = ['position', 'position^2', 'RMS deviation', 'potential energy']
+observables = ["position", "position^2", "RMS deviation", "potential energy"]
 
 
 @pytest.fixture(scope="module", params=system_generators)
 def mbar_and_test(request):
     name, test = request.param()
-    x_n, u_kn, N_k_output, s_n = test.sample(N_k, mode='u_kn')
+    x_n, u_kn, N_k_output, s_n = test.sample(N_k, mode="u_kn")
     assert_equal(N_k, N_k_output)
     mbar = MBAR(u_kn, N_k, verbose=True)
     yield_bundle = {
-        'mbar': mbar,
-        'test': test,
-        'x_n': x_n,
-        'u_kn': u_kn,
+        "mbar": mbar,
+        "test": test,
+        "x_n": x_n,
+        "u_kn": u_kn,
     }
     yield yield_bundle
 
@@ -58,14 +60,14 @@ def mbar_and_test(request):
 @pytest.fixture(scope="module")
 def mbar_and_test_harmonic():
     name, test = generate_ho()
-    x_n, u_kn, N_k_output, s_n = test.sample(N_k, mode='u_kn')
+    x_n, u_kn, N_k_output, s_n = test.sample(N_k, mode="u_kn")
     assert_equal(N_k, N_k_output)
     mbar = MBAR(u_kn, N_k, verbose=True)
     yield_bundle = {
-        'mbar': mbar,
-        'test': test,
-        'x_n': x_n,
-        'u_kn': u_kn,
+        "mbar": mbar,
+        "test": test,
+        "x_n": x_n,
+        "u_kn": u_kn,
     }
     yield yield_bundle
 
@@ -73,14 +75,14 @@ def mbar_and_test_harmonic():
 @pytest.fixture(scope="module")
 def mbar_and_test_kln():
     name, test = generate_ho()
-    x_n, u_kn, N_k_output = test.sample(N_k, mode='u_kln')
+    x_n, u_kn, N_k_output = test.sample(N_k, mode="u_kln")
     assert_equal(N_k, N_k_output)
     mbar = MBAR(u_kn, N_k, verbose=True)
     yield_bundle = {
-        'mbar': mbar,
-        'test': test,
-        'x_n': x_n,
-        'u_kn': u_kn,
+        "mbar": mbar,
+        "test": test,
+        "x_n": x_n,
+        "u_kn": u_kn,
     }
     yield yield_bundle
 
@@ -102,48 +104,48 @@ def free_energies_almost_equal(mbar_fe, err_fe, analytical_fe):
 
 def test_ukln(mbar_and_test_kln):
     """Test that MBAR's u_kln->u_kn works correctly"""
-    mbar, test = mbar_and_test_kln['mbar'], mbar_and_test_kln['test']
+    mbar, test = mbar_and_test_kln["mbar"], mbar_and_test_kln["test"]
     results = mbar.getFreeEnergyDifferences()
-    fe = results['Delta_f']
-    fe_sigma = results['dDelta_f']
+    fe = results["Delta_f"]
+    fe_sigma = results["dDelta_f"]
     free_energies_almost_equal(fe, fe_sigma, test.analytical_free_energies())
 
 
 def test_duplicate_state(fixed_harmonic_sample, caplog):
     """Test that MBAR's duplicate state check is working"""
-    _, u_kn, _, _ = fixed_harmonic_sample.sample(N_k, mode='u_kn')
+    _, u_kn, _, _ = fixed_harmonic_sample.sample(N_k, mode="u_kn")
     u_kn_dup = np.append(u_kn, u_kn[[0], :], axis=0)
     N_k_dup = np.append(N_k, [0])
     mbar = MBAR(u_kn_dup, N_k_dup, verbose=True)
     assert "likely to to be the same thermodynamic state" in caplog.text
     results = mbar.getFreeEnergyDifferences()
-    fe = results['Delta_f']
+    fe = results["Delta_f"]
     assert np.allclose(fe[0], fe[-1])
 
 
 def test_x_kindices(fixed_harmonic_sample):
     """Test that setting x_kindices results in the same calculation"""
-    _, u_kn, _, _ = fixed_harmonic_sample.sample(N_k, mode='u_kn')
-    flat_x_indices = np.concatenate([[k]*n for k, n in enumerate(N_k)]).astype(int)
+    _, u_kn, _, _ = fixed_harmonic_sample.sample(N_k, mode="u_kn")
+    flat_x_indices = np.concatenate([[k] * n for k, n in enumerate(N_k)]).astype(int)
     mbar = MBAR(u_kn, N_k)
     mbar_indices = MBAR(u_kn, N_k, x_kindices=flat_x_indices)
-    fe = mbar.getFreeEnergyDifferences()['Delta_f']
-    fes = mbar_indices.getFreeEnergyDifferences()['Delta_f']
+    fe = mbar.getFreeEnergyDifferences()["Delta_f"]
+    fes = mbar_indices.getFreeEnergyDifferences()["Delta_f"]
     assert np.allclose(fe, fes)
 
 
 @pytest.mark.xfail(raises=ParameterError)
 def test_bad_inital_f_k(fixed_harmonic_sample):
-    _, u_kn, _, _ = fixed_harmonic_sample.sample(N_k, mode='u_kn')
-    MBAR(u_kn, N_k, initial_f_k=[0]*(N_k.size + 1))
+    _, u_kn, _, _ = fixed_harmonic_sample.sample(N_k, mode="u_kn")
+    MBAR(u_kn, N_k, initial_f_k=[0] * (N_k.size + 1))
 
 
 def test_covariance_of_sums_runs(mbar_and_test_kln):
     """Test that CovarianceOfSums function runs"""
     # TODO: Is this function still needed? And what would be a better test?
-    mbar = mbar_and_test_kln['mbar']
+    mbar = mbar_and_test_kln["mbar"]
     results = mbar.getFreeEnergyDifferences(return_theta=True)
-    theta = results['Theta']
+    theta = results["Theta"]
     mbar.computeCovarianceOfSums(theta, 1, np.array([1, -1]))
 
 
@@ -166,39 +168,44 @@ def test_sample(system_generator):
     name, test = system_generator()
     print(name)
 
-    x_n, u_kn, N_k, s_n = test.sample([5, 6, 7, 8], mode='u_kn')
-    x_n, u_kn, N_k, s_n = test.sample([5, 5, 5, 5], mode='u_kn')
-    x_n, u_kn, N_k, s_n = test.sample([1, 1, 1, 1], mode='u_kn')
-    x_n, u_kn, N_k, s_n = test.sample([10, 0, 8, 0], mode='u_kn')
+    x_n, u_kn, N_k, s_n = test.sample([5, 6, 7, 8], mode="u_kn")
+    x_n, u_kn, N_k, s_n = test.sample([5, 5, 5, 5], mode="u_kn")
+    x_n, u_kn, N_k, s_n = test.sample([1, 1, 1, 1], mode="u_kn")
+    x_n, u_kn, N_k, s_n = test.sample([10, 0, 8, 0], mode="u_kn")
 
-    x_kn, u_kln, N_k = test.sample([5, 6, 7, 8], mode='u_kln')
-    x_kn, u_kln, N_k = test.sample([5, 5, 5, 5], mode='u_kln')
-    x_kn, u_kln, N_k = test.sample([1, 1, 1, 1], mode='u_kln')
-    x_kn, u_kln, N_k = test.sample([10, 0, 8, 0], mode='u_kln')
+    x_kn, u_kln, N_k = test.sample([5, 6, 7, 8], mode="u_kln")
+    x_kn, u_kln, N_k = test.sample([5, 5, 5, 5], mode="u_kln")
+    x_kn, u_kln, N_k = test.sample([1, 1, 1, 1], mode="u_kln")
+    x_kn, u_kln, N_k = test.sample([10, 0, 8, 0], mode="u_kln")
 
 
-@pytest.mark.parametrize("uncertainty_method",
-                         [None, 'approximate', 'svd', 'svd-ew', pytest.param('waffles', marks=pytest.mark.xfail)]
-                         )
+@pytest.mark.parametrize(
+    "uncertainty_method",
+    [None, "approximate", "svd", "svd-ew", pytest.param("waffles", marks=pytest.mark.xfail)],
+)
 def test_mbar_free_energies(mbar_and_test, uncertainty_method):
 
     """Can MBAR calculate moderately correct free energy differences?"""
-    mbar, test = mbar_and_test['mbar'], mbar_and_test['test']
-    results = mbar.getFreeEnergyDifferences(return_theta=True, uncertainty_method=uncertainty_method)
-    fe = results['Delta_f']
-    fe_sigma = results['dDelta_f']
+    mbar, test = mbar_and_test["mbar"], mbar_and_test["test"]
+    results = mbar.getFreeEnergyDifferences(
+        return_theta=True, uncertainty_method=uncertainty_method
+    )
+    fe = results["Delta_f"]
+    fe_sigma = results["dDelta_f"]
     free_energies_almost_equal(fe, fe_sigma, test.analytical_free_energies())
 
 
-@pytest.mark.parametrize("method",
-                         ['zeros', 'mean-reduced-potential', 'BAR', pytest.param("waffles", marks=pytest.mark.xfail)])
+@pytest.mark.parametrize(
+    "method",
+    ["zeros", "mean-reduced-potential", "BAR", pytest.param("waffles", marks=pytest.mark.xfail)],
+)
 def test_mbar_initialization(fixed_harmonic_sample, method):
     """Do the MBAR initialization methods work?"""
-    _, u_kn, _, _ = fixed_harmonic_sample.sample(N_k, mode='u_kn')
+    _, u_kn, _, _ = fixed_harmonic_sample.sample(N_k, mode="u_kn")
     mbar = MBAR(u_kn, N_k, initialize=method, verbose=True)
     results = mbar.getFreeEnergyDifferences()
-    fe = results['Delta_f']
-    fe_sigma = results['dDelta_f']
+    fe = results["Delta_f"]
+    fe_sigma = results["dDelta_f"]
     free_energies_almost_equal(fe, fe_sigma, fixed_harmonic_sample.analytical_free_energies())
 
 
@@ -206,12 +213,12 @@ def test_mbar_computeExpectations_position_averages(mbar_and_test):
 
     """Can MBAR calculate E(x_n)??"""
 
-    mbar, test, x_n = mbar_and_test['mbar'], mbar_and_test['test'], mbar_and_test['x_n']
+    mbar, test, x_n = mbar_and_test["mbar"], mbar_and_test["test"], mbar_and_test["x_n"]
     results = mbar.computeExpectations(x_n)
-    mu = results['mu']
-    sigma = results['sigma']
+    mu = results["mu"]
+    sigma = results["sigma"]
 
-    mu0 = test.analytical_observable(observable='position')
+    mu0 = test.analytical_observable(observable="position")
 
     z = (mu0 - mu) / sigma
     assert_almost_equal(z / z_scale_factor, np.zeros(len(z)), decimal=0)
@@ -221,12 +228,12 @@ def test_mbar_computeExpectations_position_differences(mbar_and_test):
 
     """Can MBAR calculate E(x_n)??"""
 
-    mbar, test, x_n = mbar_and_test['mbar'], mbar_and_test['test'], mbar_and_test['x_n']
-    results = mbar.computeExpectations(x_n, output='differences')
-    mu_ij = results['mu']
-    sigma_ij = results['sigma']
+    mbar, test, x_n = mbar_and_test["mbar"], mbar_and_test["test"], mbar_and_test["x_n"]
+    results = mbar.computeExpectations(x_n, output="differences")
+    mu_ij = results["mu"]
+    sigma_ij = results["sigma"]
 
-    mu0 = test.analytical_observable(observable='position')
+    mu0 = test.analytical_observable(observable="position")
     z = convert_to_differences(mu_ij, sigma_ij, mu0)
     assert_almost_equal(z / z_scale_factor, np.zeros(np.shape(z)), decimal=0)
 
@@ -235,11 +242,11 @@ def test_mbar_computeExpectations_position2(mbar_and_test):
 
     """Can MBAR calculate E(x_n^2)??"""
 
-    mbar, test, x_n = mbar_and_test['mbar'], mbar_and_test['test'], mbar_and_test['x_n']
+    mbar, test, x_n = mbar_and_test["mbar"], mbar_and_test["test"], mbar_and_test["x_n"]
     results = mbar.computeExpectations(x_n ** 2)
-    mu = results['mu']
-    sigma = results['sigma']
-    mu0 = test.analytical_observable(observable='position^2')
+    mu = results["mu"]
+    sigma = results["sigma"]
+    mu0 = test.analytical_observable(observable="position^2")
 
     z = (mu0 - mu) / sigma
     assert_almost_equal(z / z_scale_factor, np.zeros(len(z)), decimal=0)
@@ -249,72 +256,86 @@ def test_mbar_computeExpectations_potential(mbar_and_test):
 
     """Can MBAR calculate E(u_kn)??"""
 
-    mbar, test, u_kn = mbar_and_test['mbar'], mbar_and_test['test'], mbar_and_test['u_kn']
+    mbar, test, u_kn = mbar_and_test["mbar"], mbar_and_test["test"], mbar_and_test["u_kn"]
     results = mbar.computeExpectations(u_kn, state_dependent=True)
-    mu = results['mu']
-    sigma = results['sigma']
-    mu0 = test.analytical_observable(observable='potential energy')
+    mu = results["mu"]
+    sigma = results["sigma"]
+    mu0 = test.analytical_observable(observable="potential energy")
     z = (mu0 - mu) / sigma
     assert_almost_equal(z / z_scale_factor, np.zeros(len(z)), decimal=0)
 
 
-@pytest.mark.parametrize("observable,state_dependent,sample_mode,single_dim,with_uxx",
-                         [
-                             ('position', False, 'u_kln', False, False),
-                             ('position', False, 'u_kln', False, True),
-                             ('position', False, 'u_kn',  False, False),
-                             ('position', False, 'u_kn',  False, True),
-                             ('position', False, 'u_kn',  True, False),
-
-                             ('potential energy', True, 'u_kln', False, False),
-                             ('potential energy', True, 'u_kln', False, True),
-                             ('potential energy', True, 'u_kn', False, False),
-                             ('potential energy', True, 'u_kn', False, True),
-                             ('potential energy', True, 'u_kn', True, False),
-                          ])
-def test_mbar_computeExpectations_edges(mbar_and_test_harmonic, mbar_and_test_kln,
-                                        observable, state_dependent, sample_mode, single_dim, with_uxx):
-    if sample_mode == 'u_kln':
+@pytest.mark.parametrize(
+    "observable,state_dependent,sample_mode,single_dim,with_uxx",
+    [
+        ("position", False, "u_kln", False, False),
+        ("position", False, "u_kln", False, True),
+        ("position", False, "u_kn", False, False),
+        ("position", False, "u_kn", False, True),
+        ("position", False, "u_kn", True, False),
+        ("potential energy", True, "u_kln", False, False),
+        ("potential energy", True, "u_kln", False, True),
+        ("potential energy", True, "u_kn", False, False),
+        ("potential energy", True, "u_kn", False, True),
+        ("potential energy", True, "u_kn", True, False),
+    ],
+)
+def test_mbar_computeExpectations_edges(
+    mbar_and_test_harmonic,
+    mbar_and_test_kln,
+    observable,
+    state_dependent,
+    sample_mode,
+    single_dim,
+    with_uxx,
+):
+    if sample_mode == "u_kln":
         payload = mbar_and_test_kln
     else:
         payload = mbar_and_test_harmonic
-    mbar = payload['mbar']
-    test = payload['test']
-    u_xxx = payload['u_kn']
+    mbar = payload["mbar"]
+    test = payload["test"]
+    u_xxx = payload["u_kn"]
     if state_dependent:
-        obs = payload['u_kn']
+        obs = payload["u_kn"]
     else:
-        obs = payload['x_n']
+        obs = payload["x_n"]
     if single_dim:
         u_xxx = u_xxx[0]
-    results = mbar.computeExpectations(obs, state_dependent=state_dependent, u_kn=u_xxx if with_uxx else None,
-                                       return_theta=True)
-    mu = results['mu']
-    sigma = results['sigma']
+    results = mbar.computeExpectations(
+        obs, state_dependent=state_dependent, u_kn=u_xxx if with_uxx else None, return_theta=True
+    )
+    mu = results["mu"]
+    sigma = results["sigma"]
     mu0 = test.analytical_observable(observable=observable)
     z = (mu0 - mu) / sigma
     assert_almost_equal(z / z_scale_factor, np.zeros(len(z)), decimal=0)
 
 
 def multiExpectationAssertion(results, test, state=1):
-    mu = results['mu']
-    sigma = results['sigma']
-    mu0 = test.analytical_observable(observable='position')[state]
-    mu1 = test.analytical_observable(observable='position^2')[state]
+    mu = results["mu"]
+    sigma = results["sigma"]
+    mu0 = test.analytical_observable(observable="position")[state]
+    mu1 = test.analytical_observable(observable="position^2")[state]
     z = (mu0 - mu[0]) / sigma[0]
-    assert_almost_equal(z / z_scale_factor, 0*z, decimal=0)
+    assert_almost_equal(z / z_scale_factor, 0 * z, decimal=0)
     z = (mu1 - mu[1]) / sigma[1]
-    assert_almost_equal(z / z_scale_factor, 0*z, decimal=0)
+    assert_almost_equal(z / z_scale_factor, 0 * z, decimal=0)
 
 
 def test_mbar_computeMultipleExpectations(mbar_and_test):
 
     """Can MBAR calculate E(u_kn)??"""
 
-    mbar, test, x_n, u_kn = mbar_and_test['mbar'], mbar_and_test['test'], mbar_and_test['x_n'], mbar_and_test['u_kn']
+    mbar, test, x_n, u_kn = (
+        mbar_and_test["mbar"],
+        mbar_and_test["test"],
+        mbar_and_test["x_n"],
+        mbar_and_test["u_kn"],
+    )
     A = np.zeros([2, len(x_n)])
     A[0, :] = x_n
-    A[1, :] = x_n**2
+    A[1, :] = x_n ** 2
     state = 1
     results = mbar.computeMultipleExpectations(A, u_kn[state, :])
     multiExpectationAssertion(results, test, state=state)
@@ -324,13 +345,19 @@ def test_mbar_computeMultipleExpectations_more_dims(mbar_and_test_kln):
 
     """Can MBAR calculate E(u_kn) with 3 dimensions??"""
 
-    mbar, test, x_n, u_kn = \
-        mbar_and_test_kln['mbar'], mbar_and_test_kln['test'], mbar_and_test_kln['x_n'], mbar_and_test_kln['u_kn']
+    mbar, test, x_n, u_kn = (
+        mbar_and_test_kln["mbar"],
+        mbar_and_test_kln["test"],
+        mbar_and_test_kln["x_n"],
+        mbar_and_test_kln["u_kn"],
+    )
     A = np.zeros([2, x_n.shape[0], x_n.shape[1]])
     A[0, :, :] = x_n
-    A[1, :, :] = x_n**2
+    A[1, :, :] = x_n ** 2
     state = 1
-    results = mbar.computeMultipleExpectations(A, u_kn[:, state, :], compute_covariance=True, return_theta=True)
+    results = mbar.computeMultipleExpectations(
+        A, u_kn[:, state, :], compute_covariance=True, return_theta=True
+    )
     multiExpectationAssertion(results, test, state=state)
 
 
@@ -338,22 +365,27 @@ def test_mbar_computeEntropyAndEnthalpy(mbar_and_test, with_uxx=True):
 
     """Can MBAR calculate f_k, <u_k> and s_k ??"""
 
-    mbar, test, x_n, u_kn = mbar_and_test['mbar'], mbar_and_test['test'], mbar_and_test['x_n'], mbar_and_test['u_kn']
+    mbar, test, x_n, u_kn = (
+        mbar_and_test["mbar"],
+        mbar_and_test["test"],
+        mbar_and_test["x_n"],
+        mbar_and_test["u_kn"],
+    )
     results = mbar.computeEntropyAndEnthalpy(u_kn if with_uxx else None, verbose=True)
-    f_ij = results['Delta_f']
-    df_ij = results['dDelta_f']
-    u_ij = results['Delta_u']
-    du_ij = results['dDelta_u']
-    s_ij = results['Delta_s']
-    ds_ij = results['dDelta_s']
+    f_ij = results["Delta_f"]
+    df_ij = results["dDelta_f"]
+    u_ij = results["Delta_u"]
+    du_ij = results["dDelta_u"]
+    s_ij = results["Delta_s"]
+    ds_ij = results["dDelta_s"]
 
     fa = test.analytical_free_energies()
-    ua = test.analytical_observable('potential energy')
+    ua = test.analytical_observable("potential energy")
     sa = test.analytical_entropies()
 
-    fa_ij = fa-fa.T
-    ua_ij = ua-ua.T
-    sa_ij = sa-sa.T
+    fa_ij = fa - fa.T
+    ua_ij = ua - ua.T
+    sa_ij = sa - sa.T
 
     z = convert_to_differences(f_ij, df_ij, fa)
     assert_almost_equal(z / z_scale_factor, np.zeros(np.shape(z)), decimal=0)
@@ -363,13 +395,18 @@ def test_mbar_computeEntropyAndEnthalpy(mbar_and_test, with_uxx=True):
     assert_almost_equal(z / z_scale_factor, np.zeros(np.shape(z)), decimal=0)
 
 
-@pytest.mark.parametrize("as_kln,with_uxx",
-                         [(True, True),
-                          (True, False),
-                          (False, False)
-                          # False True handled by main test
-                          ])
-def test_mbar_computeEntropyAndEnthalpy_edges(mbar_and_test_harmonic, mbar_and_test_kln, as_kln, with_uxx):
+@pytest.mark.parametrize(
+    "as_kln,with_uxx",
+    [
+        (True, True),
+        (True, False),
+        (False, False)
+        # False True handled by main test
+    ],
+)
+def test_mbar_computeEntropyAndEnthalpy_edges(
+    mbar_and_test_harmonic, mbar_and_test_kln, as_kln, with_uxx
+):
     if as_kln:
         payload = mbar_and_test_kln
     else:
@@ -380,7 +417,7 @@ def test_mbar_computeEntropyAndEnthalpy_edges(mbar_and_test_harmonic, mbar_and_t
 def test_mbar_computeEffectiveSampleNumber(mbar_and_test):
     """ testing computeEffectiveSampleNumber """
 
-    mbar = mbar_and_test['mbar']
+    mbar = mbar_and_test["mbar"]
     # one mathematical effective sample numbers should be between N_k and sum_k N_k
     N_eff = mbar.computeEffectiveSampleNumber()
     sumN = np.sum(N_k)
@@ -392,19 +429,19 @@ def test_mbar_computeOverlap_analytical():
     """Tests Overlap with identical states, which gives analytical results."""
 
     d = len(N_k)
-    even_O_k = 2.0*np.ones(d)
-    even_K_k = 0.5*np.ones(d)
-    even_N_k = 100*np.ones(d)
+    even_O_k = 2.0 * np.ones(d)
+    even_K_k = 0.5 * np.ones(d)
+    even_N_k = 100 * np.ones(d)
     name, test = generate_ho(O_k=even_O_k, K_k=even_K_k)
-    x_n, u_kn, N_k_output, s_n = test.sample(even_N_k, mode='u_kn')
+    x_n, u_kn, N_k_output, s_n = test.sample(even_N_k, mode="u_kn")
     mbar = MBAR(u_kn, even_N_k)
 
     results = mbar.computeOverlap()
-    overlap_scalar = results['scalar']
-    eigenval = results['eigenvalues']
-    O = results['matrix']
+    overlap_scalar = results["scalar"]
+    eigenval = results["eigenvalues"]
+    O = results["matrix"]
 
-    reference_matrix = (1.0/d)*np.ones([d,d])
+    reference_matrix = (1.0 / d) * np.ones([d, d])
     reference_eigenvalues = np.zeros(d)
     reference_eigenvalues[0] = 1.0
     reference_scalar = np.float64(1.0)
@@ -416,11 +453,11 @@ def test_mbar_computeOverlap_analytical():
 
 def test_mbar_computeOverlap_nonanalytical(mbar_and_test):
     """Tests Overlap with stochastic tests"""
-    mbar = mbar_and_test['mbar']
+    mbar = mbar_and_test["mbar"]
     results = mbar.computeOverlap()
-    overlap_scalar = results['scalar']
-    eigenval = results['eigenvalues']
-    O = results['matrix']
+    overlap_scalar = results["scalar"]
+    eigenval = results["eigenvalues"]
+    O = results["matrix"]
 
     assert isinstance(overlap_scalar, (float, int))
     # rows of matrix should sum to one
@@ -433,18 +470,21 @@ def test_mbar_getWeights(mbar_and_test):
 
     """ testing getWeights """
 
-    mbar = mbar_and_test['mbar']
+    mbar = mbar_and_test["mbar"]
     W = mbar.getWeights()
     sumrows = np.sum(W, axis=0)
     assert_almost_equal(sumrows, np.ones(len(sumrows)), decimal=precision)
 
 
-@pytest.mark.parametrize("system_generator,mode,bad_n",
-                         [(generate_ho, 'u_kn', False),
-                          (generate_exp, 'u_kn', False),
-                          (generate_ho, 'u_kln', False),
-                          pytest.param(generate_ho, 'u_kn', True, marks=pytest.mark.xfail(strict=True))
-                          ])
+@pytest.mark.parametrize(
+    "system_generator,mode,bad_n",
+    [
+        (generate_ho, "u_kn", False),
+        (generate_exp, "u_kn", False),
+        (generate_ho, "u_kln", False),
+        pytest.param(generate_ho, "u_kn", True, marks=pytest.mark.xfail(strict=True)),
+    ],
+)
 def test_mbar_computePerturbedFreeEnergeies(system_generator, mode, bad_n):
 
     """ testing computePerturbedFreeEnergies """
@@ -452,7 +492,7 @@ def test_mbar_computePerturbedFreeEnergeies(system_generator, mode, bad_n):
     # only do MBAR with the first and last set
 
     name, test = system_generator()
-    if mode == 'u_kln':
+    if mode == "u_kln":
         x_n, u_kn, N_k_output = test.sample(N_k, mode=mode)
         numN = max(N_k[:2])
         if bad_n:
@@ -469,8 +509,8 @@ def test_mbar_computePerturbedFreeEnergeies(system_generator, mode, bad_n):
 
     mbar = MBAR(u_kn[mslice], N_k[:2])
     results = mbar.computePerturbedFreeEnergies(u_kn[pslice])
-    fe = results['Delta_f']
-    fe_sigma = results['dDelta_f']
+    fe = results["Delta_f"]
+    fe_sigma = results["dDelta_f"]
 
     fe, fe_sigma = fe[0, 1:], fe_sigma[0, 1:]
     fe0 = test.analytical_free_energies()[2:]
@@ -483,7 +523,12 @@ def test_mbar_computePerturbedFreeEnergeies(system_generator, mode, bad_n):
 def test_mbar_computeExpectationsInner(mbar_and_test):
 
     """Can MBAR calculate general expectations inner code (note: this just tests completion)"""
-    mbar, test, x_n, u_kn = mbar_and_test['mbar'], mbar_and_test['test'], mbar_and_test['x_n'], mbar_and_test['u_kn']
+    mbar, test, x_n, u_kn = (
+        mbar_and_test["mbar"],
+        mbar_and_test["test"],
+        mbar_and_test["x_n"],
+        mbar_and_test["u_kn"],
+    )
     A_in = np.array([x_n, x_n ** 2, x_n ** 3])
     u_n = u_kn[:2, :]
     state_map = np.array([[0, 0], [1, 0], [2, 0], [2, 1]], int)

--- a/pymbar/tests/test_mbar_solvers.py
+++ b/pymbar/tests/test_mbar_solvers.py
@@ -1,32 +1,38 @@
 import numpy as np
 import pytest
 import pymbar
-from pymbar.utils_for_testing import (suppress_derivative_warnings_for_tests, suppress_matrix_warnings_for_tests,
-                                      assert_almost_equal,
-                                      oscillators, exponentials)
+from pymbar.utils_for_testing import (
+    suppress_derivative_warnings_for_tests,
+    suppress_matrix_warnings_for_tests,
+    assert_almost_equal,
+    oscillators,
+    exponentials,
+)
 from pymbar.tests.test_mbar import z_scale_factor
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def base_oscillator():
     name, u_kn, N_k, s_n, test = oscillators(50, 100, provide_test=True)
-    return {'name': name, 'u_kn': u_kn, 'N_k': N_k, 's_n': s_n, 'test': test}
+    return {"name": name, "u_kn": u_kn, "N_k": N_k, "s_n": s_n, "test": test}
 
 
 @pytest.mark.parametrize(
-    'statesa, statesb, test_system',
-    [(100, 100, oscillators),
-     (200, 50, oscillators),
-     (200, 50, exponentials)]
+    "statesa, statesb, test_system",
+    [(100, 100, oscillators), (200, 50, oscillators), (200, 50, exponentials)],
 )
 def test_solvers(statesa, statesb, test_system):
     name, U, N_k, s_n, _ = test_system(statesa, statesb, provide_test=True)
     print(name)
     mbar = pymbar.MBAR(U, N_k)
-    assert_almost_equal(pymbar.mbar_solvers.mbar_gradient(U, N_k, mbar.f_k), np.zeros(N_k.shape), decimal=8)
+    assert_almost_equal(
+        pymbar.mbar_solvers.mbar_gradient(U, N_k, mbar.f_k), np.zeros(N_k.shape), decimal=8
+    )
     assert_almost_equal(np.exp(mbar.Log_W_nk).sum(0), np.ones(len(N_k)), decimal=10)
     assert_almost_equal(np.exp(mbar.Log_W_nk).dot(N_k), np.ones(U.shape[1]), decimal=10)
-    assert_almost_equal(pymbar.mbar_solvers.self_consistent_update(U, N_k, mbar.f_k), mbar.f_k, decimal=10)
+    assert_almost_equal(
+        pymbar.mbar_solvers.self_consistent_update(U, N_k, mbar.f_k), mbar.f_k, decimal=10
+    )
 
     # Test against old MBAR code.
     with suppress_derivative_warnings_for_tests():
@@ -36,9 +42,22 @@ def test_solvers(statesa, statesb, test_system):
     assert_almost_equal(np.exp(mbar.Log_W_nk), np.exp(mbar0.Log_W_nk), decimal=5)
 
 
-@pytest.mark.parametrize('protocol',
-                         ['adaptive', 'hybr', 'lm', 'L-BFGS-B', 'dogleg', 'CG', 'BFGS', 'Newton-CG', 'TNC',
-                            'trust-ncg', 'SLSQP'])
+@pytest.mark.parametrize(
+    "protocol",
+    [
+        "adaptive",
+        "hybr",
+        "lm",
+        "L-BFGS-B",
+        "dogleg",
+        "CG",
+        "BFGS",
+        "Newton-CG",
+        "TNC",
+        "trust-ncg",
+        "SLSQP",
+    ],
+)
 def test_protocols(base_oscillator, protocol):
     """
     Test that free energy is moderately equal to analytical solution, independent of solver protocols
@@ -46,9 +65,9 @@ def test_protocols(base_oscillator, protocol):
 
     # Importing the hacky fix to asert that free energies are moderately correct
 
-    test = base_oscillator['test']
-    u_kn = base_oscillator['u_kn']
-    N_k = base_oscillator['N_k']
+    test = base_oscillator["test"]
+    u_kn = base_oscillator["u_kn"]
+    N_k = base_oscillator["N_k"]
     fa = test.analytical_free_energies()
     fa = fa[1:] - fa[0]
     with suppress_derivative_warnings_for_tests():
@@ -56,11 +75,13 @@ def test_protocols(base_oscillator, protocol):
         # subsampling_protocols = ['adaptive', 'L-BFGS-B', 'dogleg', 'CG', 'BFGS', 'Newton-CG', 'TNC', 'trust-ncg', 'SLSQP']
         # scipy.optimize.root methods. Omitting methods which do not use the Jacobian. Adding the custom adaptive protocol.
         # Solve MBAR with zeros for initial weights
-        mbar = pymbar.MBAR(u_kn, N_k, solver_protocol=({'method': protocol},))
+        mbar = pymbar.MBAR(u_kn, N_k, solver_protocol=({"method": protocol},))
         # Solve MBAR with the correct f_k used for the inital weights
-        mbar = pymbar.MBAR(u_kn, N_k, initial_f_k=mbar.f_k, solver_protocol=({'method': protocol},))
+        mbar = pymbar.MBAR(
+            u_kn, N_k, initial_f_k=mbar.f_k, solver_protocol=({"method": protocol},)
+        )
         results = mbar.getFreeEnergyDifferences()
-        fe = results['Delta_f'][0,1:]
-        fe_sigma = results['dDelta_f'][0,1:]
+        fe = results["Delta_f"][0, 1:]
+        fe_sigma = results["dDelta_f"][0, 1:]
         z = (fe - fa) / fe_sigma
         assert_almost_equal(z / z_scale_factor, np.zeros(len(z)), decimal=0)

--- a/pymbar/tests/test_timeseries.py
+++ b/pymbar/tests/test_timeseries.py
@@ -8,15 +8,17 @@ from pymbar.utils_for_testing import assert_almost_equal
 
 try:
     import statsmodels.api as sm
+
     HAVE_STATSMODELS = True
 except ImportError as err:
     HAVE_STATSMODELS = False
 
-has_statmodels = pytest.mark.skipif(not HAVE_STATSMODELS,
-                                    reason="Skipping FFT based tests because statsmodels not installed.")
+has_statmodels = pytest.mark.skipif(
+    not HAVE_STATSMODELS, reason="Skipping FFT based tests because statsmodels not installed."
+)
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def data(N=10000, K=10):
     var = np.ones(N)
 
@@ -89,7 +91,9 @@ def test_statistical_inefficiency_fft_gaussian():
 
     for i in range(5):
         x = np.random.normal(size=100000)
-        x = np.repeat(x, 3)  # e.g. Construct correlated gaussian e.g. [a, b, c] -> [a, a, a, b, b, b, c, c, c]
+        x = np.repeat(
+            x, 3
+        )  # e.g. Construct correlated gaussian e.g. [a, b, c] -> [a, a, a, b, b, b, c, c, c]
         g0 = timeseries.statisticalInefficiency(x, fast=False)
         g1 = timeseries.statisticalInefficiency(x, x, fast=False)
         g2 = timeseries.statisticalInefficiency_fft(x)
@@ -99,7 +103,7 @@ def test_statistical_inefficiency_fft_gaussian():
         assert_almost_equal(g0, g3, decimal=5)
 
         assert_almost_equal(np.log(g0), np.log(3.0), decimal=1)
-        
+
 
 def test_detectEquil():
     x = np.random.normal(size=10000)
@@ -118,19 +122,20 @@ def test_compare_detectEquil(show_hist=False):
     compare detectEquilibration implementations (with and without binary search + fft)
     """
     t_res = []
-    N=100
+    N = 100
     for _ in range(100):
         A_t = testsystems.correlated_timeseries_example(N=N, tau=5.0) + 2.0
         B_t = testsystems.correlated_timeseries_example(N=N, tau=5.0) + 1.0
-        C_t = testsystems.correlated_timeseries_example(N=N*2, tau=5.0)
+        C_t = testsystems.correlated_timeseries_example(N=N * 2, tau=5.0)
         D_t = np.concatenate([A_t, B_t, C_t])
         bs_de = timeseries.detectEquilibration_binary_search(D_t, bs_nodes=10)
         std_de = timeseries.detectEquilibration(D_t, fast=False, nskip=1)
-        t_res.append(bs_de[0]-std_de[0])
+        t_res.append(bs_de[0] - std_de[0])
     t_res_mode = float(stats.mode(t_res)[0][0])
-    assert_almost_equal(t_res_mode, 0., decimal=1)
+    assert_almost_equal(t_res_mode, 0.0, decimal=1)
     if show_hist:
         import matplotlib.pyplot as plt
+
         plt.hist(t_res)
         plt.show()
 
@@ -155,10 +160,14 @@ def test_correlationFunctionMultiple():
     A_t = [testsystems.correlated_timeseries_example(N=10000, tau=10.0) for _ in range(10)]
     corr_norm = timeseries.normalizedFluctuationCorrelationFunctionMultiple(A_kn=A_t)
     corr = timeseries.normalizedFluctuationCorrelationFunctionMultiple(A_kn=A_t, norm=False)
-    corr_norm_trun = timeseries.normalizedFluctuationCorrelationFunctionMultiple(A_kn=A_t, truncate=True)
-    corr_trun = timeseries.normalizedFluctuationCorrelationFunctionMultiple(A_kn=A_t, norm=False, truncate=True)
-    assert (corr_norm_trun[-1] >= 0)
-    assert (corr_trun[-1] >= 0)
-    assert (corr_norm[0] == 1.)
-    assert (corr_norm_trun[0] == 1.)
-    assert (len(corr_trun) == len(corr_norm_trun))
+    corr_norm_trun = timeseries.normalizedFluctuationCorrelationFunctionMultiple(
+        A_kn=A_t, truncate=True
+    )
+    corr_trun = timeseries.normalizedFluctuationCorrelationFunctionMultiple(
+        A_kn=A_t, norm=False, truncate=True
+    )
+    assert corr_norm_trun[-1] >= 0
+    assert corr_trun[-1] >= 0
+    assert corr_norm[0] == 1.0
+    assert corr_norm_trun[0] == 1.0
+    assert len(corr_trun) == len(corr_norm_trun)

--- a/pymbar/tests/test_utils.py
+++ b/pymbar/tests/test_utils.py
@@ -3,6 +3,7 @@ import pytest
 import pymbar
 from pymbar.utils_for_testing import assert_equal, assert_almost_equal
 from pymbar.utils import ParameterError, ensure_type, TypeCastPerformanceWarning
+
 try:
     from scipy.special import logsumexp
 except ImportError:
@@ -29,7 +30,7 @@ def test_logsumexp_single_infinite():
 
 def test_logsumexp_b():
     a = np.random.normal(size=(200, 500, 5))
-    b = np.random.normal(size=(200, 500, 5)) ** 2.
+    b = np.random.normal(size=(200, 500, 5)) ** 2.0
 
     for axis in range(a.ndim):
         ans_ne = pymbar.utils.logsumexp(a, b=b, axis=axis)
@@ -48,36 +49,149 @@ def test_logsum():
 
 @pytest.mark.xfail(raises=ParameterError)
 def test_non_normalized_w_badrow():
-    w = np.array([[0.5, 0.5,
-                   0.75, 0.25]])
+    w = np.array([[0.5, 0.5, 0.75, 0.25]])
     n_k = np.array([1, 1])
     pymbar.utils.check_w_normalized(w, n_k)
 
 
 @pytest.mark.xfail(raises=ParameterError)
 def test_non_normalized_w_badcol():
-    w = np.array([[0.5, 0.5],
-                  [0.5, 0.5]])
+    w = np.array([[0.5, 0.5], [0.5, 0.5]])
     n_k = np.array([1, 0])
     pymbar.utils.check_w_normalized(w, n_k)
 
 
-@pytest.mark.parametrize('fn_args_and_kwargs,expected,warn',
-                         [
-                             ({'val': None, 'dtype': int, 'ndim': 1, 'name': 'thetest', 'can_be_none': True}, None, None),
-                             ({'val': 0, 'dtype': int, 'ndim': 1, 'name': 'thetest', 'add_newaxis_on_deficient_ndim': True}, np.array([0]), None),
-                             pytest.param({'val': 0, 'dtype': int, 'ndim': 1, 'name': 'thetest', 'add_newaxis_on_deficient_ndim': False}, 'Should Fail', None, marks=pytest.mark.xfail),
-                             pytest.param({'val': [], 'dtype': int, 'ndim': 1, 'name': 'thetest', 'add_newaxis_on_deficient_ndim': True}, 'Should Fail', None, marks=pytest.mark.xfail),
-                             ({'val': np.array([1.0]), 'dtype': int, 'ndim': 1, 'name': 'thetest', 'warn_on_cast': True}, np.array([1]), TypeCastPerformanceWarning),
-                             ({'val': np.array([1]), 'dtype': int, 'ndim': 2, 'name': 'thetest', 'add_newaxis_on_deficient_ndim': True}, np.array([[1]]), None),
-                             pytest.param({'val': np.array([1]), 'dtype': int, 'ndim': 3, 'name': 'thetest', 'add_newaxis_on_deficient_ndim': True}, 'Should Fail', None, marks=pytest.mark.xfail),
-                             pytest.param({'val': np.array([1, 2, 3]), 'dtype': int, 'ndim': 1, 'name': 'thetest', 'length': 4}, 'Should Fail', None, marks=pytest.mark.xfail),
-                             ({'val': np.array([[1, 2, 3], [4, 5, 6]]), 'dtype': int, 'ndim': 2, 'name': 'thetest', 'shape': (2, 3)}, np.array([[1, 2, 3], [4, 5, 6]]), None),
-                             ({'val': np.array([[1, 2, 3], [4, 5, 6]]), 'dtype': int, 'ndim': 2, 'name': 'thetest', 'shape': (None, 3)}, np.array([[1, 2, 3], [4, 5, 6]]), None),
-                             pytest.param({'val': np.array([[1, 2, 3], [4, 5, 6]]), 'dtype': int, 'ndim': 2, 'name': 'thetest', 'shape': (2,)}, 'Should Fail', None, marks=pytest.mark.xfail),
-                             pytest.param({'val': np.array([[1, 2, 3], [4, 5, 6]]), 'dtype': int, 'ndim': 2, 'name': 'thetest', 'shape': (3, 1)}, 'Should Fail', None, marks=pytest.mark.xfail),
-
-                         ])
+@pytest.mark.parametrize(
+    "fn_args_and_kwargs,expected,warn",
+    [
+        (
+            {"val": None, "dtype": int, "ndim": 1, "name": "thetest", "can_be_none": True},
+            None,
+            None,
+        ),
+        (
+            {
+                "val": 0,
+                "dtype": int,
+                "ndim": 1,
+                "name": "thetest",
+                "add_newaxis_on_deficient_ndim": True,
+            },
+            np.array([0]),
+            None,
+        ),
+        pytest.param(
+            {
+                "val": 0,
+                "dtype": int,
+                "ndim": 1,
+                "name": "thetest",
+                "add_newaxis_on_deficient_ndim": False,
+            },
+            "Should Fail",
+            None,
+            marks=pytest.mark.xfail,
+        ),
+        pytest.param(
+            {
+                "val": [],
+                "dtype": int,
+                "ndim": 1,
+                "name": "thetest",
+                "add_newaxis_on_deficient_ndim": True,
+            },
+            "Should Fail",
+            None,
+            marks=pytest.mark.xfail,
+        ),
+        (
+            {
+                "val": np.array([1.0]),
+                "dtype": int,
+                "ndim": 1,
+                "name": "thetest",
+                "warn_on_cast": True,
+            },
+            np.array([1]),
+            TypeCastPerformanceWarning,
+        ),
+        (
+            {
+                "val": np.array([1]),
+                "dtype": int,
+                "ndim": 2,
+                "name": "thetest",
+                "add_newaxis_on_deficient_ndim": True,
+            },
+            np.array([[1]]),
+            None,
+        ),
+        pytest.param(
+            {
+                "val": np.array([1]),
+                "dtype": int,
+                "ndim": 3,
+                "name": "thetest",
+                "add_newaxis_on_deficient_ndim": True,
+            },
+            "Should Fail",
+            None,
+            marks=pytest.mark.xfail,
+        ),
+        pytest.param(
+            {"val": np.array([1, 2, 3]), "dtype": int, "ndim": 1, "name": "thetest", "length": 4},
+            "Should Fail",
+            None,
+            marks=pytest.mark.xfail,
+        ),
+        (
+            {
+                "val": np.array([[1, 2, 3], [4, 5, 6]]),
+                "dtype": int,
+                "ndim": 2,
+                "name": "thetest",
+                "shape": (2, 3),
+            },
+            np.array([[1, 2, 3], [4, 5, 6]]),
+            None,
+        ),
+        (
+            {
+                "val": np.array([[1, 2, 3], [4, 5, 6]]),
+                "dtype": int,
+                "ndim": 2,
+                "name": "thetest",
+                "shape": (None, 3),
+            },
+            np.array([[1, 2, 3], [4, 5, 6]]),
+            None,
+        ),
+        pytest.param(
+            {
+                "val": np.array([[1, 2, 3], [4, 5, 6]]),
+                "dtype": int,
+                "ndim": 2,
+                "name": "thetest",
+                "shape": (2,),
+            },
+            "Should Fail",
+            None,
+            marks=pytest.mark.xfail,
+        ),
+        pytest.param(
+            {
+                "val": np.array([[1, 2, 3], [4, 5, 6]]),
+                "dtype": int,
+                "ndim": 2,
+                "name": "thetest",
+                "shape": (3, 1),
+            },
+            "Should Fail",
+            None,
+            marks=pytest.mark.xfail,
+        ),
+    ],
+)
 def test_type_ensure(fn_args_and_kwargs, expected, warn):
     if warn is not None:
         with pytest.warns(warn):
@@ -91,38 +205,30 @@ def test_type_ensure(fn_args_and_kwargs, expected, warn):
         assert ret == expected
 
 
-@pytest.mark.parametrize("n_k", [None, np.array([3]*3)])
+@pytest.mark.parametrize("n_k", [None, np.array([3] * 3)])
 def test_kln_to_nk_to_k(n_k):
     # 3 samples per state
     # 3 states
     # Samples energies are (state index + 1)*(relative state index)
-    u_kln = np.array([
-        # k=0
-        [[0, 0, 0],  # l=0: n=1*0
-         [1, 1, 1],  # l=1: n=1*1
-         [2, 2, 2]  # l=2: n=1*2
-        ],
-        # k=1
-        [[-2, -2, -2],  # l=0: n=2*-1
-         [0, 0, 0],  # l=1: n=2*0
-         [2, 2, 2]  # l=2: n=2*1
-        ],
-        # k=2
-        [[-6, -6, -6],  # l=0: n=3*-2
-         [-3, -3, -3],  # l=1: n=3*-1
-         [0, 0, 0]  # l=2: n=3*0
-         ],
-    ]
+    u_kln = np.array(
+        [
+            # k=0
+            [[0, 0, 0], [1, 1, 1], [2, 2, 2]],  # l=0: n=1*0  # l=1: n=1*1  # l=2: n=1*2
+            # k=1
+            [[-2, -2, -2], [0, 0, 0], [2, 2, 2]],  # l=0: n=2*-1  # l=1: n=2*0  # l=2: n=2*1
+            # k=2
+            [[-6, -6, -6], [-3, -3, -3], [0, 0, 0]],  # l=0: n=3*-2  # l=1: n=3*-1  # l=2: n=3*0
+        ]
     )
     u_kn = np.array(
-        [   # n 1 2 3...
+        [  # n 1 2 3...
             [0, 0, 0, -2, -2, -2, -6, -6, -6],  # k = 0
-            [1, 1, 1,  0,  0,  0, -3, -3, -3],  # k = 1
-            [2, 2, 2,  2,  2,  2,  0,  0,  0]   # k = 3
+            [1, 1, 1, 0, 0, 0, -3, -3, -3],  # k = 1
+            [2, 2, 2, 2, 2, 2, 0, 0, 0],  # k = 3
         ]
     )
     u_n = np.array(
-        [0, 0, 0, -2, -2, -2, -6, -6, -6, 1, 1, 1,  0,  0,  0, -3, -3, -3, 2, 2, 2,  2,  2,  2,  0,  0,  0]
+        [0, 0, 0, -2, -2, -2, -6, -6, -6, 1, 1, 1, 0, 0, 0, -3, -3, -3, 2, 2, 2, 2, 2, 2, 0, 0, 0]
     )
     u_kn_out = pymbar.utils.kln_to_kn(u_kln, N_k=n_k, cleanup=True)
     assert np.allclose(u_kn, u_kn_out)
@@ -130,6 +236,6 @@ def test_kln_to_nk_to_k(n_k):
         # Because we're testing both None _and_ set N_k, we have to assume the u_kn we fed in was reset for
         # this second test. If we didn't, then the behavior for N_k=None is ambiguous or assumes things about
         # a state (programming/object) it has no knowledge of.
-        n_k = np.array([9]*3)
+        n_k = np.array([9] * 3)
     u_n_out = pymbar.utils.kn_to_n(u_kn, N_k=n_k, cleanup=True)
     assert np.allclose(u_n, u_n_out)

--- a/pymbar/testsystems/__init__.py
+++ b/pymbar/testsystems/__init__.py
@@ -1,5 +1,11 @@
-__all__ = ["timeseries", "exponential_distributions", "harmonic_oscillators", "gaussian_work",
-           "HarmonicOscillatorsTestCase", "ExponentialTestCase"]
+__all__ = [
+    "timeseries",
+    "exponential_distributions",
+    "harmonic_oscillators",
+    "gaussian_work",
+    "HarmonicOscillatorsTestCase",
+    "ExponentialTestCase",
+]
 
 from pymbar.testsystems.harmonic_oscillators import HarmonicOscillatorsTestCase
 from pymbar.testsystems.exponential_distributions import ExponentialTestCase

--- a/pymbar/testsystems/exponential_distributions.py
+++ b/pymbar/testsystems/exponential_distributions.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+
 class ExponentialTestCase(object):
 
     """Test cases using exponential distributions.
@@ -55,7 +56,7 @@ class ExponentialTestCase(object):
         rates = np.array(rates, np.float64)
 
         self.n_states = len(rates)
-        self.rates = np.array(rates,np. float64)
+        self.rates = np.array(rates, np.float64)
         self.beta = beta
 
     def analytical_free_energies(self):
@@ -63,33 +64,36 @@ class ExponentialTestCase(object):
         return np.log(self.rates)
 
     def analytical_means(self):
-        return self.rates ** -1.
+        return self.rates ** -1.0
 
     def analytical_variances(self):
-        return self.rates ** -2.
+        return self.rates ** -2.0
 
     def analytical_standard_deviations(self):
-        return np.sqrt(self.rates ** -2.)
+        return np.sqrt(self.rates ** -2.0)
 
-    def analytical_observable(self, observable = 'position'):
+    def analytical_observable(self, observable="position"):
 
-        if observable == 'position':
+        if observable == "position":
             return self.analytical_means()
-        if observable == 'position^2':
-            return 2.0*self.analytical_variances()
-        if observable == 'RMS displacement':
-            #<X^2> - <X>^2 = 2L^2-L^2 = L^2
+        if observable == "position^2":
+            return 2.0 * self.analytical_variances()
+        if observable == "RMS displacement":
+            # <X^2> - <X>^2 = 2L^2-L^2 = L^2
             return self.analytical_variances()
-        if observable == 'potential energy':
+        if observable == "potential energy":
             return np.ones(len(self.rates))
 
     def analytical_entropies(self):
-        return self.analytical_observable(observable='potential energy') - self.analytical_free_energies()
+        return (
+            self.analytical_observable(observable="potential energy")
+            - self.analytical_free_energies()
+        )
 
     def analytical_x_squared(self):
-        return self.analytical_variances() + self.analytical_means() ** 2.
+        return self.analytical_variances() + self.analytical_means() ** 2.0
 
-    def sample(self, N_k=(10, 20, 30, 40, 50), mode='u_kln', seed=None):
+    def sample(self, N_k=(10, 20, 30, 40, 50), mode="u_kln", seed=None):
         """Draw samples from the distribution.
 
         Parameters
@@ -142,11 +146,19 @@ class ExponentialTestCase(object):
 
         N_k = np.array(N_k, np.int32)
         if len(N_k) != self.n_states:
-            raise Exception("N_k has {:d} states while self.n_states has {:d} states.".format(len(N_k), self.n_states))
+            raise Exception(
+                "N_k has {:d} states while self.n_states has {:d} states.".format(
+                    len(N_k), self.n_states
+                )
+            )
 
-        if mode == 'wFwR':
+        if mode == "wFwR":
             if len(N_k) != 2:
-                raise Exception("N_k has {:d} states instead of 2, we cannot generate forward and reverse work distributions".format(len(N_k)))
+                raise Exception(
+                    "N_k has {:d} states instead of 2, we cannot generate forward and reverse work distributions".format(
+                        len(N_k)
+                    )
+                )
 
         N_max = N_k.max()  # maximum number of samples per state
         N_tot = N_k.sum()  # total number of samples
@@ -157,29 +169,35 @@ class ExponentialTestCase(object):
         u_kn = np.zeros([self.n_states, N_tot], np.float64)
         index = 0
         for k, N in enumerate(N_k):
-            x = np.random.exponential(scale=self.rates[k] ** -1., size=N)
+            x = np.random.exponential(scale=self.rates[k] ** -1.0, size=N)
             x_kn[k, 0:N] = x
-            x_n[index:(index + N)] = x
-            s_n[index:(index + N)] = k
+            x_n[index : (index + N)] = x
+            s_n[index : (index + N)] = k
             for l in range(self.n_states):
                 u = self.beta * self.rates[l] * x
                 u_kln[k, l, 0:N] = u
-                u_kn[l, index:(index + N)] = u
+                u_kn[l, index : (index + N)] = u
             index += N
 
-        if mode == 'u_kn':
+        if mode == "u_kn":
             return x_n, u_kn, N_k, s_n
-        elif mode == 'u_kln':
+        elif mode == "u_kln":
             return x_kn, u_kln, N_k
-        elif mode == 'wFwR':
-            return u_kln[0,1,:N_k[0]]-u_kln[0,0,:N_k[0]], u_kln[1,0,:N_k[1]]-u_kln[1,1,:N_k[1]], N_k
+        elif mode == "wFwR":
+            return (
+                u_kln[0, 1, : N_k[0]] - u_kln[0, 0, : N_k[0]],
+                u_kln[1, 0, : N_k[1]] - u_kln[1, 1, : N_k[1]],
+                N_k,
+            )
         else:
             raise Exception("Unknown mode '{}'".format(mode))
 
         return
-    
+
     @classmethod
-    def evenly_spaced_exponentials(cls, n_states, n_samples_per_state, lower_rate=1.0, upper_rate=3.0):
+    def evenly_spaced_exponentials(
+        cls, n_states, n_samples_per_state, lower_rate=1.0, upper_rate=3.0
+    ):
         """Generate samples from evenly spaced exponential distributions.
 
         Parameters
@@ -213,13 +231,13 @@ class ExponentialTestCase(object):
         s_n : np.ndarray, shape=(n_samples)
             State of origin of each sample
         """
-                
+
         name = "{:d}x{:d} exponentials".format(n_states, n_samples_per_state)
 
         rates = np.linspace(lower_rate, upper_rate, n_states)
-        N_k = (np.ones(n_states) * n_samples_per_state).astype('int')
+        N_k = (np.ones(n_states) * n_samples_per_state).astype("int")
 
         testsystem = cls(rates)
-        x_n, u_kn, N_k_output, s_n = testsystem.sample(N_k, mode='u_kn')
+        x_n, u_kn, N_k_output, s_n = testsystem.sample(N_k, mode="u_kn")
 
         return name, testsystem, x_n, u_kn, N_k_output, s_n

--- a/pymbar/testsystems/gaussian_work.py
+++ b/pymbar/testsystems/gaussian_work.py
@@ -80,12 +80,14 @@ def gaussian_work_example(N_F=200, N_R=200, mu_F=2.0, DeltaF=None, sigma_F=1.0, 
 
     # Make sure either mu_F or DeltaF, but not both, are specified.
     if (mu_F is not None) and (DeltaF is not None):
-        raise ValueError("mu_F and DeltaF are not independent, and cannot both be specified; one must be set to None.")
+        raise ValueError(
+            "mu_F and DeltaF are not independent, and cannot both be specified; one must be set to None."
+        )
     if (mu_F is None) and (DeltaF is None):
         raise ValueError("Either mu_F or DeltaF must be specified.")
-    if (mu_F is None):
+    if mu_F is None:
         mu_F = DeltaF + sigma_F ** 2 / 2.0
-    if (DeltaF is None):
+    if DeltaF is None:
         DeltaF = mu_F - sigma_F ** 2 / 2.0
 
     # Set random number generator into a known state for reproducibility.
@@ -93,7 +95,7 @@ def gaussian_work_example(N_F=200, N_R=200, mu_F=2.0, DeltaF=None, sigma_F=1.0, 
 
     # Determine mean and variance of reverse work distribution by Crooks
     # fluctuation theorem (CFT).
-    mu_R = - mu_F + sigma_F ** 2
+    mu_R = -mu_F + sigma_F ** 2
     sigma_R = sigma_F * np.exp(mu_F - sigma_F ** 2 / 2.0 - DeltaF)
 
     # Draw samples from forward and reverse distributions.

--- a/pymbar/testsystems/harmonic_oscillators.py
+++ b/pymbar/testsystems/harmonic_oscillators.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+
 class HarmonicOscillatorsTestCase(object):
 
     """Test cases using harmonic oscillators.
@@ -65,26 +66,28 @@ class HarmonicOscillatorsTestCase(object):
         self.K_k = np.array(K_k, np.float64)
 
         if len(self.K_k) != self.n_states:
-            raise ValueError('Lengths of K_k={} and O_k={} should be equal'.format(len(self.O_k), len(self.K_k)))
+            raise ValueError(
+                "Lengths of K_k={} and O_k={} should be equal".format(len(self.O_k), len(self.K_k))
+            )
 
     def analytical_means(self):
         return self.O_k
 
     def analytical_variances(self):
-        return (self.beta * self.K_k) ** -1.
+        return (self.beta * self.K_k) ** -1.0
 
     def analytical_standard_deviations(self):
         return (self.beta * self.K_k) ** -0.5
 
-    def analytical_observable(self, observable='position'):
+    def analytical_observable(self, observable="position"):
 
-        if observable == 'position':
+        if observable == "position":
             return self.analytical_means()
-        if observable == 'potential energy':
-            return (0.5/self.beta)*np.ones(self.n_states)
-        if observable == 'position^2':
-            return 1.0/(self.beta*self.K_k) + np.square(self.O_k)
-        if observable == 'RMS displacement':
+        if observable == "potential energy":
+            return (0.5 / self.beta) * np.ones(self.n_states)
+        if observable == "position^2":
+            return 1.0 / (self.beta * self.K_k) + np.square(self.O_k)
+        if observable == "RMS displacement":
             return self.analytical_standard_deviations()
 
     def analytical_free_energies(self, subtract_component=0):
@@ -93,10 +96,12 @@ class HarmonicOscillatorsTestCase(object):
             fe -= fe[subtract_component]
         return fe
 
-    def analytical_entropies(self, subtract_component = 0):
-        return self.analytical_observable(observable = 'potential energy') - self.analytical_free_energies(subtract_component)
+    def analytical_entropies(self, subtract_component=0):
+        return self.analytical_observable(
+            observable="potential energy"
+        ) - self.analytical_free_energies(subtract_component)
 
-    def sample(self, N_k=(10, 20, 30, 40, 50), mode='u_kn', seed = None):
+    def sample(self, N_k=(10, 20, 30, 40, 50), mode="u_kn", seed=None):
         """Draw samples from the distribution.
 
         Parameters
@@ -146,11 +151,19 @@ class HarmonicOscillatorsTestCase(object):
 
         N_k = np.array(N_k, np.int32)
         if len(N_k) != self.n_states:
-            raise Exception("N_k has {:d} states while self.n_states has {:d} states.".format(len(N_k), self.n_states))
+            raise Exception(
+                "N_k has {:d} states while self.n_states has {:d} states.".format(
+                    len(N_k), self.n_states
+                )
+            )
 
-        if mode == 'wFwR':
+        if mode == "wFwR":
             if len(N_k) != 2:
-                raise Exception("N_k has {:d} states instead of 2, we cannot generate forward and reverse work distributions".format(len(N_k)))
+                raise Exception(
+                    "N_k has {:d} states instead of 2, we cannot generate forward and reverse work distributions".format(
+                        len(N_k)
+                    )
+                )
 
         N_max = N_k.max()  # maximum number of samples per state
         N_tot = N_k.sum()  # total number of samples
@@ -166,27 +179,39 @@ class HarmonicOscillatorsTestCase(object):
             sigma = (self.beta * self.K_k[k]) ** -0.5
             x = np.random.normal(loc=x0, scale=sigma, size=N)
             x_kn[k, 0:N] = x
-            x_n[index:(index + N)] = x
-            s_n[index:(index + N)] = k
+            x_n[index : (index + N)] = x
+            s_n[index : (index + N)] = k
             for l in range(self.n_states):
                 u = self.beta * 0.5 * self.K_k[l] * (x - self.O_k[l]) ** 2.0
                 u_kln[k, l, 0:N] = u
-                u_kn[l, index:(index + N)] = u
+                u_kn[l, index : (index + N)] = u
             index += N
 
-        if (mode == 'u_kn'):
+        if mode == "u_kn":
             return x_n, u_kn, N_k, s_n
-        elif (mode == 'u_kln'):
+        elif mode == "u_kln":
             return x_kn, u_kln, N_k
-        elif (mode == 'wFwR'):
-            return u_kln[0,1,:N_k[0]]-u_kln[0,0,:N_k[0]], u_kln[1,0,:N_k[1]]-u_kln[1,1,:N_k[1]], N_k
+        elif mode == "wFwR":
+            return (
+                u_kln[0, 1, : N_k[0]] - u_kln[0, 0, : N_k[0]],
+                u_kln[1, 0, : N_k[1]] - u_kln[1, 1, : N_k[1]],
+                N_k,
+            )
         else:
             raise Exception("Unknown mode '{}'".format(mode))
 
         return
 
     @classmethod
-    def evenly_spaced_oscillators(cls, n_states, n_samples_per_state, lower_O_k=1.0, upper_O_k=5.0, lower_k_k=1.0, upper_k_k=3.0):
+    def evenly_spaced_oscillators(
+        cls,
+        n_states,
+        n_samples_per_state,
+        lower_O_k=1.0,
+        upper_O_k=5.0,
+        lower_k_k=1.0,
+        upper_k_k=3.0,
+    ):
         """Generate samples from evenly spaced harmonic oscillators.
 
         Parameters
@@ -220,13 +245,13 @@ class HarmonicOscillatorsTestCase(object):
         s_n : np.ndarray, shape=(n_samples)
             State of origin of each sample
         """
-        name = "{:d}x{:d} oscillators",format(n_states, n_samples_per_state)
+        name = "{:d}x{:d} oscillators", format(n_states, n_samples_per_state)
 
         O_k = np.linspace(lower_O_k, upper_O_k, n_states)
         k_k = np.linspace(lower_k_k, upper_k_k, n_states)
-        N_k = (np.ones(n_states) * n_samples_per_state).astype('int')
+        N_k = (np.ones(n_states) * n_samples_per_state).astype("int")
 
         testsystem = cls(O_k, k_k)
-        x_n, u_kn, N_k_output, s_n = testsystem.sample(N_k, mode='u_kn', seed=seed)
+        x_n, u_kn, N_k_output, s_n = testsystem.sample(N_k, mode="u_kn", seed=seed)
 
         return name, testsystem, x_n, u_kn, N_k_output, s_n

--- a/pymbar/timeseries.py
+++ b/pymbar/timeseries.py
@@ -40,12 +40,12 @@ JCTC 3(1):26-41, 2007.
 
 """
 
-#=============================================================================================
+# =============================================================================================
 # TODO
 # * Implement unit tests that generate timeseries with various levels of Gaussian correlation to test all methods.
 # * Add Zwanzig procedure for estimating statistical uncertainties in correlation functions
 # (by making Gaussian process assumptions).
-#=============================================================================================
+# =============================================================================================
 
 
 __authors__ = "Michael R. Shirts and John D. Chodera."
@@ -65,13 +65,15 @@ from pymbar.utils import ParameterError
 # =============================================================================================
 
 logger = logging.getLogger(__name__)
-LongWarning = ("Warning on use of the timeseries module: If the inherent timescales of the system "
-               "are long compared to those being analyzed, this statistical inefficiency may be an underestimate.  "
-               "The estimate presumes the use of many statistically independent samples.  "
-               "Tests should be performed to assess whether this condition is satisfied.   "
-               "Be cautious in the interpretation of the data.")
+LongWarning = (
+    "Warning on use of the timeseries module: If the inherent timescales of the system "
+    "are long compared to those being analyzed, this statistical inefficiency may be an underestimate.  "
+    "The estimate presumes the use of many statistically independent samples.  "
+    "Tests should be performed to assess whether this condition is satisfied.   "
+    "Be cautious in the interpretation of the data."
+)
 logger.warning(LongWarning)
-#sys.stderr.write(LongWarning + '\n')
+# sys.stderr.write(LongWarning + '\n')
 
 # =============================================================================================
 # METHODS
@@ -134,7 +136,7 @@ def statisticalInefficiency(A_n, B_n=None, fast=False, mintime=3, fft=False):
     A_n = np.array(A_n)
 
     if fft and B_n is None:
-        return statisticalInefficiency_fft(A_n, mintime=mintime)    
+        return statisticalInefficiency_fft(A_n, mintime=mintime)
 
     if B_n is not None:
         B_n = np.array(B_n)
@@ -145,8 +147,8 @@ def statisticalInefficiency(A_n, B_n=None, fast=False, mintime=3, fft=False):
     N = A_n.size
 
     # Be sure A_n and B_n have the same dimensions.
-    if(A_n.shape != B_n.shape):
-        raise ParameterError('A_n and B_n must have same dimensions.')
+    if A_n.shape != B_n.shape:
+        raise ParameterError("A_n and B_n must have same dimensions.")
 
     # Initialize statistical inefficiency estimate with uncorrelated value.
     g = 1.0
@@ -163,8 +165,10 @@ def statisticalInefficiency(A_n, B_n=None, fast=False, mintime=3, fft=False):
     sigma2_AB = (dA_n * dB_n).mean()  # standard estimator to ensure C(0) = 1
 
     # Trap the case where this covariance is zero, and we cannot proceed.
-    if(sigma2_AB == 0):
-        raise ParameterError('Sample covariance sigma_AB^2 = 0 -- cannot compute statistical inefficiency')
+    if sigma2_AB == 0:
+        raise ParameterError(
+            "Sample covariance sigma_AB^2 = 0 -- cannot compute statistical inefficiency"
+        )
 
     # Accumulate the integrated correlation time by computing the normalized correlation time at
     # increasing values of t.  Stop accumulating if the correlation function goes negative, since
@@ -172,10 +176,12 @@ def statisticalInefficiency(A_n, B_n=None, fast=False, mintime=3, fft=False):
     # is dominated by noise and indistinguishable from zero.
     t = 1
     increment = 1
-    while (t < N - 1):
+    while t < N - 1:
 
         # compute normalized fluctuation correlation function at time t
-        C = np.sum(dA_n[0:(N - t)] * dB_n[t:N] + dB_n[0:(N - t)] * dA_n[t:N]) / (2.0 * float(N - t) * sigma2_AB)
+        C = np.sum(dA_n[0 : (N - t)] * dB_n[t:N] + dB_n[0 : (N - t)] * dA_n[t:N]) / (
+            2.0 * float(N - t) * sigma2_AB
+        )
         # Terminate if the correlation function has crossed zero and we've computed the correlation
         # function at least out to 'mintime'.
         if (C <= 0.0) and (t > mintime):
@@ -192,12 +198,14 @@ def statisticalInefficiency(A_n, B_n=None, fast=False, mintime=3, fft=False):
             increment += 1
 
     # g must be at least unity
-    if (g < 1.0):
+    if g < 1.0:
         g = 1.0
 
     # Return the computed statistical inefficiency.
     return g
-#=============================================================================================
+
+
+# =============================================================================================
 
 
 def statisticalInefficiencyMultiple(A_kn, fast=False, return_correlation_function=False):
@@ -252,7 +260,7 @@ def statisticalInefficiencyMultiple(A_kn, fast=False, return_correlation_functio
     """
 
     # Convert A_kn into a list of arrays if it is not in this form already.
-    if (type(A_kn) == np.ndarray):
+    if type(A_kn) == np.ndarray:
         A_kn_list = list()
         if A_kn.ndim == 1:
             A_kn_list.append(A_kn.copy())
@@ -301,7 +309,9 @@ def statisticalInefficiencyMultiple(A_kn, fast=False, return_correlation_functio
     g = 1.0
 
     # Initialize storage for correlation function.
-    Ct = list()  # Ct[n] is a tuple (t, C) of the time lag t and estimate of normalized fluctuation correlation function C
+    Ct = (
+        list()
+    )  # Ct[n] is a tuple (t, C) of the time lag t and estimate of normalized fluctuation correlation function C
 
     # Accumulate the integrated correlation time by computing the normalized correlation time at
     # increasing values of t.  Stop accumulating if the correlation function goes negative, since
@@ -309,15 +319,15 @@ def statisticalInefficiencyMultiple(A_kn, fast=False, return_correlation_functio
     # is dominated by noise and indistinguishable from zero.
     t = 1
     increment = 1
-    while (t < N_k.max() - 1):
+    while t < N_k.max() - 1:
         # compute unnormalized correlation function
         numerator = 0.0
         denominator = 0.0
         for k in range(K):
-            if (t >= N_k[k]):
+            if t >= N_k[k]:
                 continue  # skip trajectory if lag time t is greater than its length
             dA_n = dA_kn[k]  # retrieve trajectory
-            x = dA_n[0:(N_k[k] - t)] * dA_n[t:N_k[k]]
+            x = dA_n[0 : (N_k[k] - t)] * dA_n[t : N_k[k]]
             numerator += np.sum(x)  # accumulate contribution from trajectory k
             denominator += float(x.size)  # count how many overlapping time segments we've included
 
@@ -346,7 +356,7 @@ def statisticalInefficiencyMultiple(A_kn, fast=False, return_correlation_functio
             increment += 1
 
     # g must be at least unity
-    if (g < 1.0):
+    if g < 1.0:
         g = 1.0
 
     # Return statistical inefficency and correlation function estimate, if requested.
@@ -355,7 +365,9 @@ def statisticalInefficiencyMultiple(A_kn, fast=False, return_correlation_functio
 
     # Return the computed statistical inefficiency.
     return g
-#=============================================================================================
+
+
+# =============================================================================================
 
 
 def integratedAutocorrelationTime(A_n, B_n=None, fast=False, mintime=3):
@@ -370,7 +382,9 @@ def integratedAutocorrelationTime(A_n, B_n=None, fast=False, mintime=3):
     g = statisticalInefficiency(A_n, B_n, fast, mintime)
     tau = (g - 1.0) / 2.0
     return tau
-#=============================================================================================
+
+
+# =============================================================================================
 
 
 def integratedAutocorrelationTimeMultiple(A_kn, fast=False):
@@ -385,7 +399,9 @@ def integratedAutocorrelationTimeMultiple(A_kn, fast=False):
     g = statisticalInefficiencyMultiple(A_kn, fast, False)
     tau = (g - 1.0) / 2.0
     return tau
-#=============================================================================================
+
+
+# =============================================================================================
 
 
 def normalizedFluctuationCorrelationFunction(A_n, B_n=None, N_max=None, norm=True):
@@ -450,8 +466,8 @@ def normalizedFluctuationCorrelationFunction(A_n, B_n=None, N_max=None, norm=Tru
         N_max = N - 1
 
     # Be sure A_n and B_n have the same dimensions.
-    if(A_n.shape != B_n.shape):
-        raise ParameterError('A_n and B_n must have same dimensions.')
+    if A_n.shape != B_n.shape:
+        raise ParameterError("A_n and B_n must have same dimensions.")
 
     # Initialize statistical inefficiency estimate with uncorrelated value.
     g = 1.0
@@ -466,8 +482,10 @@ def normalizedFluctuationCorrelationFunction(A_n, B_n=None, N_max=None, norm=Tru
 
     # sigma2_AB = sum((A_n-mu_A) * (B_n-mu_B)) / (float(N)-1.0) # unbiased estimator
     sigma2_AB = (dA_n * dB_n).mean()  # standard estimator to ensure C(0) = 1
-    if(sigma2_AB == 0):
-        raise ParameterError('Sample covariance sigma_AB^2 = 0 -- cannot compute statistical inefficiency')
+    if sigma2_AB == 0:
+        raise ParameterError(
+            "Sample covariance sigma_AB^2 = 0 -- cannot compute statistical inefficiency"
+        )
 
     # allocate storage for normalized fluctuation correlation function
     C_n = np.zeros([N_max + 1], np.float64)
@@ -476,17 +494,23 @@ def normalizedFluctuationCorrelationFunction(A_n, B_n=None, N_max=None, norm=Tru
     t = 0
     for t in range(0, N_max + 1):
         # compute normalized fluctuation correlation function at time t
-        C_n[t] = np.sum(dA_n[0:(N - t)] * dB_n[t:N] + dB_n[0:(N - t)] * dA_n[t:N]) / (2.0 * float(N - t) * sigma2_AB)
+        C_n[t] = np.sum(dA_n[0 : (N - t)] * dB_n[t:N] + dB_n[0 : (N - t)] * dA_n[t:N]) / (
+            2.0 * float(N - t) * sigma2_AB
+        )
 
     # Return the computed correlation function
     if norm:
         return C_n
     else:
-        return C_n*sigma2_AB + mu_A*mu_B
-#=============================================================================================
+        return C_n * sigma2_AB + mu_A * mu_B
 
 
-def normalizedFluctuationCorrelationFunctionMultiple(A_kn, B_kn=None, N_max=None, norm=True, truncate=False):
+# =============================================================================================
+
+
+def normalizedFluctuationCorrelationFunctionMultiple(
+    A_kn, B_kn=None, N_max=None, norm=True, truncate=False
+):
     """Compute the normalized fluctuation (cross) correlation function of (two) timeseries from multiple timeseries samples.
 
     C(t) = (<A(t) B(t)> - <A><B>) / (<AB> - <A><B>)
@@ -545,8 +569,10 @@ def normalizedFluctuationCorrelationFunctionMultiple(A_kn, B_kn=None, N_max=None
         raise ParameterError("A_kn and B_kn must each be a list of numpy arrays.")
 
     # Ensure the same number of timeseries are stored in A_kn and B_kn.
-    if (len(A_kn) != len(B_kn)):
-        raise ParameterError("A_kn and B_kn must contain corresponding timeseries -- different numbers of timeseries detected in each.")
+    if len(A_kn) != len(B_kn):
+        raise ParameterError(
+            "A_kn and B_kn must contain corresponding timeseries -- different numbers of timeseries detected in each."
+        )
 
     # Determine number of timeseries stored.
     K = len(A_kn)
@@ -556,7 +582,9 @@ def normalizedFluctuationCorrelationFunctionMultiple(A_kn, B_kn=None, N_max=None
         A_n = A_kn[k]
         B_n = B_kn[k]
         if A_n.size != B_n.size:
-            raise ParameterError("A_kn and B_kn must contain corresponding timeseries -- lack of correspondence in timeseries lenghts detected.")
+            raise ParameterError(
+                "A_kn and B_kn must contain corresponding timeseries -- lack of correspondence in timeseries lenghts detected."
+            )
 
     # Get the length of each timeseries.
     N_k = np.zeros([K], np.int32)
@@ -608,9 +636,9 @@ def normalizedFluctuationCorrelationFunctionMultiple(A_kn, B_kn=None, N_max=None
         numerator = 0.0
         denominator = 0.0
         for k in range(K):
-            if (t >= N_k[k]):
+            if t >= N_k[k]:
                 continue  # skip this trajectory if t is longer than the timeseries
-            numerator += np.sum(dA_kn[k][0:(N_k[k] - t)] * dB_kn[k][t:N_k[k]])
+            numerator += np.sum(dA_kn[k][0 : (N_k[k] - t)] * dB_kn[k][t : N_k[k]])
             denominator += float(N_k[k] - t)
             if truncate and numerator < 0:
                 negative = True
@@ -629,8 +657,10 @@ def normalizedFluctuationCorrelationFunctionMultiple(A_kn, B_kn=None, N_max=None
     if norm:
         return C_n[:t]
     else:
-        return C_n[:t]*sigma2_AB + mu_A*mu_B
-#=============================================================================================
+        return C_n[:t] * sigma2_AB + mu_A * mu_B
+
+
+# =============================================================================================
 
 
 def subsampleCorrelatedData(A_t, g=None, fast=False, conservative=False, verbose=False):
@@ -734,7 +764,11 @@ def subsampleCorrelatedData(A_t, g=None, fast=False, conservative=False, verbose
     N = len(indices)
 
     if verbose:
-        logger.info("The resulting subsampled set has {:d} samples (original timeseries had {:d}).".format(N, T))
+        logger.info(
+            "The resulting subsampled set has {:d} samples (original timeseries had {:d}).".format(
+                N, T
+            )
+        )
 
     # Return the list of indices of uncorrelated snapshots.
     return indices
@@ -799,7 +833,7 @@ def detectEquilibration(A_t, fast=True, nskip=1):
         try:
             g_t[t] = statisticalInefficiency(A_t[t:T], fast=fast)
         except ParameterError:  # Fix for issue https://github.com/choderalab/pymbar/issues/122
-            g_t[t] = (T - t + 1)
+            g_t[t] = T - t + 1
         Neff_t[t] = (T - t + 1) / g_t[t]
     Neff_max = Neff_t.max()
     t = Neff_t.argmax()
@@ -842,7 +876,10 @@ def statisticalInefficiency_fft(A_n, mintime=3):
     try:
         import statsmodels.api as sm
     except ImportError as err:
-        err.args = (err.args[0] + "\n You need to install statsmodels to use the FFT based correlation function.",)
+        err.args = (
+            err.args[0]
+            + "\n You need to install statsmodels to use the FFT based correlation function.",
+        )
         raise
 
     # Create np copies of input arguments.
@@ -852,9 +889,9 @@ def statisticalInefficiency_fft(A_n, mintime=3):
     N = A_n.size
 
     C_t = sm.tsa.stattools.acf(A_n, fft=True, unbiased=True, nlags=N)
-    t_grid = np.arange(N).astype('float')
+    t_grid = np.arange(N).astype("float")
     g_t = 2.0 * C_t * (1.0 - t_grid / float(N))
-    
+
     try:
         ind = np.where((C_t <= 0) & (t_grid > mintime))[0][0]
     except IndexError:
@@ -904,14 +941,16 @@ def detectEquilibration_binary_search(A_t, bs_nodes=10):
     start = 1
     end = T - 1
     n_grid = min(bs_nodes, T)
-    
+
     while True:
-        time_grid = np.unique((10 ** np.linspace(np.log10(start), np.log10(end), n_grid)).round().astype('int')) 
+        time_grid = np.unique(
+            (10 ** np.linspace(np.log10(start), np.log10(end), n_grid)).round().astype("int")
+        )
         g_t = np.ones(time_grid.size)
         Neff_t = np.ones(time_grid.size)
-        
+
         for k, t in enumerate(time_grid):
-            if t < T-1:
+            if t < T - 1:
                 g_t[k] = statisticalInefficiency_fft(A_t[t:])
                 Neff_t[k] = (T - t + 1) / g_t[k]
 
@@ -919,10 +958,10 @@ def detectEquilibration_binary_search(A_t, bs_nodes=10):
         k = Neff_t.argmax()
         t = time_grid[k]
         g = g_t[k]
-        
-        if (end - start < 4):
+
+        if end - start < 4:
             break
-        
+
         if k == 0:
             start = time_grid[0]
             end = time_grid[1]
@@ -932,5 +971,5 @@ def detectEquilibration_binary_search(A_t, bs_nodes=10):
         else:
             start = time_grid[k - 1]
             end = time_grid[k + 1]
-        
+
     return (t, g, Neff_max)

--- a/pymbar/utils.py
+++ b/pymbar/utils.py
@@ -71,7 +71,7 @@ def kln_to_kn(kln, N_k=None, cleanup=False):
             kn[:, i] = kln[k, :, ik]
             i += 1
     if cleanup:
-        del(kln)  # very big, let's explicitly delete
+        del kln  # very big, let's explicitly delete
 
     return kn
 
@@ -93,7 +93,7 @@ def kn_to_n(kn, N_k=None, cleanup=False):
     u_n: np.ndarray, float, shape=(N)
     """
 
-    #print "warning: KxN arrays deprecated; convering into new preferred N shape"
+    # print "warning: KxN arrays deprecated; convering into new preferred N shape"
     # rewrite into kn shape
 
     # rewrite into kn shape
@@ -102,7 +102,7 @@ def kn_to_n(kn, N_k=None, cleanup=False):
     if N_k is None:
         # We assume that all N_k are N_max.
         # Not really an easier way to do this without being given the answer.
-        N_k = N_max*np.ones([K], dtype=np.int64)
+        N_k = N_max * np.ones([K], dtype=np.int64)
     N = np.sum(N_k)
 
     n = np.zeros([N], dtype=np.float64)
@@ -112,12 +112,21 @@ def kn_to_n(kn, N_k=None, cleanup=False):
             n[i] = kn[k, ik]
             i += 1
     if cleanup:
-        del(kn)  # very big, let's explicitly delete
+        del kn  # very big, let's explicitly delete
     return n
 
 
-def ensure_type(val, dtype, ndim, name, length=None, can_be_none=False, shape=None,
-                warn_on_cast=True, add_newaxis_on_deficient_ndim=False):
+def ensure_type(
+    val,
+    dtype,
+    ndim,
+    name,
+    length=None,
+    can_be_none=False,
+    shape=None,
+    warn_on_cast=True,
+    add_newaxis_on_deficient_ndim=False,
+):
     """Typecheck the size, shape and dtype of a numpy array, with optional
     casting.
 
@@ -175,33 +184,41 @@ def ensure_type(val, dtype, ndim, name, length=None, can_be_none=False, shape=No
         if add_newaxis_on_deficient_ndim and ndim == 1 and np.isscalar(val):
             val = np.array([val])
         else:
-            raise TypeError(("{} must be numpy array. "
-                             " You supplied type {}".format(name, type(val))))
+            raise TypeError(
+                ("{} must be numpy array. " " You supplied type {}".format(name, type(val)))
+            )
 
     if warn_on_cast and val.dtype != dtype:
-        warnings.warn("Casting {} dtype={} to {} ".format(name, val.dtype, dtype),
-                      TypeCastPerformanceWarning)
+        warnings.warn(
+            "Casting {} dtype={} to {} ".format(name, val.dtype, dtype), TypeCastPerformanceWarning
+        )
 
     if not val.ndim == ndim:
         if add_newaxis_on_deficient_ndim and val.ndim + 1 == ndim:
             val = val[np.newaxis, ...]
         else:
-            raise ValueError(("{} must be ndim {}. "
-                              "You supplied {}".format(name, ndim, val.ndim)))
+            raise ValueError(
+                ("{} must be ndim {}. " "You supplied {}".format(name, ndim, val.ndim))
+            )
 
     val = np.ascontiguousarray(val, dtype=dtype)
 
     if length is not None and len(val) != length:
-        raise ValueError(("{} must be length {}. "
-                          "You supplied {}.".format(name, length, len(val))))
+        raise ValueError(
+            ("{} must be length {}. " "You supplied {}.".format(name, length, len(val)))
+        )
 
     if shape is not None:
         # the shape specified given by the user can look like (None, None 3)
         # which indicates that ANY length is accepted in dimension 0 or
         # dimension 1
         sentenel = object()
-        error = ValueError(("{} must be shape {}. You supplied  "
-                            "{}".format(name, str(shape).replace('None', 'Any'), val.shape)))
+        error = ValueError(
+            (
+                "{} must be shape {}. You supplied  "
+                "{}".format(name, str(shape).replace("None", "Any"), val.shape)
+            )
+        )
         for a, b in zip_longest(val.shape, shape, fillvalue=sentenel):
             if a is sentenel or b is sentenel:
                 # if the sentenel was reached, it means that the ndim didn't
@@ -321,7 +338,7 @@ def logsumexp(a, axis=None, b=None, use_numexpr=True):
     return out
 
 
-def check_w_normalized(W, N_k, tolerance = 1.0e-4):
+def check_w_normalized(W, N_k, tolerance=1.0e-4):
     """Check the weight matrix W is properly normalized. The sum over N should be 1, and the sum over k by N_k should aslo be 1
 
     Parameters
@@ -343,22 +360,29 @@ def check_w_normalized(W, N_k, tolerance = 1.0e-4):
     [N, K] = W.shape
 
     column_sums = np.sum(W, axis=0)
-    badcolumns = (np.abs(column_sums - 1) > tolerance)
+    badcolumns = np.abs(column_sums - 1) > tolerance
     if np.any(badcolumns):
         which_badcolumns = np.arange(K)[badcolumns]
         firstbad = which_badcolumns[0]
         raise ParameterError(
-            'Warning: Should have \\sum_n W_nk = 1. Actual column sum for state {:d} was {:f}. {:d} other columns have similar problems'.format(firstbad, column_sums[firstbad], np.sum(badcolumns)))
+            "Warning: Should have \\sum_n W_nk = 1. Actual column sum for state {:d} was {:f}. {:d} other columns have similar problems".format(
+                firstbad, column_sums[firstbad], np.sum(badcolumns)
+            )
+        )
 
     row_sums = np.sum(W * N_k, axis=1)
-    badrows = (np.abs(row_sums - 1) > tolerance)
+    badrows = np.abs(row_sums - 1) > tolerance
     if np.any(badrows):
         which_badrows = np.arange(N)[badrows]
         firstbad = which_badrows[0]
         raise ParameterError(
-            'Warning: Should have \\sum_k N_k W_nk = 1.  Actual row sum for sample {:d} was {:f}. {:d} other rows have similar problems'.format(firstbad, row_sums[firstbad], np.sum(badrows)))
+            "Warning: Should have \\sum_k N_k W_nk = 1.  Actual row sum for sample {:d} was {:f}. {:d} other rows have similar problems".format(
+                firstbad, row_sums[firstbad], np.sum(badrows)
+            )
+        )
 
     return
+
 
 # ============================================================================================
 # Exception classes

--- a/pymbar/utils_for_testing.py
+++ b/pymbar/utils_for_testing.py
@@ -20,21 +20,43 @@
 ##############################################################################
 
 import numpy as np
-from numpy.testing import (assert_allclose, assert_almost_equal,
-                           assert_approx_equal, assert_array_almost_equal, assert_array_almost_equal_nulp,
-                           assert_array_equal, assert_array_less, assert_array_max_ulp, assert_equal,
-                           assert_raises, assert_string_equal, assert_warns)
+from numpy.testing import (
+    assert_allclose,
+    assert_almost_equal,
+    assert_approx_equal,
+    assert_array_almost_equal,
+    assert_array_almost_equal_nulp,
+    assert_array_equal,
+    assert_array_less,
+    assert_array_max_ulp,
+    assert_equal,
+    assert_raises,
+    assert_string_equal,
+    assert_warns,
+)
 import warnings
 import contextlib
 
 from pymbar.testsystems import HarmonicOscillatorsTestCase, ExponentialTestCase
 
-__all__ = ['assert_allclose', 'assert_almost_equal', 'assert_approx_equal',
-           'assert_array_almost_equal', 'assert_array_almost_equal_nulp',
-           'assert_array_equal', 'assert_array_less', 'assert_array_max_ulp',
-           'assert_equal', 'assert_raises', 'assert_string_equal', 'assert_warns',
-           'suppress_derivative_warnings_for_tests', 'suppress_matrix_warnings_for_tests',
-           'oscillators', 'exponentials']
+__all__ = [
+    "assert_allclose",
+    "assert_almost_equal",
+    "assert_approx_equal",
+    "assert_array_almost_equal",
+    "assert_array_almost_equal_nulp",
+    "assert_array_equal",
+    "assert_array_less",
+    "assert_array_max_ulp",
+    "assert_equal",
+    "assert_raises",
+    "assert_string_equal",
+    "assert_warns",
+    "suppress_derivative_warnings_for_tests",
+    "suppress_matrix_warnings_for_tests",
+    "oscillators",
+    "exponentials",
+]
 
 ##############################################################################
 # functions
@@ -47,9 +69,11 @@ def suppress_derivative_warnings_for_tests():
     Suppress specific warnings and then reset when done, used as a with suppress_warnings():
     """
     # Supress the warnings when Jacobian and Hessian information is not used in a specific solver
-    warnings.filterwarnings('ignore', '.*does not use the Jacobian.*')
-    warnings.filterwarnings('ignore', '.*does not use Hessian.*')
-    warnings.filterwarnings('ignore', '.*parameter will change to the default of machine precision.*')
+    warnings.filterwarnings("ignore", ".*does not use the Jacobian.*")
+    warnings.filterwarnings("ignore", ".*does not use Hessian.*")
+    warnings.filterwarnings(
+        "ignore", ".*parameter will change to the default of machine precision.*"
+    )
     yield
     # Clear warning filters
     warnings.resetwarnings()
@@ -61,7 +85,7 @@ def suppress_matrix_warnings_for_tests():
     Suppress specific warnings and then reset when done, used as a with suppress_warnings():
     """
     # Supress the numpy matrix warnings
-    warnings.filterwarnings('ignore', '.*the matrix subclass is not*')
+    warnings.filterwarnings("ignore", ".*the matrix subclass is not*")
     yield
     # Clear warning filters
     warnings.resetwarnings()
@@ -71,9 +95,9 @@ def oscillators(n_states, n_samples, provide_test=False):
     name = f"{n_states}x{n_samples} oscillators"
     O_k = np.linspace(1, 5, n_states)
     k_k = np.linspace(1, 3, n_states)
-    N_k = (np.ones(n_states) * n_samples).astype('int')
+    N_k = (np.ones(n_states) * n_samples).astype("int")
     test = HarmonicOscillatorsTestCase(O_k, k_k)
-    x_n, u_kn, N_k_output, s_n = test.sample(N_k, mode='u_kn')
+    x_n, u_kn, N_k_output, s_n = test.sample(N_k, mode="u_kn")
     returns = [name, u_kn, N_k_output, s_n]
     if provide_test:
         returns.append(test)
@@ -83,9 +107,9 @@ def oscillators(n_states, n_samples, provide_test=False):
 def exponentials(n_states, n_samples, provide_test=False):
     name = f"{n_states}x{n_samples} exponentials"
     rates = np.linspace(1, 3, n_states)
-    N_k = (np.ones(n_states) * n_samples).astype('int')
+    N_k = (np.ones(n_states) * n_samples).astype("int")
     test = ExponentialTestCase(rates)
-    x_n, u_kn, N_k_output, s_n = test.sample(N_k, mode='u_kn')
+    x_n, u_kn, N_k_output, s_n = test.sample(N_k, mode="u_kn")
     returns = [name, u_kn, N_k_output, s_n]
     if provide_test:
         returns.append(test)


### PR DESCRIPTION
Command applied:

```
$> black -l 99 pymbar/ --exclude pymbar/old_mbar.py
reformatted /home/jaime/devel/py/choderalab/pymbar/pymbar/__init__.py
reformatted /home/jaime/devel/py/choderalab/pymbar/pymbar/exp.py
reformatted /home/jaime/devel/py/choderalab/pymbar/pymbar/tests/test_covariance.py
reformatted /home/jaime/devel/py/choderalab/pymbar/pymbar/tests/test_bar.py
reformatted /home/jaime/devel/py/choderalab/pymbar/pymbar/bar.py
reformatted /home/jaime/devel/py/choderalab/pymbar/pymbar/tests/test_mbar_solvers.py
reformatted /home/jaime/devel/py/choderalab/pymbar/pymbar/tests/test_exp.py
reformatted /home/jaime/devel/py/choderalab/pymbar/pymbar/mbar_solvers.py
reformatted /home/jaime/devel/py/choderalab/pymbar/pymbar/testsystems/__init__.py
reformatted /home/jaime/devel/py/choderalab/pymbar/pymbar/confidenceintervals.py
reformatted /home/jaime/devel/py/choderalab/pymbar/pymbar/testsystems/exponential_distributions.py
reformatted /home/jaime/devel/py/choderalab/pymbar/pymbar/tests/test_timeseries.py
reformatted /home/jaime/devel/py/choderalab/pymbar/pymbar/testsystems/gaussian_work.py
reformatted /home/jaime/devel/py/choderalab/pymbar/pymbar/tests/test_utils.py
reformatted /home/jaime/devel/py/choderalab/pymbar/pymbar/utils_for_testing.py
reformatted /home/jaime/devel/py/choderalab/pymbar/pymbar/testsystems/harmonic_oscillators.py
reformatted /home/jaime/devel/py/choderalab/pymbar/pymbar/utils.py
reformatted /home/jaime/devel/py/choderalab/pymbar/pymbar/tests/test_mbar.py
reformatted /home/jaime/devel/py/choderalab/pymbar/pymbar/tests/test_pmf.py
reformatted /home/jaime/devel/py/choderalab/pymbar/pymbar/mbar.py
reformatted /home/jaime/devel/py/choderalab/pymbar/pymbar/timeseries.py
reformatted /home/jaime/devel/py/choderalab/pymbar/pymbar/pmf.py
All done! ✨ 🍰 ✨
22 files reformatted, 2 files left unchanged.
```

Check mode (`--check`) is being applied at CI to detect deviations from format. This means contributors are _expected_ to apply `black` during edition. This can be easily achieved on save if you configure your IDE properly.

We are using a line length of 99 characters, so make sure to add that to the config! In the future we could migrate to `pyproject.toml` for this kind of options.

Example config in VS Code + official Python extension:

![image](https://user-images.githubusercontent.com/2559438/77087609-9c6c2280-6a03-11ea-8ae2-8e70c3c960ac.png)

![image](https://user-images.githubusercontent.com/2559438/77087506-81011780-6a03-11ea-9593-836d683ed1f5.png)

![image](https://user-images.githubusercontent.com/2559438/77087541-8a8a7f80-6a03-11ea-94b3-7164978289a3.png)
