### PR TITLE
change anaconda channel from omnia to conda-forge

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -14,7 +14,7 @@ conda (recommended)
 The easiest way to install the ``pymbar`` release is via `conda <http://conda.pydata.org>`_:
 
 ::
-   $ conda install -c omnia pymbar
+   $ conda install -c conda-forge pymbar
 
 pip
 ---


### PR DESCRIPTION
Addresses issue #396 

Per the comment by @Lnaden, conda-forge should be the channel used when installing pymbar via anaconda; however, the installation instructions in the getting started section still specify to use omnia.

I ran across this issue due to being unable to install via omnia when using python 3.7