### PR TITLE
Backport PR 350

### DIFF
--- a/pymbar/bar.py
+++ b/pymbar/bar.py
@@ -46,6 +46,7 @@ __license__ = "MIT"
 #=============================================================================================
 # IMPORTS
 #=============================================================================================
+import warnings
 import numpy as np
 import numpy.linalg
 from pymbar.utils import ParameterError, ConvergenceError, BoundsError, logsumexp
@@ -218,6 +219,8 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
     >>> results = BAR(w_F, w_R, method='bisection', return_dict=True)
 
     """
+    if return_dict:
+        warnings.warn("In pymbar 4+, this function will always behave like `return_dict=True`", FutureWarning)
 
     result_vals = dict()
     # if computing nonoptimized, one step value, we set the max-iterations

--- a/pymbar/bar.py
+++ b/pymbar/bar.py
@@ -219,7 +219,7 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
     >>> results = BAR(w_F, w_R, method='bisection', return_dict=True)
 
     """
-    if return_dict:
+    if not return_dict:
         warnings.warn("In pymbar 4+, this function will always behave like `return_dict=True`", FutureWarning)
 
     result_vals = dict()

--- a/pymbar/bar.py
+++ b/pymbar/bar.py
@@ -228,6 +228,12 @@ def BAR(w_F, w_R, DeltaF=0.0, compute_uncertainty=True, uncertainty_method='BAR'
         method = 'self-consistent-iteration'
         DeltaF_initial = DeltaF
 
+    if method not in ['self-consistent-iteration', 'false-position', 'bisection']:
+        raise ParameterError('method {:d} is not defined for BAR'.format(method))
+
+    if uncertainty_method not in ['BAR', 'MBAR']:
+        raise ParameterError('uncertainty_method {:d} is not defined for BAR'.format(uncertainty_method))
+
     if method == 'self-consistent-iteration':
         nfunc = 0
 

--- a/pymbar/confidenceintervals.py
+++ b/pymbar/confidenceintervals.py
@@ -231,7 +231,7 @@ def generate_confidence_intervals(replicates, K):
                     print(replicate['error'])
                     print("destimated")
                     print(replicate['destimated'])
-                    raise ArithmaticError("Encountered isnan in computation")
+                    raise ArithmeticError("Encountered isnan in computation")
                 else:
                     if abs(replicate['error']) <= alpha * replicate['destimated']:
                         a += 1.0
@@ -246,7 +246,7 @@ def generate_confidence_intervals(replicates, K):
                         print(replicate['error'])
                         print("destimated")
                         print(replicate['destimated'])
-                        raise ArithmaticError("Encountered isnan in computation")
+                        raise ArithmeticError("Encountered isnan in computation")
                     else:
                         if abs(replicate['error'][i]) <= alpha * replicate['destimated'][i]:
                             a += 1.0
@@ -262,7 +262,7 @@ def generate_confidence_intervals(replicates, K):
                             print(replicate['error'])
                             print("ij_estimated")
                             print(replicate['destimated'])
-                            raise ArithmaticError("Encountered isnan in computation")
+                            raise ArithmeticError("Encountered isnan in computation")
                         else:
                             if abs(replicate['error'][i, j]) <= alpha * replicate['destimated'][i, j]:
                                 a += 1.0

--- a/pymbar/exp.py
+++ b/pymbar/exp.py
@@ -96,7 +96,7 @@ def EXP(w_F, compute_uncertainty=True, is_timeseries=False, return_dict=False):
     Reverse free energy difference is -1.073 +- 0.082 kT
 
     """
-    if return_dict:
+    if not return_dict:
         warnings.warn("In pymbar 4+, this function will always behave like `return_dict=True`", FutureWarning)
         
     result_vals = dict()
@@ -187,7 +187,7 @@ def EXP_gauss(w_F, compute_uncertainty=True, is_timeseries=False, return_dict=Fa
     Reverse Gaussian approximated free energy difference is -1.073 +- 0.080 kT
 
     """
-    if return_dict:
+    if not return_dict:
         warnings.warn("In pymbar 4+, this function will always behave like `return_dict=True`", FutureWarning)
         
     # Get number of work measurements.

--- a/pymbar/exp.py
+++ b/pymbar/exp.py
@@ -44,6 +44,7 @@ __license__ = "MIT"
 #=============================================================================================
 # IMPORTS
 #=============================================================================================
+import warnings
 import numpy as np
 from pymbar.utils import logsumexp
 from pymbar._deprecate import _deprecate, warn
@@ -95,7 +96,9 @@ def EXP(w_F, compute_uncertainty=True, is_timeseries=False, return_dict=False):
     Reverse free energy difference is -1.073 +- 0.082 kT
 
     """
-
+    if return_dict:
+        warnings.warn("In pymbar 4+, this function will always behave like `return_dict=True`", FutureWarning)
+        
     result_vals = dict()
     result_list = []
 
@@ -184,7 +187,9 @@ def EXP_gauss(w_F, compute_uncertainty=True, is_timeseries=False, return_dict=Fa
     Reverse Gaussian approximated free energy difference is -1.073 +- 0.080 kT
 
     """
-
+    if return_dict:
+        warnings.warn("In pymbar 4+, this function will always behave like `return_dict=True`", FutureWarning)
+        
     # Get number of work measurements.
     T = float(np.size(w_F))  # number of work measurements
 

--- a/pymbar/mbar.py
+++ b/pymbar/mbar.py
@@ -455,7 +455,7 @@ class MBAR:
         >>> results = mbar.compute_overlap(return_dict=True)
 
         """
-        if return_dict:
+        if not return_dict:
             warnings.warn("In pymbar 4+, this function will always behave like `return_dict=True`", FutureWarning)
 
         W = np.matrix(self.weights(), np.float64)
@@ -531,7 +531,7 @@ class MBAR:
         >>> results = mbar.compute_free_energy_differences(return_dict=True)
 
         """
-        if return_dict:
+        if not return_dict:
             warnings.warn("In pymbar 4+, this function will always behave like `return_dict=True`", FutureWarning)
 
         Deltaf_ij, dDeltaf_ij, Theta_ij = None, None, None  # By default, returns None for dDelta and Theta
@@ -1221,7 +1221,7 @@ class MBAR:
         >>> mbar = MBAR(u_kn, N_k)
         >>> results = mbar.compute_perturbed_free_energies(u_kn, return_dict=True)
         """
-        if return_dict:
+        if not return_dict:
             warnings.warn("In pymbar 4+, this function will always behave like `return_dict=True`", FutureWarning)
 
         # Convert to np matrix.
@@ -1314,7 +1314,7 @@ class MBAR:
         >>> results = mbar.compute_entropy_and_enthalpy(return_dict=True)
 
         """
-        if return_dict:
+        if not return_dict:
             warnings.warn("In pymbar 4+, this function will always behave like `return_dict=True`", FutureWarning)
 
         if verbose:

--- a/pymbar/mbar.py
+++ b/pymbar/mbar.py
@@ -38,6 +38,7 @@ This module contains implementations of
 """
 
 import math
+import warnings
 import numpy as np
 import numpy.linalg as linalg
 from pymbar import mbar_solvers
@@ -411,7 +412,7 @@ class MBAR:
     computeEffectiveSampleNumber = _deprecate(compute_effective_sample_number, "computeEffectiveSampleNumber")
     
     # =========================================================================
-    def compute_overlap(self, return_dict=True):
+    def compute_overlap(self, return_dict=False):
         """
         Compute estimate of overlap matrix between the states.
 
@@ -454,6 +455,8 @@ class MBAR:
         >>> results = mbar.compute_overlap(return_dict=True)
 
         """
+        if return_dict:
+            warnings.warn("In pymbar 4+, this function will always behave like `return_dict=True`", FutureWarning)
 
         W = np.matrix(self.weights(), np.float64)
         O = np.multiply(self.N_k, W.T * W)
@@ -528,6 +531,9 @@ class MBAR:
         >>> results = mbar.compute_free_energy_differences(return_dict=True)
 
         """
+        if return_dict:
+            warnings.warn("In pymbar 4+, this function will always behave like `return_dict=True`", FutureWarning)
+
         Deltaf_ij, dDeltaf_ij, Theta_ij = None, None, None  # By default, returns None for dDelta and Theta
 
         # Compute free energy differences.
@@ -1215,6 +1221,8 @@ class MBAR:
         >>> mbar = MBAR(u_kn, N_k)
         >>> results = mbar.compute_perturbed_free_energies(u_kn, return_dict=True)
         """
+        if return_dict:
+            warnings.warn("In pymbar 4+, this function will always behave like `return_dict=True`", FutureWarning)
 
         # Convert to np matrix.
         u_ln = np.array(u_ln, dtype=np.float64)
@@ -1306,6 +1314,9 @@ class MBAR:
         >>> results = mbar.compute_entropy_and_enthalpy(return_dict=True)
 
         """
+        if return_dict:
+            warnings.warn("In pymbar 4+, this function will always behave like `return_dict=True`", FutureWarning)
+
         if verbose:
             print("Computing average energy and entropy by MBAR.")
 
@@ -1466,8 +1477,7 @@ class MBAR:
         >>> f_i_corrected = results['f_i'] - np.log(bin_widths)
 
         """
-        from warnings import warn
-        warn("This method will be deprecated in pymbar v4. Equivalent functionality will be available in `pymbar.fes.FES`.", DeprecationWarning)
+        warnings.warn("This method will be deprecated in pymbar v4. Equivalent functionality will be available in `pymbar.fes.FES`.", DeprecationWarning)
         # Verify that no PMF bins are empty -- we can't deal with empty bins,
         # because the free energy is infinite.
         for i in range(nbins):

--- a/pymbar/tests/test_bar.py
+++ b/pymbar/tests/test_bar.py
@@ -1,0 +1,102 @@
+"""Test bar by performing statistical tests on a set of model systems
+for which the true free energy differences can be computed analytically.
+"""
+
+import numpy as np
+import pytest
+from pymbar import bar as pybar 
+from pymbar.testsystems import harmonic_oscillators, exponential_distributions
+from pymbar.utils_for_testing import assert_equal, assert_almost_equal
+
+precision = 8  # the precision for systems that do have analytical results that should be matched.
+# Scales the z_scores so that we can reject things that differ at the ones decimal place.  TEMPORARY HACK
+z_scale_factor = 12.0
+# 0.5 is rounded to 1, so this says they must be within 3.0 sigma
+N_k = np.array([500, 800])
+
+
+def generate_ho(O_k = np.array([1.0, 2.0]), K_k = np.array([0.5, 2.0])):
+    return "Harmonic Oscillators", harmonic_oscillators.HarmonicOscillatorsTestCase(O_k, K_k)
+
+
+def generate_exp(rates=np.array([1.0, 4.0])):  # Rates, e.g. Lambda
+    return "Exponentials", exponential_distributions.ExponentialTestCase(rates)
+
+
+system_generators = [generate_ho, generate_exp]
+
+
+@pytest.fixture(scope="module", params=system_generators)
+def bar_and_test(request):
+    name, test = request.param()
+    w_F, w_R, N_k_output = test.sample(N_k, mode='wFwR')
+    assert_equal(N_k, N_k_output)
+    bars = dict()
+    # can't return method, because BAR is just a function
+    bars['sci'] = pybar.BAR(w_F,w_R,method='self-consistent-iteration',return_dict=True)
+    bars['bis'] = pybar.BAR(w_F,w_R,method='bisection',return_dict=True)
+    bars['fp'] = pybar.BAR(w_F,w_R,method='false-position',return_dict=True)
+    bars['dBAR'] = pybar.BAR(w_F,w_R,uncertainty_method='BAR',return_dict=True)
+    bars['dMBAR'] = pybar.BAR(w_F,w_R,uncertainty_method='MBAR',return_dict=True)
+
+    yield_bundle = {
+        'bars': bars,
+        'test': test,
+        'w_F': w_F,
+        'w_R': w_R,
+    }
+    yield yield_bundle
+
+
+@pytest.mark.parametrize("system_generator", system_generators)
+def test_sample(system_generator):
+    """Draw samples via test object."""
+
+    name, test = system_generator()
+    print(name)
+
+    w_F, w_R, N_k = test.sample([10,8], mode='wFwR')
+    w_F, w_R, N_k = test.sample([1,1], mode='wFwR')
+    w_F, w_R, N_k = test.sample([10,0], mode='wFwR')
+    w_F, w_R, N_k = test.sample([0,5], mode='wFwR')
+
+def test_bar_free_energies(bar_and_test):
+
+    """Can BAR calculate moderately correct free energy differences?"""
+
+    bars, test = bar_and_test['bars'], bar_and_test['test']
+
+    fe0 = test.analytical_free_energies()
+    fe0 = fe0[1:] - fe0[0]
+
+    results_fp = bars['fp']
+    fe_fp = results_fp['Delta_f']
+    dfe_fp = results_fp['dDelta_f']
+    z = (fe_fp - fe0) / dfe_fp
+    assert_almost_equal(z / z_scale_factor, np.zeros(len(z)), decimal=0)
+
+    results_sci = bars['sci']
+    fe_sci = results_sci['Delta_f']
+    dfe_sci = results_sci['dDelta_f']
+    z = (fe_sci - fe0) / dfe_sci
+    assert_almost_equal(z / z_scale_factor, np.zeros(len(z)), decimal=0)
+
+    results_bis = bars['bis']
+    fe_bis = results_bis['Delta_f']
+    dfe_bis = results_bis['dDelta_f']
+    z = (fe_bis - fe0) / dfe_bis
+    assert_almost_equal(z / z_scale_factor, np.zeros(len(z)), decimal=0)
+
+    # make sure the different methods are nearly equal.
+    assert_almost_equal(fe_bis, fe_fp, decimal=8)
+    assert_almost_equal(fe_sci, fe_bis, decimal=8)
+    assert_almost_equal(fe_fp, fe_bis, decimal=8)
+
+    # Test uncertainty methods
+    results_dBAR = bars['dBAR']
+    dfe_bar = results_dBAR['dDelta_f']
+    results_dMBAR = bars['dMBAR']
+    dfe_mbar = results_dMBAR['dDelta_f']
+
+    # not sure exactly how close they need to be for sample problems?
+    assert_almost_equal(dfe_bar,dfe_mbar,decimal=3)

--- a/pymbar/tests/test_exp.py
+++ b/pymbar/tests/test_exp.py
@@ -1,0 +1,97 @@
+"""Test exp by performing statistical tests on a set of model systems
+for which the true free energy differences can be computed analytically.
+"""
+
+import numpy as np
+import pytest
+from pymbar import exp as pyexp 
+from pymbar.testsystems import harmonic_oscillators, exponential_distributions
+from pymbar.utils_for_testing import assert_equal, assert_almost_equal
+
+precision = 8  # the precision for systems that do have analytical results that should be matched.
+# Scales the z_scores so that we can reject things that differ at the ones decimal place.  TEMPORARY HACK
+z_scale_factor = 12.0
+# 0.5 is rounded to 1, so this says they must be within 3.0 sigma
+N_k = np.array([50000, 100000])
+
+
+def generate_ho(O_k = np.array([1.0, 2.0]), K_k = np.array([0.5, 1.0])):
+    return "Harmonic Oscillators", harmonic_oscillators.HarmonicOscillatorsTestCase(O_k, K_k)
+
+
+def generate_exp(rates=np.array([1.0, 4.0])):  # Rates, e.g. Lambda
+    return "Exponentials", exponential_distributions.ExponentialTestCase(rates)
+
+system_generators = [generate_ho, generate_exp]
+
+@pytest.fixture(scope="module", params=system_generators)
+def exp_and_test(request):
+    name, test = request.param()
+    w_F, w_R, N_k_output = test.sample(N_k, mode='wFwR')
+    assert_equal(N_k, N_k_output)
+    exps = dict()
+    # can't return method, because EXP is just a function
+    exps['F'] = pyexp.EXP(w_F, return_dict=True)
+    exps['R'] = pyexp.EXP(w_R, return_dict=True)
+    exps['gF'] = pyexp.EXPGauss(w_F, return_dict=True)
+    exps['gR'] = pyexp.EXPGauss(w_R, return_dict=True)
+
+    yield_bundle = {
+        'exps': exps,
+        'test': test,
+        'w_F': w_F,
+        'w_R': w_R,
+    }
+    yield yield_bundle
+
+
+@pytest.mark.parametrize("system_generator", system_generators)
+def test_sample(system_generator):
+    """Draw samples via test object."""
+
+    name, test = system_generator()
+    print(name)
+
+    w_F, w_R, N_k = test.sample([10,8], mode='wFwR')
+    w_F, w_R, N_k = test.sample([1,1], mode='wFwR')
+    w_F, w_R, N_k = test.sample([10,0], mode='wFwR')
+    w_F, w_R, N_k = test.sample([0,5], mode='wFwR')
+
+def test_EXP_free_energies(exp_and_test):
+
+    """Can EXP calculate moderately correct free energy differences?"""
+
+    exps, test = exp_and_test['exps'], exp_and_test['test']
+
+    fe0 = test.analytical_free_energies()
+    fe0 = fe0[1:] - fe0[0]
+
+    results_F = exps['F']
+    fe_F = results_F['Delta_f']
+    dfe_F = results_F['dDelta_f']
+    z = (fe_F - fe0) / dfe_F
+    assert_almost_equal(z / z_scale_factor, np.zeros(len(z)), decimal=0)
+
+    results_R = exps['R']
+    fe_R = -results_R['Delta_f']
+    dfe_R = results_R['dDelta_f']
+    z = (fe_R - fe0) / dfe_R
+    assert_almost_equal(z / z_scale_factor, np.zeros(len(z)), decimal=0)
+
+    # turning off Gaussian comparisons because it's not clear how accurate they should be!  
+
+    results_gF = exps['gF']
+    fe_gF = results_gF['Delta_f']
+    dfe_gF = results_gF['dDelta_f']
+    z = (fe_gF - fe0) / dfe_gF
+    #assert_almost_equal(z / z_scale_factor, np.zeros(len(z)), decimal=0)
+
+    results_gR = exps['gR']
+    fe_gR = -results_gR['Delta_f']
+    dfe_gR = results_gR['dDelta_f']
+    z = (fe_gR - fe0) / dfe_gR
+    #assert_almost_equal(z / z_scale_factor, np.zeros(len(z)), decimal=0)
+
+    # make sure the different methods are nearly equal for these systems (within uncertainty)
+    z = np.abs(fe_R - fe_F) / np.sqrt(dfe_R**2 + dfe_F**2)
+    assert_almost_equal(z / z_scale_factor, 0.0, decimal=0)

--- a/pymbar/tests/test_mbar.py
+++ b/pymbar/tests/test_mbar.py
@@ -278,7 +278,7 @@ def test_mbar_computeOverlap():
         name, test = system_generator()
         x_n, u_kn, N_k_output, s_n = test.sample(N_k, mode='u_kn')
         mbar = MBAR(u_kn, N_k)
-        results = mbar.computeOverlap()
+        results = mbar.computeOverlap(return_dict=True)
         overlap_scalar = results['scalar']
         eigenval = results['eigenvalues']
         O = results['matrix']

--- a/pymbar/testsystems/harmonic_oscillators.py
+++ b/pymbar/testsystems/harmonic_oscillators.py
@@ -35,6 +35,8 @@ class HarmonicOscillatorsTestCase(object):
 
     >>> (x_kn, u_kln, N_k) = testcase.sample(N_k=[10, 20, 30, 40, 50], mode='u_kln')
     >>> (x_n, u_kn, N_k, s_n) = testcase.sample(N_k=[10, 20, 30, 40, 50], mode='u_kn')
+    >>> testcase = HarmonicOscillatorsTestCase(O_k=[0, 1], K_k=[1, 2])
+    >>> (w_F, w_R, N_k) = testcase.sample(N_k=[40, 50], mode='wFwR')
 
     """
 
@@ -108,6 +110,7 @@ class HarmonicOscillatorsTestCase(object):
         mode : str, optional, default='u_kn'
             If 'u_kln', return K x K x N_max matrix where u_kln[k,l,n] is reduced potential of sample n from state k evaluated at state l.
             If 'u_kn', return K x N_tot matrix where u_kn[k,n] is reduced potential of sample n (in concatenated indexing) evaluated at state k.
+            If 'wFwR', check that len(N_k) involves only two states, and calculate the forward and reverse work distributions.
 
         seed: int, optional, default=None.  Provides control over the random seed for replicability.
 
@@ -130,6 +133,15 @@ class HarmonicOscillatorsTestCase(object):
            u_kln[k,l,n] is reduced potential of sample n from state k evaluated at state l.
         N_k : np.ndarray, shape=(n_states), dtype=int32
            N_k[k] is the number of samples generated from state k
+        
+        if mode == 'wFwR':
+
+        w_F : np.ndarray, shape=(N_k[0]), dtype=float   
+            Work generated switching from state 0 to 1
+        w_R : np.ndaarry, shape=(N_k[1]), dtype=float
+            Work generated switching from state 1 to 0
+        N_k : np.ndarray, shape=(2), dtype=float
+           N_k[k] is the number of samples generated from state k
 
         """
 
@@ -138,6 +150,9 @@ class HarmonicOscillatorsTestCase(object):
         N_k = np.array(N_k, np.int32)
         if len(N_k) != self.n_states:
             raise Exception("N_k has %d states while self.n_states has %d states." % (len(N_k), self.n_states))
+        
+        if mode == 'wFwR' and len(N_k) != 2:
+            raise Exception("N_k has {:d} states instead of 2, we cannot generate forward and reverse work distributions".format(len(N_k)))
 
         N_max = N_k.max()  # maximum number of samples per state
         N_tot = N_k.sum()  # total number of samples
@@ -165,6 +180,8 @@ class HarmonicOscillatorsTestCase(object):
             return x_n, u_kn, N_k, s_n
         elif (mode == 'u_kln'):
             return x_kn, u_kln, N_k
+        elif (mode == 'wFwR'):
+            return u_kln[0,1,:N_k[0]]-u_kln[0,0,:N_k[0]], u_kln[1,0,:N_k[1]]-u_kln[1,1,:N_k[1]], N_k
         else:
             raise Exception("Unknown mode '%s'" % mode)
 


### PR DESCRIPTION
Bring #350 and fixes to v3 -- addresses https://github.com/choderalab/pymbar/issues/364#issuecomment-592150921

I have also added deprecation warnings to the future behavior of `return_dict` here. Is that going to be a keyword option in v4 or just the default behavior with no flags?

I might have also fixed a bug in 3.0.5, where return_dict was still True by default in one method.