### PR TITLE
Update README installation instructions from -c omnia to -c conda-forge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/choderalab/pymbar.png)](https://travis-ci.org/choderalab/pymbar)
-[![Anaconda Cloud Downloads Badge](https://anaconda.org/omnia/pymbar/badges/downloads.svg)](https://anaconda.org/omnia/pymbar)
-[![Anaconda Cloud Badge](https://anaconda.org/omnia/pymbar/badges/installer/conda.svg)](https://anaconda.org/omnia/pymbar)
+[![Anaconda Cloud Downloads Badge](https://anaconda.org/conda-forge/pymbar/badges/downloads.svg)](https://anaconda.org/omnia/pymbar)
+[![Anaconda Cloud Badge](https://anaconda.org/conda-forge/pymbar/badges/installer/conda.svg)](https://anaconda.org/omnia/pymbar)
 [![PyPI Version](https://badge.fury.io/py/pymbar.png)](https://pypi.python.org/pypi/pymbar)
 [![DOI](https://zenodo.org/badge/9991771.svg)](https://zenodo.org/badge/latestdoi/9991771)
 
@@ -16,7 +16,7 @@ Installation
 
 The easiest way to install the `pymbar` release is via [conda](http://conda.pydata.org):
 ```bash
-conda install -c omnia pymbar
+conda install -c conda-forge pymbar
 ```
 You can also install `pymbar` from the [Python package index](https://pypi.python.org/pypi/pymbar) using `pip`:
 ```bash


### PR DESCRIPTION
It looks like conda-forge is the intended method of installation for this package, based on the docs. This PR updates the README to use conda-forge instead of omnia. (I just happened to check for a conda-forge package before installing.)

Users installing from omnia would get an outdated version 3.0.3 instead of conda-forge's 3.0.5. I also updated the badge URLs. The conda-forge download count is much higher! 😄