### PR TITLE
Forward maximum_iterations from MBAR constructor

### DIFF
--- a/pymbar/mbar.py
+++ b/pymbar/mbar.py
@@ -296,6 +296,7 @@ class MBAR:
         for solver in solver_protocol:
             if 'options' not in solver:
                 solver['options'] = dict()
+                solver['options']['maximum_iterations'] = maximum_iterations
             if 'verbose' not in solver['options']:
                 # should add in other ways to get information out of the scipy solvers, not just adaptive,
                 # which might involve passing in different combinations of options, and passing out other strings.

--- a/pymbar/mbar_solvers.py
+++ b/pymbar/mbar_solvers.py
@@ -268,7 +268,7 @@ def adaptive(u_kn, N_k, f_k, tol = 1.0e-12, options = None):
     """
     # put the defaults here in case we get passed an 'options' dictionary that is only partial
     options.setdefault('verbose',False)
-    options.setdefault('maximum_iterations',250)
+    options.setdefault('maximum_iterations',10000)
     options.setdefault('print_warning',False)
     options.setdefault('gamma',1.0)
 


### PR DESCRIPTION
Possibly related to https://github.com/choderalab/pymbar/issues/320 , https://github.com/choderalab/pymbar/issues/419 . In these issue reports, the logs suggest that the default `maximum_iterations = 250` was reached.

However, the default `maximum_iterations` in the MBAR constructor https://github.com/choderalab/pymbar/blob/3c4262c490261110a7595eec37df3e2b8caeab37/pymbar/mbar.py#L73 is much larger than 250.

The `maximum_iterations` argument in the MBAR constructor is currently unused. When `maximum_iterations` is absent from the `options` dictionary that is forwarded from the MBAR constructor to the `adaptive` solver, `maximum_iterations` defaults to 250 here https://github.com/choderalab/pymbar/blob/3c4262c490261110a7595eec37df3e2b8caeab37/pymbar/mbar_solvers.py#L271 

This patch solves the minimal example provided in this comment https://github.com/choderalab/pymbar/issues/419#issuecomment-796230485 (which worked in 3.0.3 but failed in 3.0.5), although other examples in the thread may not be addressed by this patch.