### PR TITLE
Fix for expectations of very small numbers

### DIFF
--- a/pymbar/mbar.py
+++ b/pymbar/mbar.py
@@ -645,6 +645,11 @@ class MBAR:
 
         """
 
+        logfactor = 0  # make sure all results are larger than this number.
+                       # We tried 1 before, but expecations that are all very small (like
+                       # fraction folded when it is low) cannot be computed accurately. 
+                       # it's possible  that something really small but > 0 might avoid
+                       # errors, but no errors have occured yet. 
         # Retrieve N and K for convenience.
         mapshape = np.shape(state_map) # number of computed expectations we desire
                                                # need to convert to matrix to be able to pick up D=1
@@ -686,7 +691,7 @@ class MBAR:
 
         for i in A_list:
             A_min[i] = np.min(A_n[i, :]) #find the minimum
-            A_n[i, :] = A_n[i,:] - (A_min[i] - 1)  #all values now positive so that we can work in logarithmic scale
+            A_n[i, :] = A_n[i,:] - (A_min[i] - logfactor)  #all values now positive so that we can work in logarithmic scale
 
         # Augment W_nk, N_k, and c_k for q_A(x) for the observables, with one
         # row for the specified state and I rows for the observable at that
@@ -734,11 +739,11 @@ class MBAR:
         # Now that covariances are computed, add the constants back to A_i that
         # were required to enforce positivity
         for s in range(S):
-            A_i[s] += (A_min[state_map[1,s]] - 1)
+            A_i[s] += (A_min[state_map[1,s]] - logfactor)
 
         # these values may be used outside the routine, so copy back.
         for i in A_list:
-            A_n[i, :] = A_n[i,:] + (A_min[i] - 1)
+            A_n[i, :] = A_n[i,:] + (A_min[i] - logfactor)
 
         # expectations of the observables at these states
         if S > 0:


### PR DESCRIPTION
Previously, expectations of very small numbers would not be correct.  Before, the code ensured that logarithms of expectations were greater than 1 by shifting the values.  Now, we only make sure they are greater than zero. this does not appear to have any numerical issues (though it's possible there could be underflow), and fixes the previous problems.  Leaving it in as factor instead of hardcoding in case we need to make it bigger in the future).  