### PR TITLE
Syncing Pymbar4 with master

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -129,9 +129,11 @@ jobs:
       run: |
         pylint $PACKAGE/
 
-    # TODO: Remove --exclude pymbar/old_mbar.py after deprecation
+    # TODO: Remove old_mbar.py from --extend-exclude after deprecation
+    # Black has a default --exclude which reads .gitignore.
+    # Black's --exclude and --extend-exclude are single specified RegEx patterns and overwrite if multi-marked.
     - name: Run black check
       shell: bash -l {0}
       if: always()
       run: |
-        black --check -l 99 $PACKAGE/ examples/ --exclude pymbar/old_mbar.py --exclude $PACKAGE/_version.py
+        black --check -l 99 $PACKAGE/ examples/ --extend-exclude "$PACKAGE/(old_mbar.py|_version.py)"

--- a/.pylintrc
+++ b/.pylintrc
@@ -11,7 +11,7 @@
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
-ignore=old_mbar.py
+ignore=old_mbar.py,_version.py
 
 # Pickle collected data for later comparisons.
 persistent=no

--- a/devtools/conda-recipe/README.md
+++ b/devtools/conda-recipe/README.md
@@ -6,7 +6,7 @@ it, running the tests, and then if successful pushing the package to binstar
 (and the docs to AWS S3). The binstar auth token is an encrypted environment
 variable generated using:
 
-binstar auth -n repex-travis -o omnia --max-age 22896000 -c --scopes api:write
+binstar auth -n repex-travis -o conda-forge --max-age 22896000 -c --scopes api:write
 
 and then saved in the environment variable BINSTAR_TOKEN.
 

--- a/examples/harmonic-oscillators/harmonic-oscillators-distributions.py
+++ b/examples/harmonic-oscillators/harmonic-oscillators-distributions.py
@@ -90,7 +90,7 @@ elif observe == "potential energy":
 elif observe == "position":
     A_k_analytical = O_k  # observable is the position
 elif observe == "position^2":
-    A_k_analytical = (1 + beta * K_k * O_k ** 2) / (beta * K_k)  # observable is the position^2
+    A_k_analytical = (1 + beta * K_k * O_k**2) / (beta * K_k)  # observable is the position^2
 else:
     raise ParameterError("Observable %s not known." % observe)
 

--- a/examples/harmonic-oscillators/harmonic-oscillators.py
+++ b/examples/harmonic-oscillators/harmonic-oscillators.py
@@ -67,7 +67,7 @@ def get_analytical(beta, K, O, observables):
             A_k_analytical[observe] = O
         if observe == "position^2":
             # observable is the position^2
-            A_k_analytical[observe] = (1 + beta * K * O ** 2) / (beta * K)
+            A_k_analytical[observe] = (1 + beta * K * O**2) / (beta * K)
 
         A_ij_analytical[observe] = A_k_analytical[observe] - np.vstack(A_k_analytical[observe])
 
@@ -772,7 +772,7 @@ mbar = MBAR(u_kn, N_k)
 xmin = gridscale * (np.min(xrange[0][0]) - 1 / 2.0)
 xmax = gridscale * (np.max(xrange[0][1]) + 1 / 2.0)
 dx = (xmax - xmin) / nbinsperdim
-nbins = 1 + nbinsperdim ** ndim
+nbins = 1 + nbinsperdim**ndim
 bin_edges = np.linspace(xmin, xmax, nbins)  # list of bin edges.
 bin_centers = np.zeros([nbins, ndim], np.float64)
 
@@ -904,7 +904,7 @@ ymin = gridscale * (np.min(xrange[1][0]) - 1 / 2.0)
 ymax = gridscale * (np.max(xrange[1][1]) + 1 / 2.0)
 dx = (xmax - xmin) / nbinsperdim
 dy = (ymax - ymin) / nbinsperdim
-nbins = 1 + nbinsperdim ** ndim
+nbins = 1 + nbinsperdim**ndim
 bin_centers = np.zeros([nbins, ndim], np.float64)
 
 ibin = 1  # first reserved for something outside.

--- a/examples/heat-capacity/heat-capacity.py
+++ b/examples/heat-capacity/heat-capacity.py
@@ -352,7 +352,7 @@ for n in range(n_boots_work):
     dDeltaE_expect = results["sigma"]
     print("Computing Expectations for E^2...")
 
-    results = mbar.compute_expectations(E_kn ** 2, state_dependent=True)
+    results = mbar.compute_expectations(E_kn**2, state_dependent=True)
     E2_expect = results["mu"]
     dE2_expect = results["sigma"]
     allE2_expect[:, n] = E2_expect[:]
@@ -380,7 +380,7 @@ for n in range(n_boots_work):
     # we just need an estimate of n-1, but we can try to get that by var(dE)/dE_expect**2
     # it's within 50% or so, but that's not good enough.
 
-    allCv_expect[:, 0, n] = (E2_expect - (E_expect * E_expect)) / (kB * temp_k ** 2)
+    allCv_expect[:, 0, n] = (E2_expect - (E_expect * E_expect)) / (kB * temp_k**2)
 
     ####################################
     # C_v by fluctuation formula
@@ -393,7 +393,7 @@ for n in range(n_boots_work):
 
     if n == 0:
         # sigma^2 / (sigma^2/n) = effective number of samples
-        N_eff = (E2_expect - (E_expect * E_expect)) / dE_expect ** 2
+        N_eff = (E2_expect - (E_expect * E_expect)) / dE_expect**2
         dCv_expect[:, 0] = allCv_expect[:, 0, n] * np.sqrt(2 / N_eff)
 
     # only loop over the points that will be plotted, not the ones that

--- a/examples/umbrella-sampling-fes/umbrella-sampling-advanced-fes.py
+++ b/examples/umbrella-sampling-fes/umbrella-sampling-advanced-fes.py
@@ -196,7 +196,7 @@ for k in range(K):
                 dchi[l] = 360.0 - abs(dchi[l])
 
         # Compute energy of snapshot n from simulation k in umbrella potential l
-        u_kln[k, :, n] = u_kn[k, n] + beta_k[k] * (K_k / 2.0) * dchi ** 2
+        u_kln[k, :, n] = u_kn[k, n] + beta_k[k] * (K_k / 2.0) * dchi**2
 
 # initialize free energy profile with the data collected.
 basefes = pymbar.FES(u_kln, N_k, verbose=True)
@@ -208,7 +208,7 @@ def bias_potential(x, k):
     # vectorize the conditional
     i = np.fabs(dchi) > 180.0
     dchi = i * (360.0 - np.fabs(dchi)) + (1 - i) * dchi
-    return beta_k[k] * (K_k[k] / 2.0) * dchi ** 2
+    return beta_k[k] * (K_k[k] / 2.0) * dchi**2
 
 
 def deltag(c, scalef=1, n=nspline):
@@ -216,7 +216,7 @@ def deltag(c, scalef=1, n=nspline):
     consider periodicity later!!
     """
     cdiff = np.diff(c)
-    logp = -scalef / n * (np.sum(cdiff ** 2))
+    logp = -scalef / n * (np.sum(cdiff**2))
     return logp
 
 

--- a/examples/umbrella-sampling-fes/umbrella-sampling.py
+++ b/examples/umbrella-sampling-fes/umbrella-sampling.py
@@ -147,7 +147,7 @@ for k in range(K):
                 dchi[l] = 360.0 - abs(dchi[l])
 
         # Compute energy of snapshot n from simulation k in umbrella potential l
-        u_kln[k, :, n] = u_kn[k, n] + beta_k[k] * (K_k / 2.0) * dchi ** 2
+        u_kln[k, :, n] = u_kn[k, n] + beta_k[k] * (K_k / 2.0) * dchi**2
 
 # initialize free energy profile with the data collected
 fes = pymbar.FES(u_kln, N_k, verbose=True)

--- a/pymbar/__init__.py
+++ b/pymbar/__init__.py
@@ -30,7 +30,7 @@ __email__ = "levi.naden@choderalab.org,jaime.rodriguez-guerra@choderalab.org,mic
 
 from . import timeseries, testsystems, confidenceintervals
 from .mbar import MBAR
-from .other_estimators import bar, bar_zero, exp, exp_gauss
+from .other_estimators import bar, bar_overlap, bar_zero, exp, exp_gauss
 from .fes import FES
 from . import old_mbar
 
@@ -43,6 +43,7 @@ __all__ = [
     "exp",
     "exp_gauss",
     "bar",
+    "bar_overlap",
     "bar_zero",
     "MBAR",
     "timeseries",

--- a/pymbar/confidenceintervals.py
+++ b/pymbar/confidenceintervals.py
@@ -177,7 +177,7 @@ def qq_plot(replicates, K, title="Generic Q-Q plot", filename="qq.pdf"):
                     labelij[k] = [i, j]
                     k += 1
 
-    sq = (nplots) ** 0.5
+    sq = nplots**0.5
     labelsize = 30.0 / sq
     matplotlib.rc("axes", facecolor="#E3E4FA")
     matplotlib.rc("axes", edgecolor="white")
@@ -369,7 +369,7 @@ def generate_confidence_intervals(replicates, K):
         logger.info(
             "{:5.1f} {:10.6f} {:10.6f} ({:10.6f},{:10.6f}) {:10.6f}".format(
                 alpha,
-                1.0 - 1.0 / alpha ** 2,
+                1.0 - 1.0 / alpha**2,
                 Pobs[alpha_index],
                 Plow[alpha_index],
                 Phigh[alpha_index],
@@ -414,9 +414,9 @@ def generate_confidence_intervals(replicates, K):
     standarddev = np.std(vals, axis=0)
     bias = np.average(vals_error, axis=0)
     aveerr = np.average(vals_error, axis=0)
-    d2 = vals_error ** 2
+    d2 = vals_error**2
     rms_error = (np.average(d2, axis=0)) ** (1.0 / 2.0)
-    d2 = vals_std ** 2
+    d2 = vals_std**2
     ave_std = (np.average(d2, axis=0)) ** (1.0 / 2.0)
 
     # for now, just print out the data at the end for each

--- a/pymbar/fes.py
+++ b/pymbar/fes.py
@@ -2071,16 +2071,13 @@ class FES:
 
         if self.mc_data["first_step"]:
             c = bspline.c
-            mc_data["previous_logposterior"] = (
-                self._get_MC_loglikelihood(
-                    x_n,
-                    w_n,
-                    self.spline_parameters["spline_weights"],
-                    bspline,
-                    self.spline_parameters["xrange"],
-                )
-                - logprior(c)
-            )
+            mc_data["previous_logposterior"] = self._get_MC_loglikelihood(
+                x_n,
+                w_n,
+                self.spline_parameters["spline_weights"],
+                bspline,
+                self.spline_parameters["xrange"],
+            ) - logprior(c)
             cold = bspline.c
             mc_data["first_step"] = True
             # create an extra one we can carry around

--- a/pymbar/fes.py
+++ b/pymbar/fes.py
@@ -2429,7 +2429,7 @@ class FES:
                             ddexpf,
                             xrangeij[i + 1, j + 1, 0],
                             xrangeij[i + 1, j + 1, 1],
-                            args=(i, j)
+                            args=(i, j),
                         )
                         h[i, j] += N * pE / pF
 

--- a/pymbar/fes.py
+++ b/pymbar/fes.py
@@ -2426,7 +2426,9 @@ class FES:
 
                         # now compute the expectation of each derivative
                         pE = self._integrate(
-                            ddexpf, xrangeij[i + 1, j + 1, 0], xrangeij[i + 1, j + 1, 1],
+                            ddexpf,
+                            xrangeij[i + 1, j + 1, 0],
+                            xrangeij[i + 1, j + 1, 1],
                             args=(i, j)
                         )
                         h[i, j] += N * pE / pF

--- a/pymbar/mbar.py
+++ b/pymbar/mbar.py
@@ -1,7 +1,7 @@
 ##############################################################################
 # pymbar: A Python Library for MBAR
 #
-# Copyright 2017 University of Colorado Boulder
+# Copyright 2017-2022 University of Colorado Boulder
 # Copyright 2010-2017 Memorial Sloan-Kettering Cancer Center
 # Portions of this software are Copyright (c) 2010-2016 University of Virginia
 # Portions of this software are Copyright (c) 2006-2007 The Regents of the University of California.  All Rights Reserved.
@@ -660,7 +660,7 @@ class MBAR:
 
         'Amin' : np.ndarray, float, shape = (S), needed for reconstructing the covariance one level up.
 
-        'f' : np.ndarray, float, shape = (K+len(state_list)), 'free energies' of the new states (i.e. ln (<A>-Amin+1)) as the log form is easier to work with.
+        'f' : np.ndarray, float, shape = (K+len(state_list)), 'free energies' of the new states (i.e. ln (<A>-Amin+logfactor)) as the log form is easier to work with.
 
         Notes
         -----

--- a/pymbar/mbar.py
+++ b/pymbar/mbar.py
@@ -440,7 +440,7 @@ class MBAR:
         N_eff = np.zeros(self.K)
         for k in range(self.K):
             w = np.exp(self.Log_W_nk[:, k])
-            N_eff[k] = 1 / np.sum(w ** 2)
+            N_eff[k] = 1 / np.sum(w**2)
             if verbose:
                 logger.info(
                     "Effective number of sample in state {:d} is {:10.3f}".format(k, N_eff[k])

--- a/pymbar/mbar.py
+++ b/pymbar/mbar.py
@@ -694,12 +694,12 @@ class MBAR:
 
         """
 
-        logfactor = 4.0*np.finfo(np.float64).eps
-                       # make sure all results are larger than this number.
-                       # We tried 1 before, but expecations that are all very small (like
-                       # fraction folded when it is low) cannot be computed accurately. 
-                       # 0 causes warnings in the test with divide by zero, as does 1*eps (though fewer),
-                       # and even occasionally 2*eps, so we chooose 4*eps
+        logfactor = 4.0 * np.finfo(np.float64).eps
+        # make sure all results are larger than this number.
+        # We tried 1 before, but expecations that are all very small (like
+        # fraction folded when it is low) cannot be computed accurately.
+        # 0 causes warnings in the test with divide by zero, as does 1*eps (though fewer),
+        # and even occasionally 2*eps, so we chooose 4*eps
         # Retrieve N and K for convenience.
         mapshape = np.shape(state_map)  # number of computed expectations we desire
         # need to convert to matrix to be able to pick up D=1
@@ -1692,13 +1692,16 @@ class MBAR:
                     # kickstart NR.
                     from pymbar.other_estimators import bar
 
-                    self.f_k[l] = self.f_k[k] + bar(
-                        w_F,
-                        w_R,
-                        relative_tolerance=0.000001,
-                        verbose=False,
-                        compute_uncertainty=False,
-                    )["Delta_f"]
+                    self.f_k[l] = (
+                        self.f_k[k]
+                        + bar(
+                            w_F,
+                            w_R,
+                            relative_tolerance=0.000001,
+                            verbose=False,
+                            compute_uncertainty=False,
+                        )["Delta_f"]
+                    )
                 else:
                     # no states observed, so we don't need to initialize this free energy anyway, as
                     # the solution is noniterative.

--- a/pymbar/mbar.py
+++ b/pymbar/mbar.py
@@ -337,6 +337,7 @@ class MBAR:
         for solver in solver_protocol:
             if "options" not in solver:
                 solver["options"] = dict()
+                solver["maximum_iterations"] = maximum_iterations
             if "verbose" not in solver["options"]:
                 # should add in other ways to get information out of the scipy solvers, not just adaptive,
                 # which might involve passing in different combinations of options, and passing out other strings.

--- a/pymbar/mbar.py
+++ b/pymbar/mbar.py
@@ -337,7 +337,7 @@ class MBAR:
         for solver in solver_protocol:
             if "options" not in solver:
                 solver["options"] = dict()
-                solver["maximum_iterations"] = maximum_iterations
+                solver["options"]["maxiter"] = maximum_iterations
             if "verbose" not in solver["options"]:
                 # should add in other ways to get information out of the scipy solvers, not just adaptive,
                 # which might involve passing in different combinations of options, and passing out other strings.
@@ -694,11 +694,12 @@ class MBAR:
 
         """
 
-        logfactor = 0  # make sure all results are larger than this number.
+        logfactor = 4.0*np.finfo(np.float64).eps
+                       # make sure all results are larger than this number.
                        # We tried 1 before, but expecations that are all very small (like
                        # fraction folded when it is low) cannot be computed accurately. 
-                       # it's possible  that something really small but > 0 might avoid
-                       # errors, but no errors have occured yet. 
+                       # 0 causes warnings in the test with divide by zero, as does 1*eps (though fewer),
+                       # and even occasionally 2*eps, so we chooose 4*eps
         # Retrieve N and K for convenience.
         mapshape = np.shape(state_map)  # number of computed expectations we desire
         # need to convert to matrix to be able to pick up D=1

--- a/pymbar/mbar.py
+++ b/pymbar/mbar.py
@@ -693,6 +693,11 @@ class MBAR:
 
         """
 
+        logfactor = 0  # make sure all results are larger than this number.
+                       # We tried 1 before, but expecations that are all very small (like
+                       # fraction folded when it is low) cannot be computed accurately. 
+                       # it's possible  that something really small but > 0 might avoid
+                       # errors, but no errors have occured yet. 
         # Retrieve N and K for convenience.
         mapshape = np.shape(state_map)  # number of computed expectations we desire
         # need to convert to matrix to be able to pick up D=1
@@ -735,7 +740,7 @@ class MBAR:
         for i in A_list:
             A_min[i] = np.min(A_n[i, :])  # find the minimum
             A_n[i, :] = A_n[i, :] - (
-                A_min[i] - 1
+                A_min[i] - logfactor
             )  # all values now positive so that we can work in logarithmic scale
 
         # Augment W_nk, N_k, and c_k for q_A(x) for the observables, with one
@@ -788,11 +793,11 @@ class MBAR:
         # Now that covariances are computed, add the constants back to A_i that
         # were required to enforce positivity
         for s in range(S):
-            A_i[s] += A_min[state_map[1, s]] - 1
+            A_i[s] += A_min[state_map[1, s]] - logfactor
 
         # these values may be used outside the routine, so copy back.
         for i in A_list:
-            A_n[i, :] = A_n[i, :] + (A_min[i] - 1)
+            A_n[i, :] = A_n[i, :] + (A_min[i] - logfactor)
 
         # expectations of the observables at these states
         if S > 0:
@@ -821,7 +826,7 @@ class MBAR:
             result_vals["Theta"] = Theta
             if S > 0:
                 # we need to return the minimum A as well
-                result_vals["Amin"] = A_min[state_map[1, np.arange(S)]] - 1
+                result_vals["Amin"] = A_min[state_map[1, np.arange(S)]] - logfactor
 
         # free energies at these new states
         result_vals["f"] = f_k[K + state_list]

--- a/pymbar/mbar_solvers.py
+++ b/pymbar/mbar_solvers.py
@@ -275,7 +275,7 @@ def adaptive(u_kn, N_k, f_k, tol=1.0e-12, options=None):
     """
     # put the defaults here in case we get passed an 'options' dictionary that is only partial
     options.setdefault("verbose", False)
-    options.setdefault("maximum_iterations", 250)
+    options.setdefault("maximum_iterations", 10000)
     options.setdefault("print_warning", False)
     options.setdefault("gamma", 1.0)
 

--- a/pymbar/mbar_solvers.py
+++ b/pymbar/mbar_solvers.py
@@ -349,7 +349,7 @@ def adaptive(u_kn, N_k, f_k, tol=1.0e-12, options=None):
 
         div = np.abs(f_k[1:])  # what we will divide by to get relative difference
         zeroed = np.abs(f_k[1:]) < np.min(
-            [10 ** -8, tol]
+            [10**-8, tol]
         )  # check which values are near enough to zero, hard coded max for now.
         div[zeroed] = 1.0  # for these values, use absolute values.
         max_delta = np.max(np.abs(f_k[1:] - f_old[1:]) / div)

--- a/pymbar/other_estimators.py
+++ b/pymbar/other_estimators.py
@@ -547,22 +547,26 @@ def bar_overlap(w_F, w_R):
         The overlap: 0 denotes no overlap, 1 denotes complete overlap
     """
     from pymbar import MBAR
-    N_k = np.array( [len(w_F), len(w_R)] )
+
+    N_k = np.array([len(w_F), len(w_R)])
     N = N_k.sum()
-    u_kn = np.zeros([2,N])
-    u_kn[1,0:N_k[0]] = w_F[:]
-    u_kn[0,N_k[0]:N] = w_R[:]
+    u_kn = np.zeros([2, N])
+    u_kn[1, 0 : N_k[0]] = w_F[:]
+    u_kn[0, N_k[0] : N] = w_R[:]
     mbar = MBAR(u_kn, N_k)
 
     # Check to make sure u_kn has been correctly formed
     results = bar(w_F, w_R)
-    bar_df = results['Delta_f']
-    bar_ddf = results['dDelta_f']
+    bar_df = results["Delta_f"]
+    bar_ddf = results["dDelta_f"]
 
-    assert np.isclose(mbar.f_k[1] - mbar.f_k[0], bar_df), f'BAR: {bar_df} +- {bar_ddF} | MBAR: {mbar.f_k[1] - mbar.f_k[0]}'
+    assert np.isclose(
+        mbar.f_k[1] - mbar.f_k[0], bar_df
+    ), f"BAR: {bar_df} +- {bar_ddF} | MBAR: {mbar.f_k[1] - mbar.f_k[0]}"
 
-    return mbar.compute_overlap()['scalar']    
-    
+    return mbar.compute_overlap()["scalar"]
+
+
 # =============================================================================================
 # One-sided exponential averaging (EXP).
 # =============================================================================================

--- a/pymbar/other_estimators.py
+++ b/pymbar/other_estimators.py
@@ -531,6 +531,35 @@ def bar(
         return result_vals
 
 
+def bar_overlap(w_F, w_R):
+    """Compute overlap between foward and backward ensembles (using MBAR definition of overlap)
+    Parameters
+    ----------
+    w_F : np.ndarray
+        w_F[t] is the forward work value from snapshot t.
+        t = 0...(T_F-1)  Length T_F is deduced from vector.
+    w_R : np.ndarray
+        w_R[t] is the reverse work value from snapshot t.
+        t = 0...(T_R-1)  Length T_R is deduced from vector.
+    Returns
+    -------
+    overlap : float
+        The overlap: 0 denotes no overlap, 1 denotes complete overlap
+    """
+    from pymbar import MBAR
+    N_k = np.array( [len(w_F), len(w_R)] )
+    N = N_k.sum()
+    u_kn = np.zeros([2,N])
+    u_kn[1,0:N_k[0]] = w_F[:]
+    u_kn[0,N_k[0]:N] = w_R[:]
+    mbar = MBAR(u_kn, N_k)
+
+    # Check to make sure u_kn has been correctly formed
+    bar_df, bar_ddf = bar(w_F, w_R, return_dict=False)
+    assert numpy.isclose(mbar.f_k[1] - mbar.f_k[0], bar_df), f'BAR: {bar_df} +- {bar_ddF} | MBAR: {mbar.f_k[1] - mbar.f_k[0]}'
+
+    return mbar.computeOverlap()['scalar']    
+    
 # =============================================================================================
 # One-sided exponential averaging (EXP).
 # =============================================================================================

--- a/pymbar/other_estimators.py
+++ b/pymbar/other_estimators.py
@@ -506,7 +506,7 @@ def bar(
         nrat = (T_F + T_R) / (T_F * T_R)  # same for both methods
 
         if uncertainty_method == "BAR":
-            variance = (afF2 / afF ** 2) / T_F + (afR2 / afR ** 2) / T_R - nrat
+            variance = (afF2 / afF**2) / T_F + (afR2 / afR**2) / T_R - nrat
             dDeltaF = np.sqrt(variance)
         elif uncertainty_method == "MBAR":
             # OR equivalently

--- a/pymbar/other_estimators.py
+++ b/pymbar/other_estimators.py
@@ -555,10 +555,13 @@ def bar_overlap(w_F, w_R):
     mbar = MBAR(u_kn, N_k)
 
     # Check to make sure u_kn has been correctly formed
-    bar_df, bar_ddf = bar(w_F, w_R, return_dict=False)
-    assert numpy.isclose(mbar.f_k[1] - mbar.f_k[0], bar_df), f'BAR: {bar_df} +- {bar_ddF} | MBAR: {mbar.f_k[1] - mbar.f_k[0]}'
+    results = bar(w_F, w_R)
+    bar_df = results['Delta_f']
+    bar_ddf = results['dDelta_f']
 
-    return mbar.computeOverlap()['scalar']    
+    assert np.isclose(mbar.f_k[1] - mbar.f_k[0], bar_df), f'BAR: {bar_df} +- {bar_ddF} | MBAR: {mbar.f_k[1] - mbar.f_k[0]}'
+
+    return mbar.compute_overlap()['scalar']    
     
 # =============================================================================================
 # One-sided exponential averaging (EXP).

--- a/pymbar/tests/test_bar.py
+++ b/pymbar/tests/test_bar.py
@@ -98,25 +98,26 @@ def test_bar_free_energies(bar_and_test):
     # not sure exactly how close they need to be for sample problems?
     assert_almost_equal(dfe_bar, dfe_mbar, decimal=3)
 
+
 def test_bar_overlap():
 
     for system_generator in system_generators:
         name, test = system_generator()
-        x_n, u_kn, N_k_output, s_n = test.sample(N_k, mode='u_kn')
-        assert_equal(N_k_output,N_k)
-        
+        x_n, u_kn, N_k_output, s_n = test.sample(N_k, mode="u_kn")
+        assert_equal(N_k_output, N_k)
+
         i = 0
         j = 1
         i_indices = np.arange(0, N_k[0])
-        j_indices = np.arange(N_k[0], N_k[0]+N_k[1])
-        w_f = u_kn[j,i_indices] - u_kn[i,i_indices]
-        w_r = u_kn[i,j_indices] - u_kn[j,j_indices]
+        j_indices = np.arange(N_k[0], N_k[0] + N_k[1])
+        w_f = u_kn[j, i_indices] - u_kn[i, i_indices]
+        w_r = u_kn[i, j_indices] - u_kn[j, j_indices]
 
         # Compute overlap
         bar_overlap = estimators.bar_overlap(w_f, w_r)
 
         # Compare with MBAR
         mbar = MBAR(u_kn, N_k)
-        mbar_overlap = mbar.compute_overlap()['scalar']
+        mbar_overlap = mbar.compute_overlap()["scalar"]
 
         assert_almost_equal(bar_overlap, mbar_overlap, decimal=precision)

--- a/pymbar/tests/test_bar.py
+++ b/pymbar/tests/test_bar.py
@@ -5,6 +5,7 @@ for which the true free energy differences can be computed analytically.
 import numpy as np
 import pytest
 from pymbar import other_estimators as estimators
+from pymbar import MBAR
 from pymbar.testsystems import harmonic_oscillators, exponential_distributions
 from pymbar.utils_for_testing import assert_equal, assert_almost_equal
 
@@ -96,3 +97,26 @@ def test_bar_free_energies(bar_and_test):
 
     # not sure exactly how close they need to be for sample problems?
     assert_almost_equal(dfe_bar, dfe_mbar, decimal=3)
+
+def test_bar_overlap():
+
+    for system_generator in system_generators:
+        name, test = system_generator()
+        x_n, u_kn, N_k_output, s_n = test.sample(N_k, mode='u_kn')
+        eq(N_k, N_k_output)
+
+        i = 0
+        j = 1
+        i_indices = np.arange(0, N_k[0])
+        j_indices = np.arange(N_k[0], N_k[0]+N_k[1])
+        w_f = u_kn[j,i_indices] - u_kn[i,i_indices]
+        w_r = u_kn[i,j_indices] - u_kn[j,j_indices]
+
+        # Compute overlap
+        bar_overlap = estimators.bar_overlap(w_f, w_r)
+
+        # Compare with MBAR
+        mbar = MBAR(u_kn, N_k)
+        mbar_overlap = mbar.computeOverlap()['scalar']
+
+        eq(bar_overlap, mbar_overlap)

--- a/pymbar/tests/test_bar.py
+++ b/pymbar/tests/test_bar.py
@@ -85,9 +85,9 @@ def test_bar_free_energies(bar_and_test):
     assert_almost_equal(z / z_scale_factor, np.zeros(len(z)), decimal=0)
 
     # make sure the different methods are nearly equal.
-    assert_almost_equal(fe_bis, fe_fp, decimal=8)
-    assert_almost_equal(fe_sci, fe_bis, decimal=8)
-    assert_almost_equal(fe_fp, fe_bis, decimal=8)
+    assert_almost_equal(fe_bis, fe_fp, decimal=precision)
+    assert_almost_equal(fe_sci, fe_bis, decimal=precision)
+    assert_almost_equal(fe_fp, fe_bis, decimal=precision)
 
     # Test uncertainty methods
     results_dBAR = bars["dBAR"]
@@ -103,8 +103,8 @@ def test_bar_overlap():
     for system_generator in system_generators:
         name, test = system_generator()
         x_n, u_kn, N_k_output, s_n = test.sample(N_k, mode='u_kn')
-        eq(N_k, N_k_output)
-
+        assert_equal(N_k_output,N_k)
+        
         i = 0
         j = 1
         i_indices = np.arange(0, N_k[0])
@@ -117,6 +117,6 @@ def test_bar_overlap():
 
         # Compare with MBAR
         mbar = MBAR(u_kn, N_k)
-        mbar_overlap = mbar.computeOverlap()['scalar']
+        mbar_overlap = mbar.compute_overlap()['scalar']
 
-        eq(bar_overlap, mbar_overlap)
+        assert_almost_equal(bar_overlap, mbar_overlap, decimal=precision)

--- a/pymbar/tests/test_exp.py
+++ b/pymbar/tests/test_exp.py
@@ -91,5 +91,5 @@ def test_EXP_free_energies(exp_and_test):
     # assert_almost_equal(z / z_scale_factor, np.zeros(len(z)), decimal=0)
 
     # make sure the different methods are nearly equal for these systems (within uncertainty)
-    z = np.abs(fe_R - fe_F) / np.sqrt(dfe_R ** 2 + dfe_F ** 2)
+    z = np.abs(fe_R - fe_F) / np.sqrt(dfe_R**2 + dfe_F**2)
     assert_almost_equal(z / z_scale_factor, 0.0, decimal=0)

--- a/pymbar/tests/test_fes.py
+++ b/pymbar/tests/test_fes.py
@@ -127,7 +127,7 @@ def fes_1d():
     xmin = gridscale * (np.min(xrange[0][0]) - 1 / 2.0)
     xmax = gridscale * (np.max(xrange[0][1]) + 1 / 2.0)
     dx = (xmax - xmin) / nbinsperdim
-    nbins = nbinsperdim ** ndim
+    nbins = nbinsperdim**ndim
     bin_edges = np.linspace(xmin, xmax, nbins + 1)  # list of bin edges.
     bin_centers = np.zeros([nbins, ndim])
 
@@ -230,7 +230,7 @@ def fes_2d():
     ymax = gridscale * (np.max(xrange[1][1]) + 1 / 2.0)
     dx = (xmax - xmin) / nbinsperdim
     dy = (ymax - ymin) / nbinsperdim
-    nbins = nbinsperdim ** ndim
+    nbins = nbinsperdim**ndim
     bin_centers = np.zeros([nbins, ndim])
 
     ibin = 0
@@ -488,7 +488,7 @@ def test_1d_fes_spline_bootstraped(fes_1d):
 )
 def test_2d_fes_histogram(fes_2d, reference_point):
 
-    """ testing fes_generate_fes and fes_get_fes in 2D """
+    """testing fes_generate_fes and fes_get_fes in 2D"""
 
     fes = fes_2d["fes"]
     fes_analytical = fes_2d["fes_analytical"]

--- a/pymbar/tests/test_mbar.py
+++ b/pymbar/tests/test_mbar.py
@@ -227,7 +227,7 @@ def test_mbar_compute_expectations_position2(mbar_and_test):
     """Can MBAR calculate E(x_n^2)??"""
 
     mbar, test, x_n = mbar_and_test["mbar"], mbar_and_test["test"], mbar_and_test["x_n"]
-    results = mbar.compute_expectations(x_n ** 2)
+    results = mbar.compute_expectations(x_n**2)
     mu = results["mu"]
     sigma = results["sigma"]
     mu0 = test.analytical_observable(observable="position^2")
@@ -319,7 +319,7 @@ def test_mbar_compute_multiple_expectations(mbar_and_test):
     )
     A = np.zeros([2, len(x_n)])
     A[0, :] = x_n
-    A[1, :] = x_n ** 2
+    A[1, :] = x_n**2
     state = 1
     results = mbar.compute_multiple_expectations(A, u_kn[state, :])
     multiExpectationAssertion(results, test, state=state)
@@ -337,7 +337,7 @@ def test_mbar_compute_multiple_expectations_more_dims(mbar_and_test_kln):
     )
     A = np.zeros([2, x_n.shape[0], x_n.shape[1]])
     A[0, :, :] = x_n
-    A[1, :, :] = x_n ** 2
+    A[1, :, :] = x_n**2
     state = 1
     results = mbar.compute_multiple_expectations(
         A, u_kn[:, state, :], compute_covariance=True, return_theta=True
@@ -399,7 +399,7 @@ def test_mbar_compute_entropy_and_enthalpy_edges(
 
 
 def test_mbar_compute_effective_sample_number(mbar_and_test):
-    """ testing compute_effective_sample_number """
+    """testing compute_effective_sample_number"""
 
     mbar = mbar_and_test["mbar"]
     # one mathematical effective sample numbers should be between N_k and sum_k N_k
@@ -452,7 +452,7 @@ def test_mbar_compute_overlap_nonanalytical(mbar_and_test):
 
 def test_mbar_weights(mbar_and_test):
 
-    """ testing weights """
+    """testing weights"""
 
     mbar = mbar_and_test["mbar"]
     W = mbar.weights()
@@ -471,7 +471,7 @@ def test_mbar_weights(mbar_and_test):
 )
 def test_mbar_computePerturbedFreeEnergeies(system_generator, mode, bad_n):
 
-    """ testing compute_perturbed_free_energies """
+    """testing compute_perturbed_free_energies"""
 
     # only do MBAR with the first and last set
 
@@ -513,7 +513,7 @@ def test_mbar_compute_expectations_inner(mbar_and_test):
         mbar_and_test["x_n"],
         mbar_and_test["u_kn"],
     )
-    A_in = np.array([x_n, x_n ** 2, x_n ** 3])
+    A_in = np.array([x_n, x_n**2, x_n**3])
     u_n = u_kn[:2, :]
     state_map = np.array([[0, 0], [1, 0], [2, 0], [2, 1]], int)
     _ = mbar.compute_expectations_inner(A_in, u_n, state_map)

--- a/pymbar/tests/test_timeseries.py
+++ b/pymbar/tests/test_timeseries.py
@@ -28,7 +28,7 @@ def data(N=10000, K=10):
     X = np.random.normal(np.zeros(K * N), var).reshape((K, N)) / 10.0
     Y = np.random.normal(np.zeros(K * N), var).reshape((K, N))
 
-    energy = 10 * (X ** 2) / 2.0 + (Y ** 2) / 2.0
+    energy = 10 * (X**2) / 2.0 + (Y**2) / 2.0
 
     return X, Y, energy
 
@@ -50,7 +50,7 @@ def test_statistical_inefficiency_single(data):
 def test_statistical_inefficiency_multiple(data):
     X, Y, energy = data
     timeseries.statistical_inefficiency_multiple(X)
-    timeseries.statistical_inefficiency_multiple(X ** 2)
+    timeseries.statistical_inefficiency_multiple(X**2)
     timeseries.statistical_inefficiency_multiple(X[0, :] ** 2)
     timeseries.statistical_inefficiency_multiple(X[0:2, :] ** 2)
     timeseries.statistical_inefficiency_multiple(energy)

--- a/pymbar/testsystems/exponential_distributions.py
+++ b/pymbar/testsystems/exponential_distributions.py
@@ -65,13 +65,13 @@ class ExponentialTestCase(object):
         return np.log(self.rates)
 
     def analytical_means(self):
-        return self.rates ** -1.0
+        return self.rates**-1.0
 
     def analytical_variances(self):
-        return self.rates ** -2.0
+        return self.rates**-2.0
 
     def analytical_standard_deviations(self):
-        return np.sqrt(self.rates ** -2.0)
+        return np.sqrt(self.rates**-2.0)
 
     def analytical_observable(self, observable="position"):
 

--- a/pymbar/testsystems/exponential_distributions.py
+++ b/pymbar/testsystems/exponential_distributions.py
@@ -170,7 +170,7 @@ class ExponentialTestCase(object):
         x_kn = np.zeros([self.n_states, N_max], np.float64)
         u_kln = np.zeros([self.n_states, self.n_states, N_max], np.float64)
         x_n = np.zeros([N_tot], np.float64)
-        s_n = np.zeros([N_tot], np.int)
+        s_n = np.zeros([N_tot], int)
         u_kn = np.zeros([self.n_states, N_tot], np.float64)
         index = 0
         for k, N in enumerate(N_k):

--- a/pymbar/testsystems/gaussian_work.py
+++ b/pymbar/testsystems/gaussian_work.py
@@ -86,17 +86,17 @@ def gaussian_work_example(N_F=200, N_R=200, mu_F=2.0, DeltaF=None, sigma_F=1.0, 
     if (mu_F is None) and (DeltaF is None):
         raise ValueError("Either mu_F or DeltaF must be specified.")
     if mu_F is None:
-        mu_F = DeltaF + sigma_F ** 2 / 2.0
+        mu_F = DeltaF + sigma_F**2 / 2.0
     if DeltaF is None:
-        DeltaF = mu_F - sigma_F ** 2 / 2.0
+        DeltaF = mu_F - sigma_F**2 / 2.0
 
     # Set random number generator into a known state for reproducibility.
     random = np.random.RandomState(seed)
 
     # Determine mean and variance of reverse work distribution by Crooks
     # fluctuation theorem (CFT).
-    mu_R = -mu_F + sigma_F ** 2
-    sigma_R = sigma_F * np.exp(mu_F - sigma_F ** 2 / 2.0 - DeltaF)
+    mu_R = -mu_F + sigma_F**2
+    sigma_R = sigma_F * np.exp(mu_F - sigma_F**2 / 2.0 - DeltaF)
 
     # Draw samples from forward and reverse distributions.
     w_F = random.randn(N_F) * sigma_F + mu_F

--- a/pymbar/testsystems/harmonic_oscillators.py
+++ b/pymbar/testsystems/harmonic_oscillators.py
@@ -153,7 +153,7 @@ class HarmonicOscillatorsTestCase(object):
 
         np.random.seed(seed)
 
-        N_k = np.array(N_k, np.int32)
+        N_k = np.array(N_k, int)
         if len(N_k) != self.n_states:
             raise Exception(
                 "N_k has {:d} states while self.n_states has {:d} states.".format(
@@ -175,7 +175,7 @@ class HarmonicOscillatorsTestCase(object):
         x_kn = np.zeros([self.n_states, N_max], np.float64)
         u_kln = np.zeros([self.n_states, self.n_states, N_max], np.float64)
         x_n = np.zeros([N_tot], np.float64)
-        s_n = np.zeros([N_tot], np.int)
+        s_n = np.zeros([N_tot], int)
         u_kn = np.zeros([self.n_states, N_tot], np.float64)
         index = 0
         for k, N in enumerate(N_k):


### PR DESCRIPTION
There are enough changes between pymbar4 and master that I had to manage things manually.  

There were also cases in the test suite where logfactor=0 resulted in some divide by zero factors, so I made logfactor = 4 x eps, where eps = np.finfo(np.float64).eps, which appears to have resolved almost all errors.  This MAY cause problems for expectations that are lower than 4 x eps, will need to be studied a bit more.  Generally, this will just apply to rare occupancies.  