### PR TITLE
Convert JAX JIT to Decorators

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
 
     - name: Additional info about the build
       shell: bash

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -9,6 +9,8 @@ dependencies:
   - numpy >=1.12
   - scipy
   - numexpr
+  - jaxlib
+  - jax
 
     # Testing
   - pytest

--- a/pymbar/mbar_solvers.py
+++ b/pymbar/mbar_solvers.py
@@ -1,6 +1,7 @@
 import logging
+import warnings
+
 import numpy as np
-import math
 from pymbar.utils import ensure_type, check_w_normalized, ParameterError
 import scipy.optimize
 use_jit = True
@@ -10,15 +11,14 @@ if use_jit:
     from jax.scipy.special import logsumexp
     from jax.config import config; config.update("jax_enable_x64", True)
     import jax.numpy as jnp
-    from jax.numpy import exp, sum, newaxis, diag, dot
+    from jax.numpy import exp, sum, newaxis, diag, dot, s_
     from jax.numpy.linalg import lstsq
     import jax.scipy.optimize
     from jax.scipy.optimize import minimize
 else:
-    from numpy import exp, sum, newaxis, diag, dot
+    from numpy import exp, sum, newaxis, diag, dot, s_
     from numpy.linalg import lstsq
 
-import warnings
 logger = logging.getLogger(__name__)
 
 # Below are the recommended default protocols (ordered sequence of minimization algorithms / NLE solvers) for solving the MBAR equations.
@@ -115,27 +115,36 @@ def self_consistent_update(u_kn, N_k, f_k, states_with_samples=None):
     Equation C3 in MBAR JCP paper.
     """
 
-    return jit_self_consistent_update(
+    return jax_self_consistent_update(
             u_kn, N_k, f_k, states_with_samples=states_with_samples
         )
+
+
+@jax.jit
+def _jit_self_consistent_update(u_kn, N_k, f_k):
+    """JAX version of self_consistent update.  For parameters, see self_consistent_update.
+    N_k must be float (should be cast at a higher level)
+
+    """
+    log_denominator_n = logsumexp(f_k - u_kn.T, b=N_k, axis=1)
+    # All states can contribute to the numerator term.
+    return -1. * logsumexp(-log_denominator_n - u_kn, axis=1)  # check transpose
+
 
 def jax_self_consistent_update(u_kn, N_k, f_k, states_with_samples=None):
     """JAX version of self_consistent update.  For parameters, see self_consistent_update.
     N_k must be float (should be cast at a higher level)
 
     """
-
     # Only the states with samples can contribute to the denominator term.
-    if states_with_samples is not None:
-        log_denominator_n = logsumexp(
-            f_k[states_with_samples] - u_kn[states_with_samples].T, b=N_k[states_with_samples], axis=1
-        )
-    else:
-        log_denominator_n = logsumexp(f_k - u_kn.T, b=N_k, axis=1) 
-    # All states can contribute to the numerator term.
-    return -1. * logsumexp(-log_denominator_n - u_kn, axis=1)  # check transpose
+    # Precondition before feeding the op to the JIT'd function
+    # In theory, this can be computed with jax.lax.cond, but trying to reuse code for non-jax paths
+    states_with_samples = s_[:] if states_with_samples is None else states_with_samples
+    # Feed to the JIT'd function. Can't pass slice types, so slice here
+    return _jit_self_consistent_update(u_kn[states_with_samples], N_k[states_with_samples], f_k[states_with_samples])
 
-jit_self_consistent_update = jax.jit(jax_self_consistent_update)
+# jit_self_consistent_update = jax.jit(jax_self_consistent_update)
+
 
 def mbar_gradient(u_kn, N_k, f_k):
     """Gradient of MBAR objective function.
@@ -158,8 +167,10 @@ def mbar_gradient(u_kn, N_k, f_k):
     -----
     This is equation C6 in the JCP MBAR paper.
     """
-    return jit_mbar_gradient(u_kn, N_k, f_k)
+    return jax_mbar_gradient(u_kn, N_k, f_k)
 
+
+@jax.jit
 def jax_mbar_gradient(u_kn, N_k, f_k):
     """ JAX version of MBAR gradient function. See documentation of mbar_gradient.
     N_k must be float (should be cast at a higher level)
@@ -169,7 +180,8 @@ def jax_mbar_gradient(u_kn, N_k, f_k):
     log_numerator_k = logsumexp(-log_denominator_n - u_kn, axis=1)
     return -1 * N_k * (1.0 - exp(f_k + log_numerator_k))
 
-jit_mbar_gradient = jax.jit(jax_mbar_gradient)
+# jit_mbar_gradient = jax.jit(jax_mbar_gradient)
+
 
 def mbar_objective(u_kn, N_k, f_k):
     """Calculates objective function for MBAR.
@@ -200,8 +212,9 @@ def mbar_objective(u_kn, N_k, f_k):
     outermost sum and logsumexp for the inner sum.
     """
 
-    return jit_mbar_objective(u_kn, N_k, f_k)
+    return jax_mbar_objective(u_kn, N_k, f_k)
 
+@jax.jit
 def jax_mbar_objective(u_kn, N_k, f_k):
     """JAX version of mbar_objective.
     For parameters, mbar_objective_and_Gradient
@@ -210,13 +223,14 @@ def jax_mbar_objective(u_kn, N_k, f_k):
     """
     
     log_denominator_n = logsumexp(f_k - u_kn.T, b=N_k, axis=1)
-    obj = sum(log_denominator_n) - dot(N_k,f_k)
+    obj = sum(log_denominator_n) - dot(N_k, f_k)
 
     return obj
 
-jit_mbar_objective = jax.jit(jax_mbar_objective)
+# jit_mbar_objective = jax.jit(jax_mbar_objective)
 
 
+@jax.jit
 def jax_mbar_objective_and_gradient(u_kn, N_k, f_k):
     """JAX version of mbar_objective_and_gradient.
     For parameters, mbar_objective_and_Gradient
@@ -228,11 +242,11 @@ def jax_mbar_objective_and_gradient(u_kn, N_k, f_k):
     log_numerator_k = logsumexp(-log_denominator_n - u_kn, axis=1)
     grad = -1 * N_k * (1.0 - exp(f_k + log_numerator_k))
 
-    obj = sum(log_denominator_n) - dot(N_k,f_k)
+    obj = sum(log_denominator_n) - dot(N_k, f_k)
 
     return obj, grad
 
-jit_mbar_objective_and_gradient = jax.jit(jax_mbar_objective_and_gradient)
+# jit_mbar_objective_and_gradient = jax.jit(jax_mbar_objective_and_gradient)
 
 
 def mbar_objective_and_gradient(u_kn, N_k, f_k):
@@ -269,8 +283,9 @@ def mbar_objective_and_gradient(u_kn, N_k, f_k):
     function is its integral.
     """
 
-    return jit_mbar_objective_and_gradient(u_kn, N_k, f_k)
+    return jax_mbar_objective_and_gradient(u_kn, N_k, f_k)
 
+@jax.jit
 def jax_mbar_hessian(u_kn, N_k, f_k):
     """JAX version of mbar_hessian.
     For parameters, see mbar_hessian
@@ -282,13 +297,14 @@ def jax_mbar_hessian(u_kn, N_k, f_k):
     logW = f_k - u_kn.T - log_denominator_n[:, newaxis]
     W = exp(logW)
 
-    H = dot(W.T,W)
+    H = dot(W.T, W)
     H *= N_k
     H *= N_k[:, newaxis]
     H -= diag(W.sum(0) * N_k)
     return -1.0 * H
 
-jit_mbar_hessian = jax.jit(jax_mbar_hessian)
+# jit_mbar_hessian = jax.jit(jax_mbar_hessian)
+
 
 def mbar_hessian(u_kn, N_k, f_k):
     """Hessian of MBAR objective function.
@@ -312,8 +328,10 @@ def mbar_hessian(u_kn, N_k, f_k):
     Equation (C9) in JCP MBAR paper.
     """
 
-    return jit_mbar_hessian(u_kn, N_k, f_k)
+    return jax_mbar_hessian(u_kn, N_k, f_k)
 
+
+@jax.jit
 def jax_mbar_log_W_nk(u_kn, N_k, f_k):
     """JAX version of mbar_log_W_nk.
     For parameters, see mbar_log_W_nk
@@ -325,7 +343,7 @@ def jax_mbar_log_W_nk(u_kn, N_k, f_k):
     logW = f_k - u_kn.T - log_denominator_n[:, newaxis]
     return logW
 
-jit_mbar_log_W_nk = jax.jit(jax_mbar_log_W_nk)
+# jit_mbar_log_W_nk = jax.jit(jax_mbar_log_W_nk)
 
 
 def mbar_log_W_nk(u_kn, N_k, f_k):
@@ -349,8 +367,10 @@ def mbar_log_W_nk(u_kn, N_k, f_k):
     -----
     Equation (9) in JCP MBAR paper.
     """
-    return jit_mbar_log_W_nk(u_kn, N_k, f_k)
+    return jax_mbar_log_W_nk(u_kn, N_k, f_k)
 
+
+@jax.jit
 def jax_mbar_W_nk(u_kn, N_k, f_k):
     """JAX version of mbar_W_nk.
     For parameters, see mbar_W_nk
@@ -359,7 +379,8 @@ def jax_mbar_W_nk(u_kn, N_k, f_k):
     """
     return exp(jax_mbar_log_W_nk(u_kn, N_k, f_k))
     
-jit_mbar_W_nk = jax.jit(jax_mbar_W_nk)
+# jit_mbar_W_nk = jax.jit(jax_mbar_W_nk)
+
 
 def mbar_W_nk(u_kn, N_k, f_k):
     """Calculate the weight matrix.
@@ -382,7 +403,8 @@ def mbar_W_nk(u_kn, N_k, f_k):
     -----
     Equation (9) in JCP MBAR paper.
     """
-    return jit_mbar_W_nk(u_kn, N_k, f_k)
+    return jax_mbar_W_nk(u_kn, N_k, f_k)
+
 
 def adaptive(u_kn, N_k, f_k, tol=1.0e-8, options=None):
 
@@ -453,7 +475,7 @@ def adaptive(u_kn, N_k, f_k, tol=1.0e-8, options=None):
     for iteration in range(0, maxiter):
 
         if use_jit:
-            (f_sci, g_sci, gnorm_sci, f_nr, g_nr, gnorm_nr) = jit_core_adaptive(u_kn, N_k, f_k, options['gamma'])
+            (f_sci, g_sci, gnorm_sci, f_nr, g_nr, gnorm_nr) = jax_core_adaptive(u_kn, N_k, f_k, options['gamma'])
         else:
             H = mbar_hessian(u_kn, N_k, f_k)  # Objective function hessian
             Hinvg = np.linalg.lstsq(H, g, rcond=-1)[0]
@@ -540,6 +562,7 @@ def adaptive(u_kn, N_k, f_k, tol=1.0e-8, options=None):
     return results
 
 
+@jax.jit
 def jax_core_adaptive(u_kn, N_k, f_k, gamma):
     """JAX version of adaptive inner loop.
     N_k must be float (should be cast at a higher level)
@@ -563,11 +586,13 @@ def jax_core_adaptive(u_kn, N_k, f_k, gamma):
     g_nr = mbar_gradient(u_kn, N_k, f_nr)
     gnorm_nr = dot(g_nr, g_nr)
 
-    return (f_sci, g_sci, gnorm_sci, f_nr, g_nr, gnorm_nr)
+    return f_sci, g_sci, gnorm_sci, f_nr, g_nr, gnorm_nr
 
-jit_core_adaptive = jax.jit(jax_core_adaptive)
+# jit_core_adaptive = jax.jit(jax_core_adaptive)
 
-def jax_precondition_u_kn(u_kn,N_k,f_k):
+
+@jax.jit
+def jax_precondition_u_kn(u_kn, N_k, f_k):
     """JAX version of precondition_u_kn
     for parameters, see precondition_u_kn
     N_k must be float (should be cast at a higher level)
@@ -578,7 +603,8 @@ def jax_precondition_u_kn(u_kn,N_k,f_k):
     u_kn += (logsumexp(f_k - u_kn.T, b=N_k, axis=1)) - dot(N_k,f_k) / N_k.sum()
     return u_kn
 
-jit_precondition_u_kn = jax.jit(jax_precondition_u_kn)
+# jit_precondition_u_kn = jax.jit(jax_precondition_u_kn)
+
 
 def precondition_u_kn(u_kn, N_k, f_k):
     """Subtract a sample-dependent constant from u_kn to improve precision
@@ -605,7 +631,8 @@ def precondition_u_kn(u_kn, N_k, f_k):
     x_n such that the current objective function value is zero, which
     should give maximum precision in the objective function.
     """
-    return jit_precondition_u_kn(u_kn, N_k, f_k)
+    return jax_precondition_u_kn(u_kn, N_k, f_k)
+
 
 def solve_mbar_once(
     u_kn_nonzero,

--- a/pymbar/tests/test_mbar_solvers.py
+++ b/pymbar/tests/test_mbar_solvers.py
@@ -4,7 +4,7 @@ import pymbar
 from pymbar.utils_for_testing import (
     suppress_derivative_warnings_for_tests,
     suppress_matrix_warnings_for_tests,
-    assert_almost_equal,
+    assert_array_almost_equal,
     oscillators,
     exponentials,
 )
@@ -26,12 +26,12 @@ def test_solvers(statesa, statesb, test_system):
     name, U, N_k, s_n, _ = test_system(statesa, statesb, provide_test=True)
     print(name)
     mbar = pymbar.MBAR(U, N_k)
-    assert_almost_equal(
+    assert_array_almost_equal(
         pymbar.mbar_solvers.mbar_gradient(U, N_k, mbar.f_k), np.zeros(N_k.shape), decimal=8
     )
-    assert_almost_equal(np.exp(mbar.Log_W_nk).sum(0), np.ones(len(N_k)), decimal=10)
-    assert_almost_equal(np.exp(mbar.Log_W_nk).dot(N_k), np.ones(U.shape[1]), decimal=10)
-    assert_almost_equal(
+    assert_array_almost_equal(np.exp(mbar.Log_W_nk).sum(0), np.ones(len(N_k)), decimal=10)
+    assert_array_almost_equal(np.exp(mbar.Log_W_nk).dot(N_k), np.ones(U.shape[1]), decimal=10)
+    assert_array_almost_equal(
         pymbar.mbar_solvers.self_consistent_update(U, N_k, mbar.f_k), mbar.f_k, decimal=10
     )
 
@@ -39,8 +39,8 @@ def test_solvers(statesa, statesb, test_system):
     with suppress_derivative_warnings_for_tests():
         with suppress_matrix_warnings_for_tests():
             mbar0 = pymbar.old_mbar.MBAR(U, N_k)
-    assert_almost_equal(mbar.f_k, mbar0.f_k, decimal=8)
-    assert_almost_equal(np.exp(mbar.Log_W_nk), np.exp(mbar0.Log_W_nk), decimal=5)
+    assert_array_almost_equal(mbar.f_k, mbar0.f_k, decimal=8)
+    assert_array_almost_equal(np.exp(mbar.Log_W_nk), np.exp(mbar0.Log_W_nk), decimal=5)
 
 
 @pytest.mark.parametrize(
@@ -85,4 +85,4 @@ def test_protocols(base_oscillator, protocol):
         fe = results["Delta_f"][0, 1:]
         fe_sigma = results["dDelta_f"][0, 1:]
         z = (fe - fa) / fe_sigma
-        assert_almost_equal(z / z_scale_factor, np.zeros(len(z)), decimal=0)
+        assert_array_almost_equal(z / z_scale_factor, np.zeros(len(z)), decimal=0)


### PR DESCRIPTION
This PR makes the `jax.jit` calls all decorators where used. This makes no effort to be efficient `jit` calls beyond the one conditional code path in `jax_self_consistent_update`.

This PR also makes all the tests pass under this setup, and should get the GitHub Action CI file to correctly pull the JAX (cpu) install. GPU install is beyond the scope of what GHA can reasonably be expected to do.

Fixed an issue in testing where newer version of numpy's `assert_almost_equal` failed because multi-value array default truth is ambiguous. Replaced with `assert_array_almost_equal`, but we should consider replacing with the more stable `assert_allclose`, but it has different tolerances.

Lastly, ensured the `Deltaf_ij` and `dDeltaf_ij` are normal NumPy arrays, which are mutable, instead of the JAX DeviceArray objects which are immutable. This only maters for in-place update calls.