### PR TITLE
Do not use removed `numpy.bool`

### DIFF
--- a/examples/parallel-tempering-2dfes/parallel-tempering-2dfes.py
+++ b/examples/parallel-tempering-2dfes/parallel-tempering-2dfes.py
@@ -212,7 +212,7 @@ else:
 # ===================================================================================================
 
 # Create a list of indices of all configurations in kn-indexing.
-mask_kn = np.zeros([K, N_max], dtype=np.bool)
+mask_kn = np.zeros([K, N_max], dtype=bool)
 for k in range(K):
     mask_kn[k, 0 : N_k[k]] = True
 # Create a list from this mask.


### PR DESCRIPTION
```python3
>>> import numpy
>>> numpy.__version__
'1.24.0'
>>> numpy.bool
<stdin>:1: FutureWarning: In the future `np.bool` will be defined as the corresponding NumPy scalar.  (This may have returned Python scalars in past versions.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/mattthompson/mambaforge/envs/openff-interchange-env/lib/python3.9/site-packages/numpy/__init__.py", line 284, in __getattr__
    raise AttributeError("module {!r} has no attribute "
AttributeError: module 'numpy' has no attribute 'bool'