### PR TITLE
Fix to bootstrap of free energy surfaces, affecting timing

### DIFF
--- a/pymbar/fes.py
+++ b/pymbar/fes.py
@@ -399,11 +399,11 @@ class FES:
                         0, N_k[k], size=N_k[k]
                     )
                     index += N_k[k]
-                    # recompute MBAR.
-                    mbar = pymbar.MBAR(
-                        self.u_kn[:, bootstrap_indices], self.N_k, initial_f_k=self.mbar.f_k
-                    )
-                    x_nb = x_n[bootstrap_indices]
+                # recompute MBAR.
+                mbar = pymbar.MBAR(
+                    self.u_kn[:, bootstrap_indices], self.N_k, initial_f_k=self.mbar.f_k
+                )
+                x_nb = x_n[bootstrap_indices]
 
             # Compute unnormalized log weights for the given reduced potential
             # u_n, needed for all methods.


### PR DESCRIPTION
Free energy surface code was calling MBAR after each call to randomizing bootstraps.  It does not appear to affect the results, but slows things down by a factor of a little less than 2x (146 vs 87 seconds for one sample run).