### PR TITLE
Remove numexpr Dependency

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -5,9 +5,8 @@ dependencies:
     # Base depends
   - python
   - pip
-  - numpy >=1.12,<2.3
+  - numpy >=1.17,<2.3
   - scipy
-  - numexpr
 
     # Testing
   - pytest

--- a/devtools/conda-envs/test_env_jax.yaml
+++ b/devtools/conda-envs/test_env_jax.yaml
@@ -5,9 +5,8 @@ dependencies:
     # Base depends
   - python
   - pip
-  - numpy >=1.12,<2.3
+  - numpy >=1.17,<2.3
   - scipy
-  - numexpr
   - jaxlib
   - jax
     # Testing

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -9,13 +9,12 @@ requirements:
   build:
     - python
     - setuptools
-    - numpy 1.11.*
+    - numpy 1.17.*
     - toolchain
   run:
     - python
-    - numpy >=1.12
+    - numpy >=1.17
     - scipy
-    - numexpr
 
 test:
   requires:

--- a/pymbar/tests/test_utils.py
+++ b/pymbar/tests/test_utils.py
@@ -4,10 +4,7 @@ import pymbar
 from pymbar.utils_for_testing import assert_equal, assert_almost_equal
 from pymbar.utils import ParameterError, ensure_type, TypeCastPerformanceWarning
 
-try:
-    from scipy.special import logsumexp
-except ImportError:
-    from scipy.misc import logsumexp
+from scipy.special import logsumexp
 
 
 def test_logsumexp():

--- a/pymbar/utils.py
+++ b/pymbar/utils.py
@@ -311,7 +311,10 @@ def logsumexp(a, axis=None, b=None, use_numexpr=True):
     """
 
     if use_numexpr:
-        warnings.warn("numexpr is not longer used to compute logsumexp, use_numexpr will be removed in a future release", DeprecationWarning)
+        warnings.warn(
+            "numexpr is not longer used to compute logsumexp, use_numexpr will be removed in a future release",
+            DeprecationWarning,
+        )
     return scipy_logsumexp(a, axis=axis, b=b)
 
 

--- a/pymbar/utils.py
+++ b/pymbar/utils.py
@@ -311,7 +311,7 @@ def logsumexp(a, axis=None, b=None, use_numexpr=True):
     """
 
     if use_numexpr:
-        warnings.warn("numexpr is not longer used to compute logsumexp, use_numexpr will be removed in a future release", warnings.DeprecationWarning)
+        warnings.warn("numexpr is not longer used to compute logsumexp, use_numexpr will be removed in a future release", DeprecationWarning)
     return scipy_logsumexp(a, axis=axis, b=b)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [
 
 dynamic = [ "version" ]
 dependencies = [
-  "numexpr",
   "numpy>=1.17",
   "scipy",
 ]


### PR DESCRIPTION
I noticed that `numexpr` is a dependency of Pymbar that is only used in the `pymbar.utils.logsumexp` function. This appears to be used by `fes` and `mbar`, so perhaps this is still significant. Seemed like using the scipy implementation would be cleaner and reduce the number of dependencies. 

This removes the dependency and calls out to `scipy.special.logsumexp` rather than having a custom implementation. Attempted to make the change such that the API is backwards compatible, but it will always throw a warning if called.  