### PR TITLE
Use MBAR Relative Tolerance in solvers

### DIFF
--- a/pymbar/mbar.py
+++ b/pymbar/mbar.py
@@ -229,7 +229,6 @@ class MBAR:
         >>> mbar = MBAR(u_kn, N_k)
 
         """
-
         # Store local copies of necessary data.
         # N_k[k] is the number of samples from state k, some of which might be zero.
         self.N_k = np.array(N_k, dtype=np.int64)
@@ -412,7 +411,12 @@ class MBAR:
                 bootstrap_solver_protocol = prot
 
         self.f_k = mbar_solvers.solve_mbar_for_all_states(
-            self.u_kn, self.N_k, self.f_k, self.states_with_samples, solver_protocol
+            self.u_kn,
+            self.N_k,
+            self.f_k,
+            self.states_with_samples,
+            solver_protocol,
+            tol=relative_tolerance,
         )
 
         if n_bootstraps > 0:
@@ -441,6 +445,7 @@ class MBAR:
                     f_k_init,
                     self.states_with_samples,
                     bootstrap_solver_protocol,
+                    tol=relative_tolerance,
                 )
                 # save the random integers for computing expectations.
                 self.bootstrap_rints[b, :] = rints

--- a/pymbar/mbar_solvers.py
+++ b/pymbar/mbar_solvers.py
@@ -1066,7 +1066,7 @@ def solve_mbar_once(
     return f_k_nonzero, results
 
 
-def solve_mbar(u_kn_nonzero, N_k_nonzero, f_k_nonzero, solver_protocol=None):
+def solve_mbar(u_kn_nonzero, N_k_nonzero, f_k_nonzero, solver_protocol=None, tol=1e-12):
     """Solve MBAR self-consistent equations using some sequence of equation solvers.
 
     Parameters
@@ -1081,6 +1081,8 @@ def solve_mbar(u_kn_nonzero, N_k_nonzero, f_k_nonzero, solver_protocol=None):
     solver_protocol : tuple(dict()), optional, default=None
         Optional list of dictionaries of steps in solver protocol.
         If None, a default protocol will be used.
+    tol : float
+        relative tolerance for convergence (default 1.0e-12)
 
     Returns
     -------
@@ -1115,7 +1117,7 @@ def solve_mbar(u_kn_nonzero, N_k_nonzero, f_k_nonzero, solver_protocol=None):
 
     for solver in solver_protocol:
         f_k_nonzero_result, results = solve_mbar_once(
-            u_kn_nonzero, N_k_nonzero, f_k_nonzero, **solver
+            u_kn_nonzero, N_k_nonzero, f_k_nonzero, **solver, tol=tol
         )
         all_fks.append(f_k_nonzero_result)
         all_gnorms.append(
@@ -1157,7 +1159,7 @@ def solve_mbar(u_kn_nonzero, N_k_nonzero, f_k_nonzero, solver_protocol=None):
     return f_k_nonzero_result, all_results
 
 
-def solve_mbar_for_all_states(u_kn, N_k, f_k, states_with_samples, solver_protocol):
+def solve_mbar_for_all_states(u_kn, N_k, f_k, states_with_samples, solver_protocol, tol=1e-12):
     """Solve for free energies of states with samples, then calculate for
     empty states.
 
@@ -1172,6 +1174,8 @@ def solve_mbar_for_all_states(u_kn, N_k, f_k, states_with_samples, solver_protoc
     solver_protocol : tuple(dict()), optional, default=None
         Sequence of dictionaries of steps in solver protocol for final
         stage of refinement.
+    tol : float
+        relative tolerance for convergence (default 1.0e-12)
 
     Returns
     -------
@@ -1187,6 +1191,7 @@ def solve_mbar_for_all_states(u_kn, N_k, f_k, states_with_samples, solver_protoc
             N_k[states_with_samples],
             f_k[states_with_samples],
             solver_protocol=solver_protocol,
+            tol=tol,
         )
 
     f_k[states_with_samples] = np.array(f_k_nonzero)

--- a/pymbar/tests/test_mbar.py
+++ b/pymbar/tests/test_mbar.py
@@ -2,12 +2,15 @@
 for which the true free energy differences can be computed analytically.
 """
 
+from unittest.mock import patch
+
 import numpy as np
 import pytest
 from pymbar import MBAR
 from pymbar.testsystems import harmonic_oscillators, exponential_distributions
 from pymbar.utils_for_testing import assert_equal, assert_almost_equal
 from pymbar.utils import ParameterError
+from pymbar.mbar_solvers import solve_mbar
 
 precision = 8  # the precision for systems that do have analytical results that should be matched.
 # Scales the z_scores so that we can reject things that differ at the ones decimal place.  TEMPORARY HACK
@@ -111,6 +114,28 @@ def test_duplicate_state(fixed_harmonic_sample, caplog):
     results = mbar.compute_free_energy_differences()
     fe = results["Delta_f"]
     assert np.allclose(fe[0], fe[-1])
+
+
+def test_tolerance_passed_to_solve_mbar(fixed_harmonic_sample, caplog):
+    """Test that the relative tolerance provided to mbar is passed all the way down"""
+    _, u_kn, _, _ = fixed_harmonic_sample.sample(N_k, mode="u_kn")
+
+    tolerances = []
+
+    def mocked_solve_mbar(*args, **kwargs):
+        tolerances.append(kwargs["tol"])
+        return solve_mbar(*args, **kwargs)
+
+    with patch("pymbar.mbar_solvers.solve_mbar", mocked_solve_mbar):
+        mbar = MBAR(u_kn, N_k, verbose=True)
+        assert len(tolerances) > 0
+        assert all(x == 1e-7 for x in tolerances)
+        tolerances.clear()
+
+        new_tolerance = 1e-12
+        mbar = MBAR(u_kn, N_k, relative_tolerance=new_tolerance, verbose=True)
+        assert len(tolerances) > 0
+        assert all(x == new_tolerance for x in tolerances)
 
 
 def test_x_kindices(fixed_harmonic_sample):


### PR DESCRIPTION
While running some simulations I noticed that despite passing `relative_tolerance=1e-7` to the MBAR object, the  warnings about convergence indicated that the tolerance was set to `1e-12`. This PR makes sure to pass the relative tolerance all the way down to the `solve_mbar` method.

