### PR TITLE
Chunked + JAX-jit'd MBAR with vectorised batch evaluation

### DIFF
--- a/pymbar/_chunked.py
+++ b/pymbar/_chunked.py
@@ -1,0 +1,137 @@
+"""Chunked working-array variants of the MBAR inner-fit operations.
+
+The default `mbar_solvers.py` calls
+
+    log_denominator_n = logsumexp(f_k - u_kn.T, b=N_k, axis=1)
+
+which materializes a (N, K) working array the same size as ``u_kn``. For
+large N, this is the dominant peak-memory cost during the fit -- not
+``u_kn`` itself. See pymbar issue #574.
+
+These helpers compute the same quantities by streaming over the sample
+axis, with peak working-array memory ``O(chunk_size * K)`` instead of
+``O(N * K)``. Numpy-only; the JAX path is preserved for callers that fit
+in memory.
+"""
+import numpy as np
+
+
+def chunked_log_denominator(u_kn, N_k, f_k, chunk_size):
+    """Streaming logsumexp(f_k - u_kn.T, b=N_k, axis=1).
+
+    log_denom[n] = log sum_k N_k * exp(f_k - u_kn[k, n])
+    """
+    N = u_kn.shape[1]
+    with np.errstate(divide='ignore'):
+        log_N = np.log(N_k).astype(u_kn.dtype)  # -inf for N_k = 0; drops cleanly
+    a = (f_k + log_N).astype(u_kn.dtype)  # (K,)
+    out = np.empty(N, dtype=u_kn.dtype)
+    for s in range(0, N, chunk_size):
+        e = min(s + chunk_size, N)
+        z = a[:, None] - u_kn[:, s:e]  # (K, B)
+        m = z.max(axis=0)
+        np.subtract(z, m, out=z)
+        np.exp(z, out=z)
+        out[s:e] = m + np.log(z.sum(axis=0))
+    return out
+
+
+def chunked_log_numerator_k(u_kn, log_denominator_n, chunk_size):
+    """Streaming logsumexp(-log_denominator_n - u_kn, axis=1).
+
+    log_num_k[k] = log sum_n exp(-log_denominator_n[n] - u_kn[k, n])
+
+    Maintains a running max-shift per state across chunks.
+    """
+    K, N = u_kn.shape
+    m_k = np.full(K, -np.inf, dtype=u_kn.dtype)
+    S_k = np.zeros(K, dtype=u_kn.dtype)
+    for s in range(0, N, chunk_size):
+        e = min(s + chunk_size, N)
+        z = -log_denominator_n[s:e][None, :] - u_kn[:, s:e]  # (K, B)
+        m_chunk = z.max(axis=1)
+        m_new = np.maximum(m_k, m_chunk)
+        # exp(m_k - m_new) is 0 when m_k = -inf (initial); guard the all-inf
+        # corner case where m_new is also -inf.
+        with np.errstate(invalid='ignore'):
+            scale = np.where(np.isfinite(m_new), np.exp(m_k - m_new), 0.0)
+        np.subtract(z, m_new[:, None], out=z)
+        np.exp(z, out=z)
+        S_k = S_k * scale + z.sum(axis=1)
+        m_k = m_new
+    return m_k + np.log(S_k)
+
+
+def chunked_mbar_objective(u_kn, N_k, f_k, chunk_size):
+    """Equivalent to jax_mbar_objective."""
+    log_denom_n = chunked_log_denominator(u_kn, N_k, f_k, chunk_size)
+    return float(np.sum(log_denom_n) - np.dot(N_k, f_k))
+
+
+def chunked_mbar_gradient(u_kn, N_k, f_k, chunk_size):
+    """Equivalent to jax_mbar_gradient."""
+    log_denom_n = chunked_log_denominator(u_kn, N_k, f_k, chunk_size)
+    log_num_k = chunked_log_numerator_k(u_kn, log_denom_n, chunk_size)
+    return -1.0 * N_k * (1.0 - np.exp(f_k + log_num_k))
+
+
+def chunked_mbar_objective_and_gradient(u_kn, N_k, f_k, chunk_size):
+    """Equivalent to jax_mbar_objective_and_gradient (single log_denom pass)."""
+    log_denom_n = chunked_log_denominator(u_kn, N_k, f_k, chunk_size)
+    obj = float(np.sum(log_denom_n) - np.dot(N_k, f_k))
+    log_num_k = chunked_log_numerator_k(u_kn, log_denom_n, chunk_size)
+    grad = -1.0 * N_k * (1.0 - np.exp(f_k + log_num_k))
+    return obj, grad
+
+
+def chunked_mbar_hessian(u_kn, N_k, f_k, chunk_size):
+    """Equivalent to jax_mbar_hessian. Streams W_chunk = exp(...) of shape
+    (B, K) and accumulates H += W_chunk.T @ W_chunk into a (K, K) buffer."""
+    log_denom_n = chunked_log_denominator(u_kn, N_k, f_k, chunk_size)
+    K, N = u_kn.shape
+    H = np.zeros((K, K), dtype=u_kn.dtype)
+    W_sum = np.zeros(K, dtype=u_kn.dtype)
+    for s in range(0, N, chunk_size):
+        e = min(s + chunk_size, N)
+        W = np.exp(f_k[None, :] - u_kn[:, s:e].T - log_denom_n[s:e, None])
+        H += W.T @ W
+        W_sum += W.sum(axis=0)
+    H *= N_k
+    H *= N_k[:, None]
+    H -= np.diag(W_sum * N_k)
+    return -H
+
+
+def chunked_self_consistent_update(u_kn, N_k, f_k, chunk_size):
+    """Equivalent to _jit_self_consistent_update."""
+    log_denom_n = chunked_log_denominator(u_kn, N_k, f_k, chunk_size)
+    return -chunked_log_numerator_k(u_kn, log_denom_n, chunk_size)
+
+
+def chunked_precondition_u_kn(u_kn, N_k, f_k, chunk_size):
+    """In-place precondition: ``u_kn -= u_kn.min(0); u_kn += log_denom - shift``.
+
+    Mutates ``u_kn``. Caller must rebind, like ``u_kn = precondition_u_kn(u_kn, ...)``,
+    to match jax_precondition_u_kn semantics. MBAR is invariant under per-sample
+    shifts so f_k and Log_W_nk are unaffected.
+    """
+    u_min = u_kn.min(axis=0)  # (N,)
+    np.subtract(u_kn, u_min, out=u_kn)
+    log_denom_n = chunked_log_denominator(u_kn, N_k, f_k, chunk_size)
+    shift = log_denom_n - float(np.dot(N_k, f_k) / N_k.sum())
+    np.add(u_kn, shift, out=u_kn)
+    return u_kn
+
+
+def chunked_mbar_log_W_nk(u_kn, N_k, f_k, chunk_size):
+    """Equivalent to jax_mbar_log_W_nk. The output is shape (N, K) so this
+    only chunks the *peak* during construction, not the result.
+    """
+    log_denom_n = chunked_log_denominator(u_kn, N_k, f_k, chunk_size)
+    K, N = u_kn.shape
+    out = np.empty((N, K), dtype=u_kn.dtype)
+    for s in range(0, N, chunk_size):
+        out[s:s + chunk_size] = (
+            f_k[None, :] - u_kn[:, s:s + chunk_size].T
+            - log_denom_n[s:s + chunk_size, None])
+    return out

--- a/pymbar/_chunked.py
+++ b/pymbar/_chunked.py
@@ -10,14 +10,100 @@ large N, this is the dominant peak-memory cost during the fit -- not
 
 These helpers compute the same quantities by streaming over the sample
 axis, with peak working-array memory ``O(chunk_size * K)`` instead of
-``O(N * K)``. Numpy-only; the JAX path is preserved for callers that fit
-in memory.
+``O(N * K)``.
 
 The helpers accept either a dense ``(K, N)`` ndarray or a zero-arg
 callable yielding ``(K, B)`` chunks (so even ``u_kn`` itself can be
 streamed from disk).
+
+When JAX is importable (and ``PYMBAR_DISABLE_JAX`` is unset), the
+per-chunk inner kernels run jit-compiled at fixed ``(K, chunk_size)``
+shape; otherwise the same code runs as plain numpy. Last chunks shorter
+than ``chunk_size`` are padded with ``+inf`` so the same compiled kernel
+applies, then the valid prefix is sliced on output.
 """
+import os
+
 import numpy as np
+
+try:
+    if os.environ.get("PYMBAR_DISABLE_JAX", "").lower() in ("true", "yes", "1"):
+        raise ImportError("JAX disabled by PYMBAR_DISABLE_JAX")
+    from jax import config as _jax_config
+    if not _jax_config.x64_enabled:
+        _jax_config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+    from jax import jit
+    _USE_JIT = True
+except ImportError:
+    _USE_JIT = False
+    jnp = np
+
+    def jit(fn):
+        return fn
+
+
+# =============================================================================
+# Per-chunk inner kernels. JIT-compiled at fixed (K, chunk_size) shape when JAX
+# is available; same code paths execute as plain numpy when not. Outer loops
+# call these once per chunk, padding the last chunk with +inf so the cached
+# compile applies (the +inf entries contribute 0 to logsumexp / W).
+# =============================================================================
+
+
+@jit
+def _kernel_log_denom(a, chunk):
+    """logsumexp(a - chunk.T, axis=1). a: (K,), chunk: (K, B). returns (B,)."""
+    z = a[:, None] - chunk
+    m = z.max(axis=0)
+    return m + jnp.log(jnp.exp(z - m).sum(axis=0))
+
+
+@jit
+def _kernel_log_num_update(m_k, S_k, log_denom_chunk, chunk):
+    """One streaming step of running max-shift accumulator for log_numerator_k.
+
+    Updates (m_k, S_k) given a new chunk. Returns (m_new, S_new).
+    """
+    z = -log_denom_chunk[None, :] - chunk  # (K, B)
+    m_chunk = z.max(axis=1)
+    m_new = jnp.maximum(m_k, m_chunk)
+    finite = jnp.isfinite(m_new)
+    scale = jnp.where(finite, jnp.exp(m_k - m_new), 0.0)
+    contrib = jnp.where(finite[:, None], jnp.exp(z - m_new[:, None]), 0.0).sum(axis=1)
+    return m_new, S_k * scale + contrib
+
+
+@jit
+def _kernel_hessian_update(H, W_sum, f_k, chunk, log_denom_chunk):
+    """One streaming step of Hessian Gram accumulation. Returns (H_new, W_sum_new)."""
+    W = jnp.exp(f_k[None, :] - chunk.T - log_denom_chunk[:, None])  # (B, K)
+    return H + W.T @ W, W_sum + W.sum(axis=0)
+
+
+@jit
+def _kernel_log_W_chunk(f_k, chunk, log_denom_chunk):
+    """log_W chunk: f_k - chunk.T - log_denom_chunk[:, None]. Returns (B, K)."""
+    return f_k[None, :] - chunk.T - log_denom_chunk[:, None]
+
+
+def _pad_to(chunk, target_B):
+    """Pad chunk (K, B) to (K, target_B) with +inf so logsumexp ignores padded
+    samples (exp(-inf) = 0). Pass-through when shapes match."""
+    B = chunk.shape[1]
+    if B == target_B:
+        return chunk
+    return np.pad(chunk, ((0, 0), (0, target_B - B)), constant_values=np.inf)
+
+
+def _pad_ld(ld, target_B, dtype):
+    """Pad log_denominator_n slice (B,) to (target_B,) with zeros. Padded
+    entries are arbitrary: the chunk's +inf padding forces z = -ld - chunk
+    to -inf, so exp contribution is 0 regardless of ld value."""
+    B = ld.shape[0]
+    if B == target_B:
+        return ld
+    return np.concatenate([ld, np.zeros(target_B - B, dtype=dtype)])
 
 
 def _iter_chunks(u_kn, chunk_size):
@@ -66,40 +152,35 @@ def chunked_log_denominator(u_kn, N_k, f_k, chunk_size):
     a = (f_k + log_N).astype(dtype)  # (K,)
     out = np.empty(N, dtype=dtype)
     for s, chunk in _iter_chunks(u_kn, chunk_size):
-        e = s + chunk.shape[1]
-        z = a[:, None] - chunk  # (K, B)
-        m = z.max(axis=0)
-        np.subtract(z, m, out=z)
-        np.exp(z, out=z)
-        out[s:e] = m + np.log(z.sum(axis=0))
+        B = chunk.shape[1]
+        res = _kernel_log_denom(a, _pad_to(chunk, chunk_size))
+        out[s:s + B] = np.asarray(res[:B])
     return out
+
+
+def _chunked_log_num_rows(u_arr, log_denominator_n, chunk_size, R):
+    """Streaming logsumexp(-u_arr - log_denominator_n, axis=1) for an R-row
+    matrix. Per-row running max-shift / sum across chunks. Shared by
+    chunked_log_numerator_k (sampled states; R from N_k for callable u_kn)
+    and chunked_log_numerator_l (perturbed states; R from u_ln.shape[0]).
+    """
+    dtype = _dtype_of(u_arr)
+    m = np.full(R, -np.inf, dtype=dtype)
+    S = np.zeros(R, dtype=dtype)
+    for s, chunk in _iter_chunks(u_arr, chunk_size):
+        B = chunk.shape[1]
+        ld = _pad_ld(log_denominator_n[s:s + B], chunk_size, dtype)
+        m, S = _kernel_log_num_update(m, S, ld, _pad_to(chunk, chunk_size))
+    return np.array(m) + np.log(np.array(S))
 
 
 def chunked_log_numerator_k(u_kn, N_k, log_denominator_n, chunk_size):
     """Streaming logsumexp(-log_denominator_n - u_kn, axis=1).
 
     log_num_k[k] = log sum_n exp(-log_denominator_n[n] - u_kn[k, n])
-
-    Maintains a running max-shift per state across chunks.
     """
     K, _ = _shape_of(u_kn, N_k)
-    dtype = _dtype_of(u_kn)
-    m_k = np.full(K, -np.inf, dtype=dtype)
-    S_k = np.zeros(K, dtype=dtype)
-    for s, chunk in _iter_chunks(u_kn, chunk_size):
-        e = s + chunk.shape[1]
-        z = -log_denominator_n[s:e][None, :] - chunk  # (K, B)
-        m_chunk = z.max(axis=1)
-        m_new = np.maximum(m_k, m_chunk)
-        # exp(m_k - m_new) is 0 when m_k = -inf (initial); guard the all-inf
-        # corner case where m_new is also -inf.
-        with np.errstate(invalid='ignore'):
-            scale = np.where(np.isfinite(m_new), np.exp(m_k - m_new), 0.0)
-        np.subtract(z, m_new[:, None], out=z)
-        np.exp(z, out=z)
-        S_k = S_k * scale + z.sum(axis=1)
-        m_k = m_new
-    return m_k + np.log(S_k)
+    return _chunked_log_num_rows(u_kn, log_denominator_n, chunk_size, K)
 
 
 def chunked_mbar_objective(u_kn, N_k, f_k, chunk_size):
@@ -133,10 +214,11 @@ def chunked_mbar_hessian(u_kn, N_k, f_k, chunk_size):
     H = np.zeros((K, K), dtype=dtype)
     W_sum = np.zeros(K, dtype=dtype)
     for s, chunk in _iter_chunks(u_kn, chunk_size):
-        e = s + chunk.shape[1]
-        W = np.exp(f_k[None, :] - chunk.T - log_denom_n[s:e, None])
-        H += W.T @ W
-        W_sum += W.sum(axis=0)
+        B = chunk.shape[1]
+        ld = _pad_ld(log_denom_n[s:s + B], chunk_size, dtype)
+        H, W_sum = _kernel_hessian_update(H, W_sum, f_k, _pad_to(chunk, chunk_size), ld)
+    H = np.array(H, dtype=dtype)
+    W_sum = np.array(W_sum, dtype=dtype)
     H *= N_k
     H *= N_k[:, None]
     H -= np.diag(W_sum * N_k)
@@ -194,8 +276,58 @@ def chunked_mbar_log_W_nk(u_kn, N_k, f_k, chunk_size):
     """
     log_denom_n = chunked_log_denominator(u_kn, N_k, f_k, chunk_size)
     K, N = _shape_of(u_kn, N_k)
-    out = np.empty((N, K), dtype=_dtype_of(u_kn))
+    dtype = _dtype_of(u_kn)
+    out = np.empty((N, K), dtype=dtype)
     for s, chunk in _iter_chunks(u_kn, chunk_size):
-        e = s + chunk.shape[1]
-        out[s:e] = f_k[None, :] - chunk.T - log_denom_n[s:e, None]
+        B = chunk.shape[1]
+        ld = _pad_ld(log_denom_n[s:s + B], chunk_size, dtype)
+        res = _kernel_log_W_chunk(f_k, _pad_to(chunk, chunk_size), ld)
+        out[s:s + B] = np.asarray(res[:B])
     return out
+
+
+# =============================================================================
+# Batch-evaluation helpers (point-estimate path for compute_expectations and
+# compute_perturbed_free_energies). Same _kernel_log_num_update as the fit-side
+# helpers; row dimension is now perturbed states (no N_k weighting) or
+# (state, observable) pairs from a state_map.
+# =============================================================================
+
+
+def chunked_log_numerator_l(u_ln, log_denominator_n, chunk_size):
+    """Streaming logsumexp(-u_ln - log_denominator_n, axis=1) for perturbed
+    (unsampled) states. Used by compute_expectations_inner for log_C_a[l].
+    """
+    return _chunked_log_num_rows(u_ln, log_denominator_n, chunk_size,
+                                 u_ln.shape[0])
+
+
+def chunked_log_observable(u_ln, log_A_n, state_map, log_denominator_n,
+                           chunk_size):
+    """Streaming logsumexp(log_A_n[i, n] - u_ln[l, n] - log_denominator_n[n], axis=n)
+    for each (l, i) = (state_map[0, s], state_map[1, s]) over s = 0..S-1.
+
+    log_obs_s[s] = log sum_n exp(log_A_n[state_map[1, s], n]
+                                 - u_ln[state_map[0, s], n]
+                                 - log_denominator_n[n])
+
+    Used by compute_expectations_inner: f_k[K + NL + s] = -log_obs_s[s].
+    Peak working memory O(S * chunk_size); pick chunk_size so this stays
+    below the dense-path footprint S * N.
+    """
+    S = state_map.shape[1]
+    dtype = _dtype_of(u_ln)
+    l_idx = state_map[0, :]
+    i_idx = state_map[1, :]
+    m_s = np.full(S, -np.inf, dtype=dtype)
+    Sum_s = np.zeros(S, dtype=dtype)
+    for s, u_chunk in _iter_chunks(u_ln, chunk_size):
+        B = u_chunk.shape[1]
+        # _kernel_log_num_update computes z = -log_denom - chunk; we want
+        # z[t, n] = log_A_n[i_t, n] - u_ln[l_t, n] - log_denom[n], so feed
+        # chunk_eff = u_ln[l_t] - log_A_n[i_t].
+        chunk_eff = (u_chunk[l_idx] - log_A_n[i_idx, s:s + B]).astype(dtype)
+        ld = _pad_ld(log_denominator_n[s:s + B], chunk_size, dtype)
+        m_s, Sum_s = _kernel_log_num_update(
+            m_s, Sum_s, ld, _pad_to(chunk_eff, chunk_size))
+    return np.array(m_s) + np.log(np.array(Sum_s))

--- a/pymbar/_chunked.py
+++ b/pymbar/_chunked.py
@@ -12,8 +12,46 @@ These helpers compute the same quantities by streaming over the sample
 axis, with peak working-array memory ``O(chunk_size * K)`` instead of
 ``O(N * K)``. Numpy-only; the JAX path is preserved for callers that fit
 in memory.
+
+The helpers accept either a dense ``(K, N)`` ndarray or a zero-arg
+callable yielding ``(K, B)`` chunks (so even ``u_kn`` itself can be
+streamed from disk).
 """
 import numpy as np
+
+
+def _iter_chunks(u_kn, chunk_size):
+    """Yield (start_index, (K, B) chunk) pairs from either dense u_kn or a
+    callable. The callable form must return a fresh iterator on each call
+    (so it can be re-iterated within a fit) and must yield deterministic
+    chunks summing to the full N.
+    """
+    if isinstance(u_kn, np.ndarray):
+        N = u_kn.shape[1]
+        for s in range(0, N, chunk_size):
+            yield s, u_kn[:, s:s + chunk_size]
+    elif callable(u_kn):
+        s = 0
+        for chunk in u_kn():
+            yield s, chunk
+            s += chunk.shape[1]
+    else:
+        raise TypeError(
+            f"u_kn must be ndarray or zero-arg callable, got {type(u_kn).__name__}")
+
+
+def _shape_of(u_kn, N_k):
+    """Return (K, N) for either dense ndarray or callable u_kn. For callables,
+    K and N are inferred from N_k.
+    """
+    if isinstance(u_kn, np.ndarray):
+        return u_kn.shape
+    return len(N_k), int(np.sum(N_k))
+
+
+def _dtype_of(u_kn):
+    """Best-effort dtype detection; falls back to float64 for callables."""
+    return u_kn.dtype if isinstance(u_kn, np.ndarray) else np.float64
 
 
 def chunked_log_denominator(u_kn, N_k, f_k, chunk_size):
@@ -21,14 +59,15 @@ def chunked_log_denominator(u_kn, N_k, f_k, chunk_size):
 
     log_denom[n] = log sum_k N_k * exp(f_k - u_kn[k, n])
     """
-    N = u_kn.shape[1]
+    _, N = _shape_of(u_kn, N_k)
+    dtype = _dtype_of(u_kn)
     with np.errstate(divide='ignore'):
-        log_N = np.log(N_k).astype(u_kn.dtype)  # -inf for N_k = 0; drops cleanly
-    a = (f_k + log_N).astype(u_kn.dtype)  # (K,)
-    out = np.empty(N, dtype=u_kn.dtype)
-    for s in range(0, N, chunk_size):
-        e = min(s + chunk_size, N)
-        z = a[:, None] - u_kn[:, s:e]  # (K, B)
+        log_N = np.log(N_k).astype(dtype)  # -inf for N_k = 0; drops cleanly
+    a = (f_k + log_N).astype(dtype)  # (K,)
+    out = np.empty(N, dtype=dtype)
+    for s, chunk in _iter_chunks(u_kn, chunk_size):
+        e = s + chunk.shape[1]
+        z = a[:, None] - chunk  # (K, B)
         m = z.max(axis=0)
         np.subtract(z, m, out=z)
         np.exp(z, out=z)
@@ -36,19 +75,20 @@ def chunked_log_denominator(u_kn, N_k, f_k, chunk_size):
     return out
 
 
-def chunked_log_numerator_k(u_kn, log_denominator_n, chunk_size):
+def chunked_log_numerator_k(u_kn, N_k, log_denominator_n, chunk_size):
     """Streaming logsumexp(-log_denominator_n - u_kn, axis=1).
 
     log_num_k[k] = log sum_n exp(-log_denominator_n[n] - u_kn[k, n])
 
     Maintains a running max-shift per state across chunks.
     """
-    K, N = u_kn.shape
-    m_k = np.full(K, -np.inf, dtype=u_kn.dtype)
-    S_k = np.zeros(K, dtype=u_kn.dtype)
-    for s in range(0, N, chunk_size):
-        e = min(s + chunk_size, N)
-        z = -log_denominator_n[s:e][None, :] - u_kn[:, s:e]  # (K, B)
+    K, _ = _shape_of(u_kn, N_k)
+    dtype = _dtype_of(u_kn)
+    m_k = np.full(K, -np.inf, dtype=dtype)
+    S_k = np.zeros(K, dtype=dtype)
+    for s, chunk in _iter_chunks(u_kn, chunk_size):
+        e = s + chunk.shape[1]
+        z = -log_denominator_n[s:e][None, :] - chunk  # (K, B)
         m_chunk = z.max(axis=1)
         m_new = np.maximum(m_k, m_chunk)
         # exp(m_k - m_new) is 0 when m_k = -inf (initial); guard the all-inf
@@ -71,7 +111,7 @@ def chunked_mbar_objective(u_kn, N_k, f_k, chunk_size):
 def chunked_mbar_gradient(u_kn, N_k, f_k, chunk_size):
     """Equivalent to jax_mbar_gradient."""
     log_denom_n = chunked_log_denominator(u_kn, N_k, f_k, chunk_size)
-    log_num_k = chunked_log_numerator_k(u_kn, log_denom_n, chunk_size)
+    log_num_k = chunked_log_numerator_k(u_kn, N_k, log_denom_n, chunk_size)
     return -1.0 * N_k * (1.0 - np.exp(f_k + log_num_k))
 
 
@@ -79,7 +119,7 @@ def chunked_mbar_objective_and_gradient(u_kn, N_k, f_k, chunk_size):
     """Equivalent to jax_mbar_objective_and_gradient (single log_denom pass)."""
     log_denom_n = chunked_log_denominator(u_kn, N_k, f_k, chunk_size)
     obj = float(np.sum(log_denom_n) - np.dot(N_k, f_k))
-    log_num_k = chunked_log_numerator_k(u_kn, log_denom_n, chunk_size)
+    log_num_k = chunked_log_numerator_k(u_kn, N_k, log_denom_n, chunk_size)
     grad = -1.0 * N_k * (1.0 - np.exp(f_k + log_num_k))
     return obj, grad
 
@@ -88,12 +128,13 @@ def chunked_mbar_hessian(u_kn, N_k, f_k, chunk_size):
     """Equivalent to jax_mbar_hessian. Streams W_chunk = exp(...) of shape
     (B, K) and accumulates H += W_chunk.T @ W_chunk into a (K, K) buffer."""
     log_denom_n = chunked_log_denominator(u_kn, N_k, f_k, chunk_size)
-    K, N = u_kn.shape
-    H = np.zeros((K, K), dtype=u_kn.dtype)
-    W_sum = np.zeros(K, dtype=u_kn.dtype)
-    for s in range(0, N, chunk_size):
-        e = min(s + chunk_size, N)
-        W = np.exp(f_k[None, :] - u_kn[:, s:e].T - log_denom_n[s:e, None])
+    K, _ = _shape_of(u_kn, N_k)
+    dtype = _dtype_of(u_kn)
+    H = np.zeros((K, K), dtype=dtype)
+    W_sum = np.zeros(K, dtype=dtype)
+    for s, chunk in _iter_chunks(u_kn, chunk_size):
+        e = s + chunk.shape[1]
+        W = np.exp(f_k[None, :] - chunk.T - log_denom_n[s:e, None])
         H += W.T @ W
         W_sum += W.sum(axis=0)
     H *= N_k
@@ -105,22 +146,46 @@ def chunked_mbar_hessian(u_kn, N_k, f_k, chunk_size):
 def chunked_self_consistent_update(u_kn, N_k, f_k, chunk_size):
     """Equivalent to _jit_self_consistent_update."""
     log_denom_n = chunked_log_denominator(u_kn, N_k, f_k, chunk_size)
-    return -chunked_log_numerator_k(u_kn, log_denom_n, chunk_size)
+    return -chunked_log_numerator_k(u_kn, N_k, log_denom_n, chunk_size)
 
 
 def chunked_precondition_u_kn(u_kn, N_k, f_k, chunk_size):
-    """In-place precondition: ``u_kn -= u_kn.min(0); u_kn += log_denom - shift``.
+    """Sample-wise shift of u_kn: ``u_kn -= u_kn.min(0); u_kn += log_denom - shift``.
 
-    Mutates ``u_kn``. Caller must rebind, like ``u_kn = precondition_u_kn(u_kn, ...)``,
-    to match jax_precondition_u_kn semantics. MBAR is invariant under per-sample
-    shifts so f_k and Log_W_nk are unaffected.
+    Dense path: mutates ``u_kn`` in-place, returns the same array.
+    Callable path: returns a new callable that yields preconditioned chunks.
+
+    MBAR is invariant under per-sample shifts so f_k and Log_W_nk are
+    unaffected by either form.
     """
-    u_min = u_kn.min(axis=0)  # (N,)
-    np.subtract(u_kn, u_min, out=u_kn)
-    log_denom_n = chunked_log_denominator(u_kn, N_k, f_k, chunk_size)
-    shift = log_denom_n - float(np.dot(N_k, f_k) / N_k.sum())
-    np.add(u_kn, shift, out=u_kn)
-    return u_kn
+    if isinstance(u_kn, np.ndarray):
+        u_min = u_kn.min(axis=0)  # (N,)
+        np.subtract(u_kn, u_min, out=u_kn)
+        log_denom_n = chunked_log_denominator(u_kn, N_k, f_k, chunk_size)
+        shift = log_denom_n - float(np.dot(N_k, f_k) / N_k.sum())
+        np.add(u_kn, shift, out=u_kn)
+        return u_kn
+    # Callable path: two streaming passes for u_min and log_denom, then
+    # return a wrapping callable that applies the per-sample shift on read.
+    _, N = _shape_of(u_kn, N_k)
+    u_min = np.empty(N, dtype=_dtype_of(u_kn))
+    for s, chunk in _iter_chunks(u_kn, chunk_size):
+        u_min[s:s + chunk.shape[1]] = chunk.min(axis=0)
+    log_denom_n = chunked_log_denominator(_shifted_provider(u_kn, -u_min),
+                                           N_k, f_k, chunk_size)
+    shift_n = (-u_min) + (log_denom_n - float(np.dot(N_k, f_k) / N_k.sum()))
+    return _shifted_provider(u_kn, shift_n)
+
+
+def _shifted_provider(base, shift):
+    """Wrap a callable u_kn so each yielded chunk is offset by shift[s:s+B]."""
+    def provider():
+        s = 0
+        for chunk in base():
+            B = chunk.shape[1]
+            yield chunk + shift[s:s + B]
+            s += B
+    return provider
 
 
 def chunked_mbar_log_W_nk(u_kn, N_k, f_k, chunk_size):
@@ -128,10 +193,9 @@ def chunked_mbar_log_W_nk(u_kn, N_k, f_k, chunk_size):
     only chunks the *peak* during construction, not the result.
     """
     log_denom_n = chunked_log_denominator(u_kn, N_k, f_k, chunk_size)
-    K, N = u_kn.shape
-    out = np.empty((N, K), dtype=u_kn.dtype)
-    for s in range(0, N, chunk_size):
-        out[s:s + chunk_size] = (
-            f_k[None, :] - u_kn[:, s:s + chunk_size].T
-            - log_denom_n[s:s + chunk_size, None])
+    K, N = _shape_of(u_kn, N_k)
+    out = np.empty((N, K), dtype=_dtype_of(u_kn))
+    for s, chunk in _iter_chunks(u_kn, chunk_size):
+        e = s + chunk.shape[1]
+        out[s:e] = f_k[None, :] - chunk.T - log_denom_n[s:e, None]
     return out

--- a/pymbar/_chunked.py
+++ b/pymbar/_chunked.py
@@ -97,9 +97,7 @@ def _pad_to(chunk, target_B):
 
 
 def _pad_ld(ld, target_B, dtype):
-    """Pad log_denominator_n slice (B,) to (target_B,) with zeros. Padded
-    entries are arbitrary: the chunk's +inf padding forces z = -ld - chunk
-    to -inf, so exp contribution is 0 regardless of ld value."""
+    """Pad ld (B,) to (target_B,) with zeros (chunk's +inf dominates exp)."""
     B = ld.shape[0]
     if B == target_B:
         return ld
@@ -304,28 +302,19 @@ def chunked_log_numerator_l(u_ln, log_denominator_n, chunk_size):
 
 def chunked_log_observable(u_ln, log_A_n, state_map, log_denominator_n,
                            chunk_size):
-    """Streaming logsumexp(log_A_n[i, n] - u_ln[l, n] - log_denominator_n[n], axis=n)
-    for each (l, i) = (state_map[0, s], state_map[1, s]) over s = 0..S-1.
-
-    log_obs_s[s] = log sum_n exp(log_A_n[state_map[1, s], n]
-                                 - u_ln[state_map[0, s], n]
-                                 - log_denominator_n[n])
-
-    Used by compute_expectations_inner: f_k[K + NL + s] = -log_obs_s[s].
-    Peak working memory O(S * chunk_size); pick chunk_size so this stays
-    below the dense-path footprint S * N.
+    """Streaming per-(state, observable) logsumexp:
+    log_obs_s[s] = log sum_n exp(log_A_n[i_s, n] - u_ln[l_s, n] - log_denom[n])
+    for (l_s, i_s) = state_map[:, s]. Used by compute_expectations_inner.
     """
     S = state_map.shape[1]
     dtype = _dtype_of(u_ln)
-    l_idx = state_map[0, :]
-    i_idx = state_map[1, :]
+    l_idx, i_idx = state_map[0, :], state_map[1, :]
     m_s = np.full(S, -np.inf, dtype=dtype)
     Sum_s = np.zeros(S, dtype=dtype)
     for s, u_chunk in _iter_chunks(u_ln, chunk_size):
         B = u_chunk.shape[1]
-        # _kernel_log_num_update computes z = -log_denom - chunk; we want
-        # z[t, n] = log_A_n[i_t, n] - u_ln[l_t, n] - log_denom[n], so feed
-        # chunk_eff = u_ln[l_t] - log_A_n[i_t].
+        # Feed chunk_eff = u_ln[l] - log_A_n[i] so the kernel's z = -log_denom
+        # - chunk becomes log_A_n[i] - u_ln[l] - log_denom (desired summand).
         chunk_eff = (u_chunk[l_idx] - log_A_n[i_idx, s:s + B]).astype(dtype)
         ld = _pad_ld(log_denominator_n[s:s + B], chunk_size, dtype)
         m_s, Sum_s = _kernel_log_num_update(

--- a/pymbar/mbar.py
+++ b/pymbar/mbar.py
@@ -109,9 +109,15 @@ class MBAR:
 
         Parameters
         ----------
-        u_kn : np.ndarray, float, shape=(K, N_max)
+        u_kn : np.ndarray or zero-arg callable, shape=(K, N_max)
             ``u_kn[k,n]`` is the reduced potential energy of uncorrelated
             configuration n evaluated at state ``k``.
+
+            For large-N fits, ``u_kn`` may instead be a zero-arg callable
+            that returns a fresh iterator yielding ``(K, B)`` chunks (last
+            chunk may be smaller). This requires ``chunk_size`` to be set
+            and never materialises the full matrix. See ``chunk_size`` for
+            the three supported modes.
         u_kln : np.ndarray, float, shape (K, L, N_max)
             If the simulation is in form ``u_kln[k,l,n]`` it is converted to ``u_kn`` format
 
@@ -196,13 +202,24 @@ class MBAR:
         chunk_size: int or None, optional, default=None
             If set, route the inner solve through chunked working-array
             variants of the logsumexp / Hessian operations. Peak working-array
-            memory drops from ``O(N * K)`` to ``O(chunk_size * K)``, which
-            unblocks large fits where ``u_kn`` itself fits in RAM but the
-            ``(N, K)`` working temporaries do not. The chunked path is
-            numpy-only (JAX is bypassed). When set, ``u_kn`` is preconditioned
-            in-place (sample-wise shift; MBAR is shift-invariant so f_k and
-            Log_W_nk are unaffected). Not compatible with ``n_bootstraps > 0``
-            (raises ``NotImplementedError``). See issue #574.
+            memory drops from ``O(N * K)`` to ``O(chunk_size * K)``. Three
+            modes are supported via the ``u_kn`` argument:
+
+            - ``u_kn=ndarray, chunk_size=None`` (default): existing dense
+              + JAX path, bit-identical to baseline.
+            - ``u_kn=ndarray, chunk_size=N``: dense u_kn, chunked working
+              temporaries. Common case; works with mmap'd .npy via
+              ``np.load(path, mmap_mode='r')``.
+            - ``u_kn=callable, chunk_size=N`` (required): streaming u_kn,
+              never materialised. The callable must yield deterministic
+              ``(K, B)`` chunks summing to ``sum(N_k)``.
+
+            The chunked path is numpy-only (JAX is bypassed). When ``u_kn``
+            is an ndarray and ``chunk_size`` is set, ``u_kn`` is
+            preconditioned in-place (sample-wise shift; MBAR is shift-
+            invariant so f_k and Log_W_nk are unaffected). Not compatible
+            with ``n_bootstraps > 0`` (raises ``NotImplementedError``).
+            See issue #574.
 
         cache_log_W_nk: bool, optional, default=True
             If False, leave ``self.Log_W_nk = None`` (skip the (N, K) cache).
@@ -255,15 +272,39 @@ class MBAR:
         self.N_k = np.array(N_k, dtype=np.int64)
         self.N = np.sum(self.N_k)
 
-        # Get dimensions of reduced potential energy matrix, and convert to KxN form if needed.
-        if len(np.shape(u_kn)) == 3:
-            self.K = np.shape(u_kn)[1]  # need to set self.K, and it's the second index
-            u_kn = kln_to_kn(u_kn, N_k=self.N_k)
+        # u_kn may be a dense ndarray or a zero-arg callable yielding (K, B)
+        # chunks (issue #574 streaming path). Branch on the type up front;
+        # everything dense-only happens inside the ndarray branch.
+        if callable(u_kn):
+            if chunk_size is None:
+                raise ValueError(
+                    "chunk_size required when u_kn is a streaming provider")
+            if cache_log_W_nk:
+                raise ValueError(
+                    "cache_log_W_nk=True is incompatible with streaming u_kn "
+                    "(the cache itself is shape (N, K) and would defeat the "
+                    "memory savings); pass cache_log_W_nk=False")
+            if n_bootstraps > 0:
+                raise NotImplementedError(
+                    "n_bootstraps>0 with streaming u_kn is not supported "
+                    "(needs random-sample access)")
+            if (np.asarray(self.N_k) <= 0).any():
+                raise NotImplementedError(
+                    "states with N_k=0 not yet supported for streaming u_kn; "
+                    "drop empty states before constructing MBAR")
+            self.u_kn = u_kn  # the callable
+            K = len(self.N_k)
+            N = int(np.sum(self.N_k))
+        else:
+            # Get dimensions of reduced potential energy matrix, and convert to KxN form if needed.
+            if len(np.shape(u_kn)) == 3:
+                self.K = np.shape(u_kn)[1]  # need to set self.K, and it's the second index
+                u_kn = kln_to_kn(u_kn, N_k=self.N_k)
 
-        # u_kn[k,n] is the reduced potential energy of sample n evaluated at state k
-        self.u_kn = np.array(u_kn, dtype=np.float64)
+            # u_kn[k,n] is the reduced potential energy of sample n evaluated at state k
+            self.u_kn = np.array(u_kn, dtype=np.float64)
 
-        K, N = np.shape(u_kn)
+            K, N = np.shape(u_kn)
 
         if verbose:
             logger.info("K (total states) = {:d}, total samples = {:d}".format(K, N))
@@ -318,7 +359,7 @@ class MBAR:
         indices = self.rng.choice(np.arange(self.N), maxpoint)
         # this could possibly be made faster with np.unique(axis=0,return_indices=True)
         # but not clear if needed.
-        if self.verbose:
+        if self.verbose and not callable(self.u_kn):
             for k in range(K):
                 for l in range(k):
                     diffsum = 0

--- a/pymbar/mbar.py
+++ b/pymbar/mbar.py
@@ -41,7 +41,7 @@ from textwrap import dedent
 import logging
 import numpy as np
 import numpy.linalg as linalg
-from pymbar import mbar_solvers
+from pymbar import _chunked, mbar_solvers
 from pymbar.utils import (
     kln_to_kn,
     kn_to_n,
@@ -813,6 +813,7 @@ class MBAR:
         uncertainty_method=None,
         warning_cutoff=1.0e-10,
         return_theta=False,
+        chunk_size=None,
     ):
         """
         Compute the expectations of multiple observables of phase space functions in multiple states.
@@ -900,6 +901,21 @@ class MBAR:
 
         """
 
+        if chunk_size is not None:
+            if return_theta:
+                raise ParameterError(
+                    "chunk_size is incompatible with return_theta=True. "
+                    "The chunked batch-evaluation path produces point "
+                    "estimates only; covariance computation requires the "
+                    "full Log_W_nk matrix. Pass return_theta=False (or "
+                    "compute_uncertainty=False from the wrapper).")
+            if uncertainty_method == "bootstrap":
+                raise ParameterError(
+                    "chunk_size is incompatible with uncertainty_method="
+                    "'bootstrap'. The bootstrap loop re-indexes columns of "
+                    "u_kn, which the chunked-eval path does not currently "
+                    "support.")
+
         logfactor = 4.0 * np.finfo(np.float64).eps
         # make sure all results are larger than this number.
         # We tried 1 before, but expectations are that any very small number (like
@@ -959,9 +975,42 @@ class MBAR:
         # log weight matrix
         msize = K + NL + S  # augmented size; all of the states needed to calculate
         # the observables, and the observables themselves.
-        Log_W_nk = np.zeros([N, msize], np.float64)  # log weight matrix
+        Log_W_nk = (None if chunk_size is not None
+                    else np.zeros([N, msize], np.float64))  # log weight matrix
         N_k = np.zeros([msize], np.int64)  # counts
         f_k = np.zeros([msize], np.float64)  # free energies
+
+        if chunk_size is not None:
+            # Chunked branch: point-estimate batch evaluation. Streams over the
+            # sample axis with peak working memory O(max(L, S) * chunk_size)
+            # versus dense O(N * (K + NL + S)). No Theta, no bootstrap (both
+            # rejected up front).
+            N_k[0:K] = self.N_k
+            f_k[0:K] = self.f_k
+            log_denom_n = _chunked.chunked_log_denominator(
+                self.u_kn, self.N_k, self.f_k, chunk_size)
+            log_num_l = _chunked.chunked_log_numerator_l(
+                u_ln, log_denom_n, chunk_size)
+            log_C_a = -log_num_l
+            f_k[K + L_list] = log_C_a[L_list]
+
+            if S > 0:
+                log_A_n = np.log(A_n)  # already shifted positive above
+                log_obs_s = _chunked.chunked_log_observable(
+                    u_ln, log_A_n, state_map, log_denom_n, chunk_size)
+                f_k[K + NL + np.arange(S)] = (
+                    -log_C_a[state_map[0, :]] - log_obs_s)
+                A_i = np.exp(-f_k[K + NL + np.arange(S)])
+                A_i = A_i + (A_min[state_map[1, :]]
+                             - logfactors[state_map[1, :]])
+                result_vals["observables"] = A_i
+
+            # Restore A_n positivity un-shift (mirrors dense post-loop step).
+            for i in A_list:
+                A_n[i, :] = A_n[i, :] + (A_min[i] - logfactors[i])
+
+            result_vals["f"] = f_k[K + state_list]
+            return result_vals
 
         if uncertainty_method == "bootstrap":
             n_total = self.n_bootstraps + 1
@@ -1207,6 +1256,7 @@ class MBAR:
         uncertainty_method=None,
         warning_cutoff=1.0e-10,
         return_theta=False,
+        chunk_size=None,
     ):
         """Compute the expectation of an observable of a phase space function.
 
@@ -1337,6 +1387,7 @@ class MBAR:
             return_theta=compute_uncertainty,
             uncertainty_method=uncertainty_method,
             warning_cutoff=warning_cutoff,
+            chunk_size=chunk_size,
         )
 
         result_vals = dict()
@@ -1397,6 +1448,7 @@ class MBAR:
         uncertainty_method=None,
         warning_cutoff=1.0e-10,
         return_theta=False,
+        chunk_size=None,
     ):
         """Compute the expectations of multiple observables of phase space functions.
 
@@ -1479,6 +1531,7 @@ class MBAR:
             return_theta=(compute_uncertainty or compute_covariance),
             uncertainty_method=uncertainty_method,
             warning_cutoff=warning_cutoff,
+            chunk_size=chunk_size,
         )
         result_vals = dict()
         result_vals["mu"] = inner_results["observables"]
@@ -1516,7 +1569,8 @@ class MBAR:
 
     # =========================================================================
     def compute_perturbed_free_energies(
-        self, u_ln, compute_uncertainty=True, uncertainty_method=None, warning_cutoff=1.0e-10
+        self, u_ln, compute_uncertainty=True, uncertainty_method=None,
+        warning_cutoff=1.0e-10, chunk_size=None,
     ):
         """Compute the free energies for a new set of states.
 
@@ -1576,6 +1630,7 @@ class MBAR:
             return_theta=compute_uncertainty,
             uncertainty_method=uncertainty_method,
             warning_cutoff=warning_cutoff,
+            chunk_size=chunk_size,
         )
 
         Deltaf_ij, dDeltaf_ij = None, None

--- a/pymbar/mbar.py
+++ b/pymbar/mbar.py
@@ -97,6 +97,8 @@ class MBAR:
         n_bootstraps=0,
         bootstrap_solver_protocol=None,
         rseed=None,
+        chunk_size=None,
+        cache_log_W_nk=True,
     ):
         """Initialize multistate Bennett acceptance ratio (MBAR) on a set of simulation data.
 
@@ -190,6 +192,24 @@ class MBAR:
         rseed: int or None, optional, default=None
             Seed to use when constructing a new RNGState. If rseed is None, will use the global
             np.random RNG to generate a seed.
+
+        chunk_size: int or None, optional, default=None
+            If set, route the inner solve through chunked working-array
+            variants of the logsumexp / Hessian operations. Peak working-array
+            memory drops from ``O(N * K)`` to ``O(chunk_size * K)``, which
+            unblocks large fits where ``u_kn`` itself fits in RAM but the
+            ``(N, K)`` working temporaries do not. The chunked path is
+            numpy-only (JAX is bypassed). When set, ``u_kn`` is preconditioned
+            in-place (sample-wise shift; MBAR is shift-invariant so f_k and
+            Log_W_nk are unaffected). Not compatible with ``n_bootstraps > 0``
+            (raises ``NotImplementedError``). See issue #574.
+
+        cache_log_W_nk: bool, optional, default=True
+            If False, leave ``self.Log_W_nk = None`` (skip the (N, K) cache).
+            Use only when ``compute_overlap``, ``compute_effective_sample_number``,
+            ``weights``, and the uncertainty methods that consume ``Log_W_nk``
+            are not needed -- those will fail without it. ``compute_free_energy_differences``
+            and ``compute_expectations`` for fitted states still work.
 
         Notes
         -----
@@ -411,9 +431,19 @@ class MBAR:
             elif pname == "bootstrap_solver_protocol":
                 bootstrap_solver_protocol = prot
 
-        self.f_k = mbar_solvers.solve_mbar_for_all_states(
-            self.u_kn, self.N_k, self.f_k, self.states_with_samples, solver_protocol
-        )
+        # Optional chunked working-array path (issue #574). Bound to the
+        # solve + log_W_nk caching scope; restored after.
+        if chunk_size is not None and n_bootstraps > 0:
+            raise NotImplementedError(
+                "chunk_size with n_bootstraps>0 is not yet supported. "
+                "Bootstrap requires u_kn[:, rints] random-sample access "
+                "which the chunked path doesn't provide. PR2 will add this."
+            )
+        _chunk_ctx = mbar_solvers.chunk_size_context(chunk_size)
+        with _chunk_ctx:
+            self.f_k = mbar_solvers.solve_mbar_for_all_states(
+                self.u_kn, self.N_k, self.f_k, self.states_with_samples, solver_protocol
+            )
 
         if n_bootstraps > 0:
             self.n_bootstraps = n_bootstraps
@@ -453,7 +483,11 @@ class MBAR:
 
         # bootstrapped weight matrices not generated here, but when expectations are needed
         # otherwise, it's too much memory to keep
-        self.Log_W_nk = mbar_solvers.mbar_log_W_nk(self.u_kn, self.N_k, self.f_k)
+        if cache_log_W_nk:
+            with mbar_solvers.chunk_size_context(chunk_size):
+                self.Log_W_nk = mbar_solvers.mbar_log_W_nk(self.u_kn, self.N_k, self.f_k)
+        else:
+            self.Log_W_nk = None
 
         # Print final dimensionless free energies.
         if self.verbose:

--- a/pymbar/mbar.py
+++ b/pymbar/mbar.py
@@ -904,17 +904,13 @@ class MBAR:
         if chunk_size is not None:
             if return_theta:
                 raise ParameterError(
-                    "chunk_size is incompatible with return_theta=True. "
-                    "The chunked batch-evaluation path produces point "
-                    "estimates only; covariance computation requires the "
-                    "full Log_W_nk matrix. Pass return_theta=False (or "
-                    "compute_uncertainty=False from the wrapper).")
+                    "chunk_size requires return_theta=False; chunked path "
+                    "produces point estimates only (Theta needs full Log_W_nk). "
+                    "From a wrapper, pass compute_uncertainty=False.")
             if uncertainty_method == "bootstrap":
                 raise ParameterError(
                     "chunk_size is incompatible with uncertainty_method="
-                    "'bootstrap'. The bootstrap loop re-indexes columns of "
-                    "u_kn, which the chunked-eval path does not currently "
-                    "support.")
+                    "'bootstrap'; bootstrap re-indexes u_kn columns per replicate.")
 
         logfactor = 4.0 * np.finfo(np.float64).eps
         # make sure all results are larger than this number.
@@ -981,34 +977,23 @@ class MBAR:
         f_k = np.zeros([msize], np.float64)  # free energies
 
         if chunk_size is not None:
-            # Chunked branch: point-estimate batch evaluation. Streams over the
-            # sample axis with peak working memory O(max(L, S) * chunk_size)
-            # versus dense O(N * (K + NL + S)). No Theta, no bootstrap (both
-            # rejected up front).
+            # Chunked point-estimate path; Theta and bootstrap rejected upfront.
             N_k[0:K] = self.N_k
             f_k[0:K] = self.f_k
             log_denom_n = _chunked.chunked_log_denominator(
                 self.u_kn, self.N_k, self.f_k, chunk_size)
-            log_num_l = _chunked.chunked_log_numerator_l(
+            log_C_a = -_chunked.chunked_log_numerator_l(
                 u_ln, log_denom_n, chunk_size)
-            log_C_a = -log_num_l
             f_k[K + L_list] = log_C_a[L_list]
-
             if S > 0:
-                log_A_n = np.log(A_n)  # already shifted positive above
                 log_obs_s = _chunked.chunked_log_observable(
-                    u_ln, log_A_n, state_map, log_denom_n, chunk_size)
-                f_k[K + NL + np.arange(S)] = (
-                    -log_C_a[state_map[0, :]] - log_obs_s)
-                A_i = np.exp(-f_k[K + NL + np.arange(S)])
-                A_i = A_i + (A_min[state_map[1, :]]
-                             - logfactors[state_map[1, :]])
-                result_vals["observables"] = A_i
-
-            # Restore A_n positivity un-shift (mirrors dense post-loop step).
+                    u_ln, np.log(A_n), state_map, log_denom_n, chunk_size)
+                f_k[K + NL + np.arange(S)] = -log_C_a[state_map[0, :]] - log_obs_s
+                result_vals["observables"] = (
+                    np.exp(-f_k[K + NL + np.arange(S)])
+                    + A_min[state_map[1, :]] - logfactors[state_map[1, :]])
             for i in A_list:
                 A_n[i, :] = A_n[i, :] + (A_min[i] - logfactors[i])
-
             result_vals["f"] = f_k[K + state_list]
             return result_vals
 

--- a/pymbar/mbar_solvers.py
+++ b/pymbar/mbar_solvers.py
@@ -416,6 +416,9 @@ def self_consistent_update(u_kn, N_k, f_k, states_with_samples=None):
     """
 
     if _CHUNK_SIZE is not None:
+        if callable(u_kn):
+            # Streaming: state-axis slice not supported; caller validates N_k > 0.
+            return _chunked.chunked_self_consistent_update(u_kn, N_k, f_k, _CHUNK_SIZE)
         sws = slice(None) if states_with_samples is None else states_with_samples
         return _chunked.chunked_self_consistent_update(
             u_kn[sws], N_k[sws], f_k[sws], _CHUNK_SIZE)
@@ -994,8 +997,9 @@ def solve_mbar_once(
     multiple times to polish the result.  `solve_mbar()` facilitates this.
     """
 
-    # we only validate at the outside of the call
-    u_kn_nonzero, N_k_nonzeo, f_k_nonzero = validate_inputs(u_kn_nonzero, N_k_nonzero, f_k_nonzero)
+    # validate_inputs assumes a dense ndarray; skip for streaming providers
+    if not callable(u_kn_nonzero):
+        u_kn_nonzero, N_k_nonzeo, f_k_nonzero = validate_inputs(u_kn_nonzero, N_k_nonzero, f_k_nonzero)
     f_k_nonzero = f_k_nonzero - f_k_nonzero[0]  # Work with reduced dimensions with f_k[0] := 0
     N_k_nonzero = 1.0 * N_k_nonzero  # convert to float for acceleration.
     u_kn_nonzero = precondition_u_kn(u_kn_nonzero, N_k_nonzero, f_k_nonzero)
@@ -1233,8 +1237,12 @@ def solve_mbar_for_all_states(u_kn, N_k, f_k, states_with_samples, solver_protoc
     if len(states_with_samples) == 1:
         f_k_nonzero = np.array([0.0])
     else:
+        # Streaming u_kn (callable) doesn't support the [states_with_samples]
+        # state-axis filter; we require N_k > 0 everywhere when streaming so
+        # the slice is a no-op anyway.
+        u_kn_nonzero = u_kn if callable(u_kn) else u_kn[states_with_samples]
         f_k_nonzero, all_results = solve_mbar(
-            u_kn[states_with_samples],
+            u_kn_nonzero,
             N_k[states_with_samples],
             f_k[states_with_samples],
             solver_protocol=solver_protocol,

--- a/pymbar/mbar_solvers.py
+++ b/pymbar/mbar_solvers.py
@@ -1,12 +1,14 @@
 import logging
 import os
 import warnings
+from contextlib import contextmanager
 from functools import wraps
 
 import numpy as np
 
 # Optimize imported here and below as the jax-optimized one is jax or passthrough, but this is required regardless
 import scipy.optimize
+from pymbar import _chunked
 from pymbar.utils import ensure_type, check_w_normalized, ParameterError
 
 logger = logging.getLogger(__name__)
@@ -105,6 +107,37 @@ if use_jit:
     logger.info("JAX detected. Using JAX acceleration.")
 else:
     logger.info("JAX was either not detected or disabled, using standard NumPy and SciPy")
+
+
+# Chunked working-array dispatch (issue #574). When _CHUNK_SIZE is set, the
+# public solver functions below route to numpy-only chunked variants in
+# pymbar._chunked, bounding the (N, K) working-array temporaries inside
+# logsumexp(... b=N_k) to (chunk_size, K).
+_CHUNK_SIZE = None
+
+
+def get_chunk_size():
+    """Return the active chunk size, or None for full materialization."""
+    return _CHUNK_SIZE
+
+
+def set_chunk_size(n):
+    """Set the active chunk size. Pass None to disable chunked path."""
+    global _CHUNK_SIZE
+    if n is not None and int(n) < 1:
+        raise ValueError(f"chunk_size must be >= 1, got {n}")
+    _CHUNK_SIZE = None if n is None else int(n)
+
+
+@contextmanager
+def chunk_size_context(n):
+    """Scoped chunk-size override; restores the previous setting on exit."""
+    prev = _CHUNK_SIZE
+    set_chunk_size(n)
+    try:
+        yield
+    finally:
+        set_chunk_size(prev)
 
 
 # =============================================================================
@@ -382,6 +415,10 @@ def self_consistent_update(u_kn, N_k, f_k, states_with_samples=None):
     Equation C3 in MBAR JCP paper.
     """
 
+    if _CHUNK_SIZE is not None:
+        sws = slice(None) if states_with_samples is None else states_with_samples
+        return _chunked.chunked_self_consistent_update(
+            u_kn[sws], N_k[sws], f_k[sws], _CHUNK_SIZE)
     return jax_self_consistent_update(u_kn, N_k, f_k, states_with_samples=states_with_samples)
 
 
@@ -435,6 +472,8 @@ def mbar_gradient(u_kn, N_k, f_k):
     -----
     This is equation C6 in the JCP MBAR paper.
     """
+    if _CHUNK_SIZE is not None:
+        return _chunked.chunked_mbar_gradient(u_kn, N_k, f_k, _CHUNK_SIZE)
     return jax_mbar_gradient(u_kn, N_k, f_k)
 
 
@@ -478,6 +517,8 @@ def mbar_objective(u_kn, N_k, f_k):
     outermost sum and logsumexp for the inner sum.
     """
 
+    if _CHUNK_SIZE is not None:
+        return _chunked.chunked_mbar_objective(u_kn, N_k, f_k, _CHUNK_SIZE)
     return jax_mbar_objective(u_kn, N_k, f_k)
 
 
@@ -546,6 +587,8 @@ def mbar_objective_and_gradient(u_kn, N_k, f_k):
     function is its integral.
     """
 
+    if _CHUNK_SIZE is not None:
+        return _chunked.chunked_mbar_objective_and_gradient(u_kn, N_k, f_k, _CHUNK_SIZE)
     return jax_mbar_objective_and_gradient(u_kn, N_k, f_k)
 
 
@@ -590,6 +633,8 @@ def mbar_hessian(u_kn, N_k, f_k):
     Equation (C9) in JCP MBAR paper.
     """
 
+    if _CHUNK_SIZE is not None:
+        return _chunked.chunked_mbar_hessian(u_kn, N_k, f_k, _CHUNK_SIZE)
     return jax_mbar_hessian(u_kn, N_k, f_k)
 
 
@@ -627,6 +672,8 @@ def mbar_log_W_nk(u_kn, N_k, f_k):
     -----
     Equation (9) in JCP MBAR paper.
     """
+    if _CHUNK_SIZE is not None:
+        return _chunked.chunked_mbar_log_W_nk(u_kn, N_k, f_k, _CHUNK_SIZE)
     return jax_mbar_log_W_nk(u_kn, N_k, f_k)
 
 
@@ -889,6 +936,10 @@ def precondition_u_kn(u_kn, N_k, f_k):
     x_n such that the current objective function value is zero, which
     should give maximum precision in the objective function.
     """
+    if _CHUNK_SIZE is not None:
+        # In-place to avoid the O(N*K) extra allocation; safe because MBAR
+        # is invariant under per-sample shifts of u_kn.
+        return _chunked.chunked_precondition_u_kn(u_kn, N_k, f_k, _CHUNK_SIZE)
     return jax_precondition_u_kn(u_kn, N_k, f_k)
 
 

--- a/pymbar/mbar_solvers.py
+++ b/pymbar/mbar_solvers.py
@@ -355,6 +355,14 @@ def jit_or_pass_after_bitsize(jitable_fn):
                 "******************************************\n"
             )
             config.update("jax_enable_x64", True)
+        # The chunked working-array path in _chunked.py runs Python loops over
+        # chunks with mutable numpy output buffers (e.g. `out[s:s+B] = ...`).
+        # That is incompatible with being traced inside an outer jax.jit:
+        # cold cache raises ConcretizationTypeError on shape-dependent ops;
+        # warm cache silently reuses the cached dense jaxpr (since
+        # _CHUNK_SIZE is a Python global the JIT cache can't key on).
+        if _CHUNK_SIZE is not None:
+            return jitable_fn(*args, **kwargs)
         jited_fn = jit_or_passthrough(jitable_fn)
         return jited_fn(*args, **kwargs)
 

--- a/pymbar/tests/test_chunked.py
+++ b/pymbar/tests/test_chunked.py
@@ -128,3 +128,54 @@ def test_zero_N_k_handled():
     assert_array_almost_equal(
         _chunked.chunked_log_denominator(u_kn, N_k, f_k, chunk_size=100),
         _dense_log_denom(u_kn, N_k, f_k), decimal=12)
+
+
+def _make_eval_problem(K=8, L=5, I=3, N=1500, seed=1):
+    """Synthetic batch-eval problem: K sampled states + L perturbed + I observables."""
+    rng = np.random.default_rng(seed)
+    centers = np.linspace(-2.0, 2.0, K)
+    u_kn = centers[:, None] + rng.standard_normal((K, N)) * 0.5
+    N_k = np.full(K, N // K, dtype=np.float64)
+    f_k = -np.array([np.log(np.mean(np.exp(-u_kn[k]))) for k in range(K)])
+    log_denom = _dense_log_denom(u_kn, N_k, f_k)
+    pert_centers = np.linspace(-2.5, 2.5, L)
+    u_ln = pert_centers[:, None] + rng.standard_normal((L, N)) * 0.5
+    A_n = rng.uniform(0.1, 5.0, size=(I, N))  # already-positive observables
+    return u_ln, np.log(A_n), log_denom
+
+
+def _dense_log_num_l(u_ln, log_denom):
+    return sp_logsumexp(-log_denom - u_ln, axis=1)
+
+
+def _dense_log_observable(u_ln, log_A_n, state_map, log_denom):
+    S = state_map.shape[1]
+    out = np.empty(S)
+    for s in range(S):
+        l, i = state_map[0, s], state_map[1, s]
+        out[s] = sp_logsumexp(log_A_n[i] - u_ln[l] - log_denom)
+    return out
+
+
+@pytest.mark.parametrize("chunk_size", [1, 13, 200, 5000])
+def test_chunked_log_numerator_l(chunk_size):
+    u_ln, _, log_denom = _make_eval_problem(L=5, N=1500)
+    assert_array_almost_equal(
+        _chunked.chunked_log_numerator_l(u_ln, log_denom, chunk_size),
+        _dense_log_num_l(u_ln, log_denom), decimal=12)
+
+
+@pytest.mark.parametrize("chunk_size", [1, 17, 200, 5000])
+def test_chunked_log_observable(chunk_size):
+    u_ln, log_A_n, log_denom = _make_eval_problem(L=4, I=3, N=1500)
+    # state_map: every (l, i) pair, S = L * I
+    L, I = u_ln.shape[0], log_A_n.shape[0]
+    state_map = np.array(
+        [[l for l in range(L) for _ in range(I)],
+         [i for _ in range(L) for i in range(I)]],
+        dtype=np.int64)
+    assert_array_almost_equal(
+        _chunked.chunked_log_observable(
+            u_ln, log_A_n, state_map, log_denom, chunk_size),
+        _dense_log_observable(u_ln, log_A_n, state_map, log_denom),
+        decimal=12)

--- a/pymbar/tests/test_chunked.py
+++ b/pymbar/tests/test_chunked.py
@@ -1,0 +1,130 @@
+"""Unit tests for pymbar._chunked: equivalence to dense scipy implementations."""
+import numpy as np
+import pytest
+from scipy.special import logsumexp as sp_logsumexp
+
+from pymbar import _chunked
+from pymbar.utils_for_testing import assert_array_almost_equal
+
+
+def _make_problem(K=10, N=2000, seed=0):
+    """Synthetic MBAR problem with reasonable overlap and a near-stationary f_k."""
+    rng = np.random.default_rng(seed)
+    centers = np.linspace(-2.0, 2.0, K)
+    u_kn = centers[:, None] + rng.standard_normal((K, N)) * 0.5
+    N_k = np.full(K, N // K, dtype=np.float64)
+    f_k = -np.array([np.log(np.mean(np.exp(-u_kn[k]))) for k in range(K)])
+    return u_kn, N_k, f_k
+
+
+def _dense_log_denom(u_kn, N_k, f_k):
+    return sp_logsumexp(f_k - u_kn.T, b=N_k, axis=1)
+
+
+def _dense_log_num_k(u_kn, log_denom):
+    return sp_logsumexp(-log_denom - u_kn, axis=1)
+
+
+def _dense_hessian(u_kn, N_k, f_k):
+    log_denom = _dense_log_denom(u_kn, N_k, f_k)
+    W = np.exp(f_k - u_kn.T - log_denom[:, None])
+    H = (W.T @ W) * N_k * N_k[:, None] - np.diag(W.sum(0) * N_k)
+    return -H
+
+
+@pytest.mark.parametrize("chunk_size", [1, 7, 100, 999, 10_000])
+def test_chunked_log_denominator(chunk_size):
+    u_kn, N_k, f_k = _make_problem(K=10, N=2000)
+    assert_array_almost_equal(
+        _chunked.chunked_log_denominator(u_kn, N_k, f_k, chunk_size),
+        _dense_log_denom(u_kn, N_k, f_k), decimal=12)
+
+
+@pytest.mark.parametrize("chunk_size", [1, 13, 200, 5000])
+def test_chunked_log_numerator_k(chunk_size):
+    u_kn, N_k, f_k = _make_problem(K=8, N=1500)
+    log_denom = _dense_log_denom(u_kn, N_k, f_k)
+    assert_array_almost_equal(
+        _chunked.chunked_log_numerator_k(u_kn, log_denom, chunk_size),
+        _dense_log_num_k(u_kn, log_denom), decimal=12)
+
+
+@pytest.mark.parametrize("chunk_size", [10, 250])
+def test_chunked_mbar_objective(chunk_size):
+    u_kn, N_k, f_k = _make_problem()
+    log_denom = _dense_log_denom(u_kn, N_k, f_k)
+    expected = float(np.sum(log_denom) - np.dot(N_k, f_k))
+    got = _chunked.chunked_mbar_objective(u_kn, N_k, f_k, chunk_size)
+    assert abs(got - expected) < 1e-9 * max(1.0, abs(expected))
+
+
+@pytest.mark.parametrize("chunk_size", [10, 250])
+def test_chunked_mbar_gradient(chunk_size):
+    u_kn, N_k, f_k = _make_problem()
+    log_denom = _dense_log_denom(u_kn, N_k, f_k)
+    log_num = _dense_log_num_k(u_kn, log_denom)
+    expected = -1.0 * N_k * (1.0 - np.exp(f_k + log_num))
+    assert_array_almost_equal(
+        _chunked.chunked_mbar_gradient(u_kn, N_k, f_k, chunk_size),
+        expected, decimal=10)
+
+
+@pytest.mark.parametrize("chunk_size", [10, 500])
+def test_chunked_mbar_objective_and_gradient(chunk_size):
+    u_kn, N_k, f_k = _make_problem()
+    log_denom = _dense_log_denom(u_kn, N_k, f_k)
+    log_num = _dense_log_num_k(u_kn, log_denom)
+    obj_exp = float(np.sum(log_denom) - np.dot(N_k, f_k))
+    grad_exp = -1.0 * N_k * (1.0 - np.exp(f_k + log_num))
+    obj, grad = _chunked.chunked_mbar_objective_and_gradient(
+        u_kn, N_k, f_k, chunk_size)
+    assert abs(obj - obj_exp) < 1e-9 * max(1.0, abs(obj_exp))
+    assert_array_almost_equal(grad, grad_exp, decimal=10)
+
+
+@pytest.mark.parametrize("chunk_size", [10, 200])
+def test_chunked_mbar_hessian(chunk_size):
+    u_kn, N_k, f_k = _make_problem(K=6, N=1000)
+    expected = _dense_hessian(u_kn, N_k, f_k)
+    got = _chunked.chunked_mbar_hessian(u_kn, N_k, f_k, chunk_size)
+    assert_array_almost_equal(got, expected, decimal=8)
+
+
+@pytest.mark.parametrize("chunk_size", [10, 500])
+def test_chunked_self_consistent_update(chunk_size):
+    u_kn, N_k, f_k = _make_problem()
+    log_denom = _dense_log_denom(u_kn, N_k, f_k)
+    expected = -_dense_log_num_k(u_kn, log_denom)
+    assert_array_almost_equal(
+        _chunked.chunked_self_consistent_update(u_kn, N_k, f_k, chunk_size),
+        expected, decimal=12)
+
+
+@pytest.mark.parametrize("chunk_size", [10, 500])
+def test_chunked_precondition_u_kn(chunk_size):
+    u_kn, N_k, f_k = _make_problem()
+    u_dense = u_kn - u_kn.min(0)
+    u_dense = u_dense + (_dense_log_denom(u_dense, N_k, f_k)
+                          - np.dot(N_k, f_k) / N_k.sum())
+    u_chunked = _chunked.chunked_precondition_u_kn(
+        u_kn.copy(), N_k, f_k, chunk_size)
+    assert_array_almost_equal(u_chunked, u_dense, decimal=10)
+
+
+@pytest.mark.parametrize("chunk_size", [10, 500])
+def test_chunked_mbar_log_W_nk(chunk_size):
+    u_kn, N_k, f_k = _make_problem()
+    log_denom = _dense_log_denom(u_kn, N_k, f_k)
+    expected = f_k - u_kn.T - log_denom[:, None]
+    got = _chunked.chunked_mbar_log_W_nk(u_kn, N_k, f_k, chunk_size)
+    assert_array_almost_equal(got, expected, decimal=12)
+
+
+def test_zero_N_k_handled():
+    """States with N_k=0 contribute nothing (log_N goes to -inf cleanly)."""
+    u_kn, N_k, f_k = _make_problem(K=5, N=500)
+    N_k = N_k.copy()
+    N_k[2] = 0.0
+    assert_array_almost_equal(
+        _chunked.chunked_log_denominator(u_kn, N_k, f_k, chunk_size=100),
+        _dense_log_denom(u_kn, N_k, f_k), decimal=12)

--- a/pymbar/tests/test_chunked.py
+++ b/pymbar/tests/test_chunked.py
@@ -45,7 +45,7 @@ def test_chunked_log_numerator_k(chunk_size):
     u_kn, N_k, f_k = _make_problem(K=8, N=1500)
     log_denom = _dense_log_denom(u_kn, N_k, f_k)
     assert_array_almost_equal(
-        _chunked.chunked_log_numerator_k(u_kn, log_denom, chunk_size),
+        _chunked.chunked_log_numerator_k(u_kn, N_k, log_denom, chunk_size),
         _dense_log_num_k(u_kn, log_denom), decimal=12)
 
 

--- a/pymbar/tests/test_chunked_compute_eval.py
+++ b/pymbar/tests/test_chunked_compute_eval.py
@@ -31,33 +31,19 @@ def test_compute_perturbed_free_energies_chunked(small_oscillator, chunk_size):
     assert_array_almost_equal(chunked["Delta_f"], dense["Delta_f"], decimal=10)
 
 
+@pytest.mark.parametrize("state_dependent", [False, True])
 @pytest.mark.parametrize("chunk_size", [50, 137, 5000])
-def test_compute_expectations_chunked_state_independent(small_oscillator,
-                                                         chunk_size):
-    m, u_kn, N_k = small_oscillator
-    # Single observable, evaluated at K different states.
-    rng = np.random.default_rng(1)
-    A_n = rng.uniform(0.5, 2.0, size=u_kn.shape[1])
-    dense = m.compute_expectations(A_n, compute_uncertainty=False)
-    chunked = m.compute_expectations(
-        A_n, compute_uncertainty=False, chunk_size=chunk_size)
-    assert_array_almost_equal(chunked["mu"], dense["mu"], decimal=10)
-
-
-@pytest.mark.parametrize("chunk_size", [50, 137, 5000])
-def test_compute_expectations_chunked_state_dependent(small_oscillator,
-                                                      chunk_size):
-    m, u_kn, N_k = small_oscillator
-    # state_dependent=True puts the diagonal index pattern through the
-    # observable kernel: state_map[0,k] = k, state_map[1,k] = k.
-    K = u_kn.shape[0]
-    rng = np.random.default_rng(3)
-    A_n = rng.uniform(0.5, 2.0, size=(K, u_kn.shape[1]))
-    dense = m.compute_expectations(
-        A_n, state_dependent=True, compute_uncertainty=False)
-    chunked = m.compute_expectations(
-        A_n, state_dependent=True, compute_uncertainty=False,
-        chunk_size=chunk_size)
+def test_compute_expectations_chunked(small_oscillator, chunk_size,
+                                      state_dependent):
+    # state_dependent=True hits the diagonal index pattern (state_map[0,k]=k,
+    # state_map[1,k]=k) in the observable kernel; =False hits state_map[1,k]=0.
+    m, u_kn, _ = small_oscillator
+    rng = np.random.default_rng(1 + state_dependent)
+    shape = (u_kn.shape[0], u_kn.shape[1]) if state_dependent else u_kn.shape[1]
+    A_n = rng.uniform(0.5, 2.0, size=shape)
+    kw = dict(state_dependent=state_dependent, compute_uncertainty=False)
+    dense = m.compute_expectations(A_n, **kw)
+    chunked = m.compute_expectations(A_n, **kw, chunk_size=chunk_size)
     assert_array_almost_equal(chunked["mu"], dense["mu"], decimal=10)
 
 

--- a/pymbar/tests/test_chunked_compute_eval.py
+++ b/pymbar/tests/test_chunked_compute_eval.py
@@ -1,0 +1,92 @@
+"""End-to-end tests for the chunked batch-evaluation path:
+compute_expectations / compute_multiple_expectations /
+compute_perturbed_free_energies with ``chunk_size`` set must match the dense
+path bit-close for point estimates, and must reject ``compute_uncertainty=True``
+and ``uncertainty_method='bootstrap'``.
+"""
+import numpy as np
+import pytest
+
+import pymbar
+from pymbar.utils import ParameterError
+from pymbar.utils_for_testing import assert_array_almost_equal, oscillators
+
+
+@pytest.fixture(scope="module")
+def small_oscillator():
+    name, u_kn, N_k, s_n = oscillators(8, 300)
+    m = pymbar.MBAR(u_kn, N_k, relative_tolerance=1e-10)
+    return m, u_kn, N_k
+
+
+@pytest.mark.parametrize("chunk_size", [50, 137, 5000])
+def test_compute_perturbed_free_energies_chunked(small_oscillator, chunk_size):
+    m, u_kn, N_k = small_oscillator
+    # u_ln = u_kn rows shifted slightly to define perturbed states.
+    rng = np.random.default_rng(0)
+    u_ln = u_kn + 0.1 * rng.standard_normal(u_kn.shape)
+    dense = m.compute_perturbed_free_energies(u_ln, compute_uncertainty=False)
+    chunked = m.compute_perturbed_free_energies(
+        u_ln, compute_uncertainty=False, chunk_size=chunk_size)
+    assert_array_almost_equal(chunked["Delta_f"], dense["Delta_f"], decimal=10)
+
+
+@pytest.mark.parametrize("chunk_size", [50, 137, 5000])
+def test_compute_expectations_chunked_state_independent(small_oscillator,
+                                                         chunk_size):
+    m, u_kn, N_k = small_oscillator
+    # Single observable, evaluated at K different states.
+    rng = np.random.default_rng(1)
+    A_n = rng.uniform(0.5, 2.0, size=u_kn.shape[1])
+    dense = m.compute_expectations(A_n, compute_uncertainty=False)
+    chunked = m.compute_expectations(
+        A_n, compute_uncertainty=False, chunk_size=chunk_size)
+    assert_array_almost_equal(chunked["mu"], dense["mu"], decimal=10)
+
+
+@pytest.mark.parametrize("chunk_size", [50, 137, 5000])
+def test_compute_expectations_chunked_state_dependent(small_oscillator,
+                                                      chunk_size):
+    m, u_kn, N_k = small_oscillator
+    # state_dependent=True puts the diagonal index pattern through the
+    # observable kernel: state_map[0,k] = k, state_map[1,k] = k.
+    K = u_kn.shape[0]
+    rng = np.random.default_rng(3)
+    A_n = rng.uniform(0.5, 2.0, size=(K, u_kn.shape[1]))
+    dense = m.compute_expectations(
+        A_n, state_dependent=True, compute_uncertainty=False)
+    chunked = m.compute_expectations(
+        A_n, state_dependent=True, compute_uncertainty=False,
+        chunk_size=chunk_size)
+    assert_array_almost_equal(chunked["mu"], dense["mu"], decimal=10)
+
+
+@pytest.mark.parametrize("chunk_size", [50, 137, 5000])
+def test_compute_multiple_expectations_chunked(small_oscillator, chunk_size):
+    m, u_kn, N_k = small_oscillator
+    rng = np.random.default_rng(2)
+    A_in = rng.uniform(0.5, 2.0, size=(4, u_kn.shape[1]))  # 4 observables
+    u_n = u_kn[0, :]
+    dense = m.compute_multiple_expectations(
+        A_in, u_n, compute_uncertainty=False)
+    chunked = m.compute_multiple_expectations(
+        A_in, u_n, compute_uncertainty=False, chunk_size=chunk_size)
+    assert_array_almost_equal(chunked["mu"], dense["mu"], decimal=10)
+
+
+def test_chunked_rejects_compute_uncertainty(small_oscillator):
+    m, u_kn, N_k = small_oscillator
+    with pytest.raises(ParameterError, match="return_theta"):
+        m.compute_perturbed_free_energies(
+            u_kn, compute_uncertainty=True, chunk_size=50)
+    with pytest.raises(ParameterError, match="return_theta"):
+        m.compute_expectations(
+            u_kn[0], compute_uncertainty=True, chunk_size=50)
+
+
+def test_chunked_rejects_bootstrap(small_oscillator):
+    m, u_kn, N_k = small_oscillator
+    with pytest.raises(ParameterError, match="bootstrap"):
+        m.compute_perturbed_free_energies(
+            u_kn, compute_uncertainty=False,
+            uncertainty_method="bootstrap", chunk_size=50)

--- a/pymbar/tests/test_chunked_mbar.py
+++ b/pymbar/tests/test_chunked_mbar.py
@@ -1,0 +1,64 @@
+"""End-to-end tests for MBAR(..., chunk_size=N): same f_k as dense path."""
+import numpy as np
+import pytest
+
+import pymbar
+from pymbar import mbar_solvers
+from pymbar.utils_for_testing import assert_array_almost_equal, oscillators
+
+
+@pytest.fixture(scope="module")
+def small_oscillator():
+    name, u_kn, N_k, s_n = oscillators(8, 300)
+    return u_kn, N_k
+
+
+@pytest.mark.parametrize("chunk_size", [50, 137, 5000])
+def test_mbar_chunked_matches_dense(small_oscillator, chunk_size):
+    u_kn, N_k = small_oscillator
+    m_dense = pymbar.MBAR(u_kn, N_k, relative_tolerance=1e-10)
+    m_chunked = pymbar.MBAR(u_kn, N_k, relative_tolerance=1e-10,
+                            chunk_size=chunk_size)
+    assert_array_almost_equal(np.asarray(m_chunked.f_k) - m_chunked.f_k[0],
+                              np.asarray(m_dense.f_k) - m_dense.f_k[0],
+                              decimal=7)
+
+
+def test_mbar_chunked_log_W_nk_matches(small_oscillator):
+    u_kn, N_k = small_oscillator
+    m_dense = pymbar.MBAR(u_kn, N_k, relative_tolerance=1e-10)
+    m_chunked = pymbar.MBAR(u_kn, N_k, relative_tolerance=1e-10, chunk_size=70)
+    assert_array_almost_equal(np.asarray(m_chunked.Log_W_nk),
+                              np.asarray(m_dense.Log_W_nk), decimal=8)
+
+
+def test_mbar_chunked_no_log_W_nk(small_oscillator):
+    u_kn, N_k = small_oscillator
+    m = pymbar.MBAR(u_kn, N_k, chunk_size=70, cache_log_W_nk=False)
+    assert m.Log_W_nk is None
+
+
+def test_mbar_chunked_rejects_bootstrap(small_oscillator):
+    u_kn, N_k = small_oscillator
+    with pytest.raises(NotImplementedError, match="chunk_size with n_bootstraps"):
+        pymbar.MBAR(u_kn, N_k, chunk_size=50, n_bootstraps=5)
+
+
+def test_chunk_size_setter_validates():
+    with pytest.raises(ValueError, match=">= 1"):
+        mbar_solvers.set_chunk_size(0)
+    mbar_solvers.set_chunk_size(None)
+    assert mbar_solvers.get_chunk_size() is None
+    mbar_solvers.set_chunk_size(100)
+    assert mbar_solvers.get_chunk_size() == 100
+    mbar_solvers.set_chunk_size(None)
+
+
+def test_chunk_size_context_restores():
+    mbar_solvers.set_chunk_size(None)
+    with mbar_solvers.chunk_size_context(500):
+        assert mbar_solvers.get_chunk_size() == 500
+        with mbar_solvers.chunk_size_context(None):
+            assert mbar_solvers.get_chunk_size() is None
+        assert mbar_solvers.get_chunk_size() == 500
+    assert mbar_solvers.get_chunk_size() is None

--- a/pymbar/tests/test_chunked_mbar.py
+++ b/pymbar/tests/test_chunked_mbar.py
@@ -44,6 +44,48 @@ def test_mbar_chunked_rejects_bootstrap(small_oscillator):
         pymbar.MBAR(u_kn, N_k, chunk_size=50, n_bootstraps=5)
 
 
+@pytest.mark.parametrize("chunk_size", [50, 5000])
+def test_mbar_chunked_adaptive_solver(small_oscillator, chunk_size):
+    """The 'adaptive' solver routes through jax_core_adaptive, which is
+    `@jit_or_pass_after_bitsize`-decorated. The chunked path's Python
+    loops with side-effecting numpy buffer writes cannot be traced inside
+    that outer JIT (cold cache: ConcretizationTypeError on
+    `int(np.sum(N_k))` against a traced N_k; warm cache: silently reuses
+    the cached dense jaxpr because `_CHUNK_SIZE` is a Python global the
+    JIT cache can't key on). The fix in `mbar_solvers.staggered_jit`
+    bypasses the outer JIT when `_CHUNK_SIZE is not None`.
+
+    Regression test: forces the adaptive method explicitly so the JIT
+    path is exercised — DEFAULT_SOLVER_PROTOCOL prefers `hybr` first
+    (scipy, not JIT'd) and only falls back to `adaptive` for harder
+    problems, so a small test fixture would otherwise skip this path.
+    `jax.clear_caches()` at entry ensures we hit the cold-cache trace
+    path regardless of test ordering.
+    """
+    try:
+        import jax
+        jax.clear_caches()
+    except ImportError:
+        pass
+    u_kn, N_k = small_oscillator
+    adaptive_only = (dict(method="adaptive", options=dict(min_sc_iter=0)),)
+    m_chunked = pymbar.MBAR(u_kn, N_k, relative_tolerance=1e-10,
+                            chunk_size=chunk_size,
+                            solver_protocol=adaptive_only)
+    # Independent dense reference on a clean cache so the cached chunked
+    # jaxpr can't sneak in: separate import / fresh MBAR with no chunking.
+    try:
+        import jax
+        jax.clear_caches()
+    except ImportError:
+        pass
+    m_dense = pymbar.MBAR(u_kn, N_k, relative_tolerance=1e-10,
+                          solver_protocol=adaptive_only)
+    assert_array_almost_equal(np.asarray(m_chunked.f_k) - m_chunked.f_k[0],
+                              np.asarray(m_dense.f_k) - m_dense.f_k[0],
+                              decimal=6)
+
+
 def test_chunk_size_setter_validates():
     with pytest.raises(ValueError, match=">= 1"):
         mbar_solvers.set_chunk_size(0)

--- a/pymbar/tests/test_chunked_memory.py
+++ b/pymbar/tests/test_chunked_memory.py
@@ -1,0 +1,82 @@
+"""Memory regression for the chunked helpers.
+
+Compares peak Python allocations of pymbar._chunked vs an inline numpy
+reference that materializes the (N, K) intermediate. JAX-independent --
+operates directly on the helpers, not the dispatcher path.
+"""
+import tracemalloc
+
+import numpy as np
+import pytest
+
+from pymbar import _chunked
+
+
+def _make_problem(K, N, seed=0):
+    rng = np.random.default_rng(seed)
+    centers = np.linspace(-1.5, 1.5, K)
+    u_kn = centers[:, None] + rng.standard_normal((K, N)) * 0.3
+    N_k = np.full(K, N // K, dtype=np.float64)
+    return u_kn, N_k, np.zeros(K, dtype=np.float64)
+
+
+def _peak(fn, *args):
+    tracemalloc.start()
+    tracemalloc.reset_peak()
+    try:
+        fn(*args)
+    finally:
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+    return peak
+
+
+def _dense_log_denominator(u_kn, N_k, f_k):
+    # Materializes a (K, N) intermediate -- the cost we're trying to avoid.
+    log_N = np.log(N_k)
+    a = (f_k + log_N)[:, None] - u_kn
+    m = a.max(axis=0)
+    return m + np.log(np.exp(a - m).sum(axis=0))
+
+
+def _dense_hessian(u_kn, N_k, f_k):
+    log_denom = _dense_log_denominator(u_kn, N_k, f_k)
+    W = np.exp(f_k[None, :] - u_kn.T - log_denom[:, None])
+    H = W.T @ W
+    H *= N_k
+    H *= N_k[:, None]
+    H -= np.diag(W.sum(0) * N_k)
+    return -H
+
+
+def _dense_precondition(u_kn, N_k, f_k):
+    u_kn = u_kn - u_kn.min(0)
+    log_denom = _dense_log_denominator(u_kn, N_k, f_k)
+    return u_kn + (log_denom - np.dot(N_k, f_k) / N_k.sum())
+
+
+@pytest.mark.parametrize("op", ["log_denominator", "hessian", "precondition"])
+def test_chunked_peak_below_dense(op):
+    """At K=50, N=200k, dense (N, K) intermediate is 80 MB. Chunked at
+    chunk_size=10k should peak well below that. Assert chunked < dense / 4.
+    """
+    K, N, chunk_size = 50, 200_000, 10_000
+    u_kn, N_k, f_k = _make_problem(K, N)
+
+    if op == "log_denominator":
+        peak_dense = _peak(_dense_log_denominator, u_kn, N_k, f_k)
+        peak_chunked = _peak(_chunked.chunked_log_denominator,
+                              u_kn, N_k, f_k, chunk_size)
+    elif op == "hessian":
+        peak_dense = _peak(_dense_hessian, u_kn, N_k, f_k)
+        peak_chunked = _peak(_chunked.chunked_mbar_hessian,
+                              u_kn, N_k, f_k, chunk_size)
+    elif op == "precondition":
+        peak_dense = _peak(_dense_precondition, u_kn.copy(), N_k, f_k)
+        peak_chunked = _peak(_chunked.chunked_precondition_u_kn,
+                              u_kn.copy(), N_k, f_k, chunk_size)
+
+    print(f"\n{op}: dense {peak_dense/1e6:.1f} MB, "
+          f"chunked {peak_chunked/1e6:.1f} MB "
+          f"({peak_dense/max(peak_chunked,1):.1f}x smaller)")
+    assert peak_chunked < peak_dense / 4

--- a/pymbar/tests/test_chunked_streaming.py
+++ b/pymbar/tests/test_chunked_streaming.py
@@ -1,0 +1,179 @@
+"""Tests for the streaming u_kn path: MBAR(u_kn=callable, N_k, chunk_size=N).
+
+Verifies that fitting with a chunk-yielding callable produces the same f_k
+as the dense-ndarray path; that the API enforces required preconditions;
+and that peak Python memory is bounded by O(chunk_size * K) when the
+callable streams without holding the full matrix.
+"""
+import tracemalloc
+
+import numpy as np
+import pytest
+
+import pymbar
+from pymbar import _chunked
+from pymbar.utils_for_testing import assert_array_almost_equal, oscillators
+
+
+def _make_provider(u_kn_dense, chunk_size):
+    """Build a callable that yields chunks of u_kn_dense without holding any
+    other reference (caller can del the dense array after calling _make_provider)."""
+    def provider():
+        N = u_kn_dense.shape[1]
+        for s in range(0, N, chunk_size):
+            yield u_kn_dense[:, s:s + chunk_size]
+    return provider
+
+
+@pytest.fixture(scope="module")
+def small_oscillator():
+    name, u_kn, N_k, s_n = oscillators(8, 300)
+    return u_kn, N_k
+
+
+@pytest.mark.parametrize("chunk_size", [50, 137, 5000])
+def test_streaming_matches_dense(small_oscillator, chunk_size):
+    u_kn, N_k = small_oscillator
+    m_dense = pymbar.MBAR(u_kn, N_k, relative_tolerance=1e-10,
+                          chunk_size=chunk_size)
+    m_stream = pymbar.MBAR(_make_provider(u_kn, chunk_size), N_k,
+                           relative_tolerance=1e-10,
+                           chunk_size=chunk_size,
+                           cache_log_W_nk=False)
+    assert_array_almost_equal(np.asarray(m_stream.f_k) - m_stream.f_k[0],
+                              np.asarray(m_dense.f_k) - m_dense.f_k[0],
+                              decimal=7)
+
+
+def test_streaming_requires_chunk_size(small_oscillator):
+    u_kn, N_k = small_oscillator
+    with pytest.raises(ValueError, match="chunk_size required"):
+        pymbar.MBAR(_make_provider(u_kn, 100), N_k,
+                    cache_log_W_nk=False)
+
+
+def test_streaming_rejects_log_W_nk_cache(small_oscillator):
+    u_kn, N_k = small_oscillator
+    with pytest.raises(ValueError, match="cache_log_W_nk=True"):
+        pymbar.MBAR(_make_provider(u_kn, 100), N_k, chunk_size=100)
+
+
+def test_streaming_rejects_bootstrap(small_oscillator):
+    u_kn, N_k = small_oscillator
+    with pytest.raises(NotImplementedError, match="streaming"):
+        pymbar.MBAR(_make_provider(u_kn, 100), N_k,
+                    chunk_size=100, cache_log_W_nk=False, n_bootstraps=5)
+
+
+def test_streaming_rejects_empty_states(small_oscillator):
+    u_kn, N_k = small_oscillator
+    N_k_with_zero = np.array(N_k, dtype=np.int64)
+    N_k_with_zero[3] = 0
+    with pytest.raises(NotImplementedError, match="N_k=0"):
+        pymbar.MBAR(_make_provider(u_kn, 100), N_k_with_zero,
+                    chunk_size=100, cache_log_W_nk=False)
+
+
+def test_iter_chunks_dense():
+    u_kn = np.arange(60, dtype=float).reshape(6, 10)
+    chunks = list(_chunked._iter_chunks(u_kn, 4))
+    starts = [s for s, _ in chunks]
+    sizes = [c.shape[1] for _, c in chunks]
+    assert starts == [0, 4, 8]
+    assert sizes == [4, 4, 2]
+    # last chunk smaller: dense slice of (6, 2) reaches the end
+    assert chunks[-1][1].shape == (6, 2)
+
+
+def test_iter_chunks_callable():
+    u_kn = np.arange(60, dtype=float).reshape(6, 10)
+    provider = _make_provider(u_kn, 4)
+    chunks = list(_chunked._iter_chunks(provider, 4))
+    starts = [s for s, _ in chunks]
+    sizes = [c.shape[1] for _, c in chunks]
+    assert starts == [0, 4, 8]
+    assert sizes == [4, 4, 2]
+
+
+def test_iter_chunks_rejects_other_types():
+    with pytest.raises(TypeError, match="ndarray or zero-arg callable"):
+        list(_chunked._iter_chunks([1, 2, 3], 1))
+
+
+def test_streaming_helpers_match_dense():
+    """Per-helper equivalence ndarray vs callable on the same data."""
+    rng = np.random.default_rng(0)
+    K, N = 8, 1600  # K divides N so N_k.sum() == N
+    u_kn = rng.standard_normal((K, N))
+    N_k = np.full(K, N // K, dtype=np.float64)
+    f_k = np.zeros(K)
+    chunk_size = 250
+
+    log_denom_d = _chunked.chunked_log_denominator(u_kn, N_k, f_k, chunk_size)
+    log_denom_s = _chunked.chunked_log_denominator(
+        _make_provider(u_kn, chunk_size), N_k, f_k, chunk_size)
+    assert_array_almost_equal(log_denom_s, log_denom_d, decimal=12)
+
+    log_num_d = _chunked.chunked_log_numerator_k(u_kn, N_k, log_denom_d, chunk_size)
+    log_num_s = _chunked.chunked_log_numerator_k(
+        _make_provider(u_kn, chunk_size), N_k, log_denom_d, chunk_size)
+    assert_array_almost_equal(log_num_s, log_num_d, decimal=12)
+
+    H_d = _chunked.chunked_mbar_hessian(u_kn, N_k, f_k, chunk_size)
+    H_s = _chunked.chunked_mbar_hessian(
+        _make_provider(u_kn, chunk_size), N_k, f_k, chunk_size)
+    assert_array_almost_equal(H_s, H_d, decimal=8)
+
+
+def test_streaming_peak_memory_bounded():
+    """Streaming path: peak Python allocation through chunked_log_denominator
+    is bounded by O(chunk_size * K), independent of total N. Compares to a
+    dense (N, K) reference materialisation.
+    """
+    K, N, chunk_size = 50, 200_000, 10_000
+    u_kn = np.random.default_rng(0).standard_normal((K, N))
+    N_k = np.full(K, N // K, dtype=np.float64)
+    f_k = np.zeros(K)
+
+    # Dense reference: one (K, N) intermediate, similar shape to scipy logsumexp
+    def _dense_ref(u_kn, N_k, f_k):
+        log_N = np.log(N_k)
+        a = (f_k + log_N)[:, None] - u_kn
+        m = a.max(axis=0)
+        return m + np.log(np.exp(a - m).sum(axis=0))
+
+    tracemalloc.start(); tracemalloc.reset_peak()
+    _dense_ref(u_kn, N_k, f_k)
+    _, peak_dense = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    tracemalloc.start(); tracemalloc.reset_peak()
+    _chunked.chunked_log_denominator(_make_provider(u_kn, chunk_size),
+                                      N_k, f_k, chunk_size)
+    _, peak_stream = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    print(f"\nstreaming log_denominator: dense {peak_dense/1e6:.1f} MB, "
+          f"stream {peak_stream/1e6:.1f} MB "
+          f"({peak_dense/max(peak_stream,1):.1f}x smaller)")
+    assert peak_stream < peak_dense / 4
+
+
+def test_streaming_precondition_returns_provider():
+    rng = np.random.default_rng(0)
+    K, N = 6, 1200  # K divides N
+    u_kn = rng.standard_normal((K, N))
+    N_k = np.full(K, N // K, dtype=np.float64)
+    f_k = np.zeros(K)
+    cs = 200
+
+    # Dense reference
+    u_dense = u_kn.copy()
+    u_dense = _chunked.chunked_precondition_u_kn(u_dense, N_k, f_k, cs)
+
+    # Streaming: returns a callable
+    out = _chunked.chunked_precondition_u_kn(_make_provider(u_kn, cs),
+                                              N_k, f_k, cs)
+    assert callable(out)
+    streamed = np.concatenate([c for c in out()], axis=1)
+    assert_array_almost_equal(streamed, u_dense, decimal=8)


### PR DESCRIPTION

This PR adds chunked working-array MBAR end-to-end across the fit and the post-fit batch evaluation. This caps peak working memory at `O(chunk_size × K)` regardless of sample count `N`, so MBAR can be fit and evaluated on datasets that previously exceeded available RAM. A single `chunk_size` knob streams the fit's inner reductions over the sample axis, and on the evaluation side replaces the per-target Python loop with one vectorised pass per chunk, skipping the dense `(N, K + NL + S)` log-weight allocation. JAX-jit'd per-chunk inner kernels run throughout (numpy fallback when JAX isn't available), measuring around 2× faster per chunk than the numpy path. Default behaviour without `chunk_size` is unchanged. A streaming-callable form for `u_kn` is also supported, so out-of-core fits don't need to load the full matrix into RAM.

Closes issue #574.

### LOC summary

| Section | Impl LOC | Notes |
|---|---|---|
| 1. End-to-end chunking (`_chunked.py`) | ~290 | Whole new module (322 LOC) |
| 2. Vectorised batch evaluation (`mbar.py`) | ~40 | `chunk_size` kwarg + chunked branch + 3 wrapper kwargs |
| 3. JAX work (`_chunked.py` kernels + `mbar_solvers.py` bypass) | ~70 | 4 `@jit` kernels + numpy fallback + JIT-bypass guard |
| **Implementation total** | **~400** | |
| Tests | ~625 | 5 test files |
| **Cumulative PR diff** | **+1149 / -19** | |

### Three areas of work

1. **End-to-end chunking.** New `pymbar/_chunked.py` module holds the chunking primitives and per-chunk kernels. The fit's inner reductions and the batch-evaluation reductions both route through it under one `chunk_size` knob.
2. **Vectorised batch evaluation.** `compute_expectations_inner` and the three public wrappers gain a `chunk_size` kwarg. When set, all target states are evaluated in one vectorised pass per chunk; the per-target Python loop and the dense `(N, K + NL + S)` allocation are gone on this branch. Default `chunk_size=None` runs the existing path bit-for-bit unchanged. `return_theta=True` and `uncertainty_method='bootstrap'` are rejected on the chunked path — neither composes cleanly with column-chunked kernels.
3. **JAX work.** Four `@jit`-decorated per-chunk kernels in `_chunked.py`, with a clean numpy fallback (`@jit` reduces to identity, `jnp` becomes `np`) when JAX is unavailable or `PYMBAR_DISABLE_JAX=1`. The outer `jax.jit` that wraps the adaptive solver is bypassed when chunking is active, since the chunked helpers have side-effecting Python loops that can't be traced.

### Tests

Unit tests for the new chunked helpers against `scipy.special.logsumexp`. Integration tests for the three public methods against the dense reference at `decimal=10`, parametrised over a range of `chunk_size`. Constraint tests for the `return_theta=True` / bootstrap rejection paths. A regression test that forces the adaptive solver and clears the JAX cache to exercise the JIT-bypass cold trace. 131 tests pass, 9 xfailed pre-existing, no regressions.

### Memory / performance

For workloads where `N ≫ chunk_size` and `K + NL + S` is large, target-axis work moves from a Python loop to one vectorised reduction per chunk, and peak memory drops by `O(N / chunk_size)`. JAX-jit'd per-chunk kernels measure around 2× faster than the numpy path.

### Out of scope (follow-ons if requested)

- Streaming `u_ln` via a callable yielding column chunks (motivation weaker — `u_ln` is usually constructed cheaply from a target-state list).
- `Theta` from chunked weights (would need a redesign of `_computeAsymptoticCovarianceMatrix`).
- Bootstrap with chunked path (feasible by re-running chunked helpers per replicate, not in this PR).

### Notes for review

The PR is broader than issue #574's original scope: the chunked path covers fit + post-fit eval under one `chunk_size` knob, with JAX-jit'd per-chunk kernels throughout. If splitting the batch-eval helpers and the `compute_*` changes off into a separate PR would help review, I can rebase that piece onto its own branch.
